### PR TITLE
fix(store): make time SQL portable on Postgres

### DIFF
--- a/backend/internal/store/migrations/0015_plans.sql
+++ b/backend/internal/store/migrations/0015_plans.sql
@@ -15,9 +15,12 @@ CREATE TABLE plans (
     updated_at    TEXT NOT NULL
 );
 
--- Seed a "Default" plan for existing data.
+-- Seed a "Default" plan for existing data. Use a fixed RFC3339 literal so the
+-- statement is portable across SQLite and Postgres (datetime('now') is
+-- SQLite-only). The rest of the app writes RFC3339 strings to these TEXT
+-- columns via formatTime, so this matches the on-disk shape.
 INSERT INTO plans (id, tenant_id, name, description, limit_micros, limit_tokens, period, alert_pct, hard_cutoff, allowed_models, created_at, updated_at)
-VALUES ('default', 'default', 'Default', 'Default plan for existing keys', 0, 0, 'monthly', 80, 1, '', datetime('now'), datetime('now'));
+VALUES ('default', 'default', 'Default', 'Default plan for existing keys', 0, 0, 'monthly', 80, 1, '', '2026-06-11T00:00:00Z', '2026-06-11T00:00:00Z');
 
 -- Add plan_id column to api_keys.
 ALTER TABLE api_keys ADD COLUMN plan_id TEXT NOT NULL DEFAULT '';

--- a/backend/internal/store/repo_resources.go
+++ b/backend/internal/store/repo_resources.go
@@ -44,9 +44,10 @@ func (r *ResourceRepo) InsertResourceSample(ctx context.Context, s ResourceSampl
 // history chart to show long-term trends without loading every raw sample.
 func (r *ResourceRepo) ResourceBuckets(ctx context.Context, since time.Time, interval time.Duration) ([]ResourceBucket, error) {
 	bucketSecs := int64(interval.Seconds())
-	q := r.db.rebind(`
+	epochCreated := r.db.epochExpr("created_at")
+	q := r.db.rebind(fmt.Sprintf(`
 		SELECT
-			(CAST(strftime('%s', created_at) AS INTEGER) / ? * ?) AS bucket,
+			(CAST(%s AS BIGINT) / ? * ?) AS bucket,
 			AVG(proc_cpu_percent), MAX(proc_cpu_percent),
 			AVG(host_cpu_percent), MAX(host_cpu_percent),
 			AVG(CAST(proc_rss_bytes AS REAL)) / 1048576.0, MAX(proc_rss_bytes),
@@ -60,7 +61,7 @@ func (r *ResourceRepo) ResourceBuckets(ctx context.Context, since time.Time, int
 		FROM resource_samples
 		WHERE created_at >= ?
 		GROUP BY bucket
-		ORDER BY bucket ASC`)
+		ORDER BY bucket ASC`, epochCreated))
 
 	rows, err := r.db.sql.QueryContext(ctx, q, bucketSecs, bucketSecs, formatTime(since))
 	if err != nil {

--- a/backend/internal/store/repo_usage.go
+++ b/backend/internal/store/repo_usage.go
@@ -477,14 +477,16 @@ func (r *UsageRepo) Timeline(ctx context.Context, tenantID string, since time.Ti
 		slotSecs = 60
 	}
 
-	q := r.db.rebind(`
-		SELECT 
-			CAST((strftime('%s', created_at) - strftime('%s', ?)) / ? AS INTEGER) as bucket,
+	epochCreated := r.db.epochExpr("created_at")
+	epochSince := r.db.epochExpr("?")
+	q := r.db.rebind(fmt.Sprintf(`
+		SELECT
+			CAST((%s - %s) / ? AS INTEGER) as bucket,
 			COUNT(*) as count
 		FROM usage_records
 		WHERE tenant_id = ? AND created_at >= ? AND created_at <= ?
 		GROUP BY bucket
-		ORDER BY bucket ASC`)
+		ORDER BY bucket ASC`, epochCreated, epochSince))
 
 	rows, err := r.db.sql.QueryContext(ctx, q, formatTime(since), slotSecs, tenantID, formatTime(since), formatTime(to))
 	if err != nil {
@@ -517,9 +519,10 @@ type DailyPoint struct {
 // DailyByKey returns per-day usage breakdown for a specific API key since the
 // given time. Used by the customer portal to show usage trends.
 func (r *UsageRepo) DailyByKey(ctx context.Context, keyID string, since time.Time) ([]DailyPoint, error) {
-	q := r.db.rebind(`
+	dayExpr := r.db.dateExpr("created_at")
+	q := r.db.rebind(fmt.Sprintf(`
 		SELECT
-			DATE(created_at) as day,
+			%s as day,
 			COUNT(*),
 			COALESCE(SUM(prompt_tokens), 0),
 			COALESCE(SUM(completion_tokens), 0),
@@ -527,7 +530,7 @@ func (r *UsageRepo) DailyByKey(ctx context.Context, keyID string, since time.Tim
 		FROM usage_records
 		WHERE api_key_id = ? AND created_at >= ?
 		GROUP BY day
-		ORDER BY day ASC`)
+		ORDER BY day ASC`, dayExpr))
 	rows, err := r.db.sql.QueryContext(ctx, q, keyID, formatTime(since))
 	if err != nil {
 		return nil, fmt.Errorf("store: daily usage by key: %w", err)

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -135,6 +135,27 @@ func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 // Close releases the connection pool.
 func (db *DB) Close() error { return db.sql.Close() }
 
+// epochExpr returns a dialect-specific SQL expression that converts a TEXT
+// RFC3339 timestamp (column or placeholder) to unix-epoch seconds. SQLite has
+// strftime; Postgres needs an explicit cast to timestamptz before EXTRACT.
+func (db *DB) epochExpr(operand string) string {
+	if db.dialect == DialectPostgres {
+		return "EXTRACT(EPOCH FROM " + operand + "::timestamptz)"
+	}
+	return "strftime('%s', " + operand + ")"
+}
+
+// dateExpr returns a dialect-specific SQL expression that yields the YYYY-MM-DD
+// calendar date (as text) of a TEXT RFC3339 timestamp. SQLite's DATE() accepts
+// text directly and returns text; Postgres needs a cast through timestamptz
+// and an explicit format so the scanned value is always a string.
+func (db *DB) dateExpr(operand string) string {
+	if db.dialect == DialectPostgres {
+		return "TO_CHAR(" + operand + "::timestamptz, 'YYYY-MM-DD')"
+	}
+	return "DATE(" + operand + ")"
+}
+
 // rebind converts '?' placeholders to the engine's native form. SQLite accepts
 // '?' directly; Postgres needs $1, $2, ... positional placeholders.
 func (db *DB) rebind(query string) string {


### PR DESCRIPTION
## Summary

- The Overview page failed on Postgres with `function strftime(unknown, text) does not exist (SQLSTATE 42883)` because `Timeline`, `DailyByKey`, and `ResourceBuckets` used SQLite-only `strftime()` / `DATE()` against the TEXT `created_at` column.
- Migration `0015_plans.sql` also failed on Postgres with `function datetime(unknown) does not exist` because the seed row called `datetime('now')`.
- Added `epochExpr()` and `dateExpr()` helpers on `*DB` that emit dialect-specific SQL (SQLite `strftime` / `DATE` vs Postgres `EXTRACT(EPOCH FROM x::timestamptz)` / `TO_CHAR(x::timestamptz, 'YYYY-MM-DD')`), and routed the three queries through them.
- Replaced `datetime('now')` in migration 0015 with an RFC3339 literal so the seed row applies on both engines (matches the on-disk shape produced by `formatTime`).

## Test plan

- [x] `cd backend && go vet ./...`
- [x] `cd backend && go test ./internal/store/...`
- [x] On a Postgres-backed deployment: load the Overview page and confirm no `strftime` / `datetime` SQLSTATE 42883 errors.
- [x] Fresh Postgres DB: confirm migration 0015 applies (default plan row is seeded with the literal timestamp).
- [x] On a SQLite-backed deployment: confirm Overview and the daily-usage portal still render correctly (regression check for the helper indirection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)