### PR TITLE
Fix/oauth callback 404

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:
@@ -33,9 +33,9 @@ jobs:
     name: Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -57,7 +57,7 @@ jobs:
     name: Deploy Artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate default Compose file
         run: docker compose -f compose.yaml config

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,6 +60,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,10 +24,10 @@ jobs:
     outputs:
       should_build: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.should_build }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: github.ref == 'refs/heads/main'
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         if: github.ref == 'refs/heads/main'
         with:
@@ -58,7 +58,7 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Lowercase image name
         run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
@@ -108,6 +108,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
           - goos: linux
             goarch: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -80,7 +80,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: main

--- a/backend/internal/gateway/oauth.go
+++ b/backend/internal/gateway/oauth.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -175,30 +174,28 @@ func (s *Server) oauthExchange(w http.ResponseWriter, r *http.Request) {
 }
 
 // oauthCallback handles the GET redirect from OAuth providers after the user
-// authorizes. It exchanges the code for tokens and redirects the browser to a
-// frontend callback page that notifies the opener tab via postMessage.
+// authorizes. It exchanges the code for tokens and writes a self-contained HTML
+// page that postMessages the opener tab and closes the popup. The HTML response
+// is rendered inline (no SPA dependency) so the flow also works on minimal
+// deployments where the dashboard assets are not bundled alongside the binary.
 func (s *Server) oauthCallback(w http.ResponseWriter, r *http.Request) {
 	state := r.URL.Query().Get("state")
 	provider := r.URL.Query().Get("provider")
 
-	frontendRedirect := func(status, msg string) {
-		// Path-style redirect (no #) — the dashboard SPA uses BrowserRouter, so
-		// the callback page reads status/message from window.location.search.
-		u := fmt.Sprintf("/oauth/callback?status=%s&provider=%s", status, url.QueryEscape(provider))
-		if msg != "" {
-			u += "&message=" + url.QueryEscape(msg)
-		}
-		http.Redirect(w, r, u, http.StatusFound)
+	writeResult := func(status, msg string) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		_, _ = w.Write([]byte(renderOAuthPopupResult(provider, status, msg)))
 	}
 
 	if state == "" {
-		frontendRedirect("error", "missing code or state parameter")
+		writeResult("error", "missing code or state parameter")
 		return
 	}
 
 	sess, ok := s.oauthSessions.Get(state)
 	if !ok {
-		frontendRedirect("error", "session expired or invalid; please restart the sign-in flow")
+		writeResult("error", "session expired or invalid; please restart the sign-in flow")
 		return
 	}
 
@@ -206,18 +203,18 @@ func (s *Server) oauthCallback(w http.ResponseWriter, r *http.Request) {
 	if provider == "" {
 		provider = sess.Provider
 	} else if sess.Provider != provider {
-		frontendRedirect("error", "provider mismatch")
+		writeResult("error", "provider mismatch")
 		return
 	}
 
 	if err := s.completeOAuthCallback(r, provider); err != nil {
 		s.log.Warn("oauth callback failed", "provider", provider, "error", err)
-		frontendRedirect("error", err.Error())
+		writeResult("error", err.Error())
 		return
 	}
 
 	s.log.Info("oauth callback success", "provider", provider)
-	frontendRedirect("success", "")
+	writeResult("success", "")
 }
 
 // oauthDeviceCode starts a device-authorization flow and returns the user code

--- a/backend/internal/gateway/oauth_callback_test.go
+++ b/backend/internal/gateway/oauth_callback_test.go
@@ -1,0 +1,85 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mydisha/keirouter/backend/internal/config"
+	"github.com/mydisha/keirouter/backend/internal/oauth"
+	"github.com/mydisha/keirouter/backend/internal/transform"
+)
+
+// TestOAuthCallback_NoFrontendDir verifies that /oauth/callback works even when
+// the dashboard asset directory is missing. This is the bug from GitHub issue
+// #1 — a binary running without bundled frontend/dist used to return chi's
+// plain-text "404 page not found" for the provider's GET redirect, leaving the
+// dashboard modal stuck on "Waiting for sign-in to complete…".
+func TestOAuthCallback_NoFrontendDir(t *testing.T) {
+	gw := New(Deps{
+		Config:      config.Default(),
+		Codecs:      transform.DefaultRegistry(),
+		FrontendDir: "", // explicitly empty — mirrors the bug environment
+	})
+	handler := gw.Handler()
+
+	t.Run("missing state renders inline error html", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/oauth/callback", nil)
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code, "callback must be handled, not 404")
+		require.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+		body := rec.Body.String()
+		require.NotContains(t, body, "404 page not found")
+		require.Contains(t, body, `"type":"oauth-callback"`)
+		require.Contains(t, body, `"status":"error"`)
+		require.Contains(t, body, "missing code or state parameter")
+	})
+
+	t.Run("unknown state renders session-expired html", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/oauth/callback?state=unknown&code=x", nil)
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+		body := rec.Body.String()
+		require.NotContains(t, body, "404 page not found")
+		require.Contains(t, body, "session expired or invalid")
+	})
+
+	t.Run("auth/callback alias is also handled", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/auth/callback?state=unknown&code=x", nil)
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+		require.NotContains(t, rec.Body.String(), "404 page not found")
+	})
+}
+
+// TestOAuthCallback_ProviderMismatch verifies that mismatched provider hints
+// surface a clean error page via the inline HTML response rather than relying
+// on the SPA to render the error.
+func TestOAuthCallback_ProviderMismatch(t *testing.T) {
+	gw := New(Deps{
+		Config: config.Default(),
+		Codecs: transform.DefaultRegistry(),
+	})
+	gw.oauthSessions.Put("state-abc", &oauth.Session{Provider: "gemini-cli"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?state=state-abc&provider=codex&code=x", nil)
+	gw.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+	body := rec.Body.String()
+	require.Contains(t, body, "provider mismatch")
+	require.True(t, strings.Contains(body, `"status":"error"`))
+}

--- a/backend/internal/gateway/server.go
+++ b/backend/internal/gateway/server.go
@@ -291,25 +291,19 @@ func (s *Server) routes() chi.Router {
 		s.mountAdmin(r)
 	})
 
+	// OAuth provider redirects (GET) land here. They MUST work without a
+	// dashboard session — state is the CSRF guard — and without depending on
+	// the frontend asset directory. The handler writes a self-contained HTML
+	// page that postMessages the opener and closes the popup, so the same
+	// route works whether or not the dashboard SPA is bundled with the binary.
+	r.Get("/oauth/callback", s.oauthCallback)
+	r.Get("/auth/callback", s.oauthCallback)
+
 	// Serve frontend static files. The dashboard is a Vite SPA; unmatched
 	// paths fall through to index.html so client-side routing works.
-	// OAuth callbacks are intercepted here because they
-	// arrive as a GET redirect from the provider and must not require a
-	// dashboard session — the state parameter provides CSRF protection.
 	if s.frontendDir != "" {
 		fs := http.FileServer(http.Dir(s.frontendDir))
 		r.Get("/*", func(w http.ResponseWriter, r *http.Request) {
-			// Only intercept the raw provider redirect (carries code/error). The
-			// post-exchange result redirect (status/message only) falls through to
-			// the SPA so the React callback page can render and postMessage the
-			// opener tab.
-			if r.URL.Path == "/oauth/callback" || r.URL.Path == "/auth/callback" {
-				q := r.URL.Query()
-				if q.Get("code") != "" || q.Get("error") != "" {
-					s.oauthCallback(w, r)
-					return
-				}
-			}
 			path := r.URL.Path
 			if path == "/" {
 				path = "/index.html"


### PR DESCRIPTION
## What

  Fix the Gemini CLI (and any auth-code OAuth provider) connect flow getting stuck on "Waiting for sign-in to complete…"
  after the user selects their Google account. The OAuth popup used to land on a plain-text `404 page not found` at
  `/oauth/callback` instead of notifying the opener tab.


## Why

  Closes #1.

  Two compounding issues in the redirect-style callback flow:

  1. `r.Get("/oauth/callback", …)` was only registered inside the `if s.frontendDir != ""` branch of the catch-all in
  `server.go`. Binaries running without a bundled `frontend/dist` next to them returned chi's default `404 page not found`
  for the provider's GET redirect — exactly what the reporter's screenshot shows.
  2. Even with the SPA present, `oauthCallback` did `http.Redirect` to `/oauth/callback?status=…` and depended on the React
  app to load and `postMessage` the opener. An unnecessary round-trip with its own failure modes (and the source of the
  v0.1.6 hash-routing bug that previously broke this path).

  ## How

  Unify the auth-code flow with the fixed-loopback flow (Codex, xAI) on the existing `renderOAuthPopupResult` helper, which
  already does the right thing for those providers:

  - **`backend/internal/gateway/oauth.go`** — `oauthCallback` now writes a self-contained HTML page that `postMessage`s the
  opener and closes the popup, regardless of whether the dashboard SPA is bundled. Dropped the now-unused `net/url` import.
  - **`backend/internal/gateway/server.go`** — Registered `/oauth/callback` and `/auth/callback` at the top-level router,
  outside the `frontendDir` guard. Removed the redundant intercept branch from the catch-all `/*` handler. State param
  remains the CSRF guard, matching the existing design.
  - **`backend/internal/gateway/oauth_callback_test.go`** *(new)* — Regression test that constructs the server with
  `FrontendDir == ""` and asserts the route returns inline HTML (never chi's `404 page not found`) for missing-state,
  after the user selects their Google account. The OAuth popup used to land on a plain-text `404 page not found` at
  `/oauth/callback` instead of notifying the opener tab.


## Checklist

- [x] `make test` passes
- [x] `make vet` passes
- [ ] `npm run lint` and `npm run typecheck` pass (if frontend changed)
- [ ] Documentation updated (if applicable)
- [ ] Config example updated (if applicable)
