### PR TITLE
feat: add async usage batching and account health checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,28 +13,36 @@ BACKEND_DIR := backend
 FRONTEND_DIR := frontend
 BIN := keirouter
 
+# ANSI colors for terminal output.
+C_RESET  := \033[0m
+C_BOLD   := \033[1m
+C_DIM    := \033[2m
+C_GREEN  := \033[32m
+C_YELLOW := \033[33m
+C_CYAN   := \033[36m
+
 .PHONY: dev backend frontend build build-backend build-frontend test vet hooks bootstrap install setup quickstart clean docker
 
 ## dev: run backend and frontend concurrently; Ctrl-C stops both.
 ##      The backend starts first; frontend waits until the backend is healthy
 ##      so the Vite proxy never hits ECONNREFUSED on cold start.
 dev:
-	@echo "Starting KeiRouter backend (:20180) and dashboard (:5180)…"
+	@printf "$(C_BOLD)$(C_CYAN)Starting KeiRouter$(C_RESET) backend (:20180) + dashboard (:5180)…\n"
 	@trap 'kill 0' INT TERM EXIT; \
 	( cd $(BACKEND_DIR) && go run ./cmd/keirouter ) & \
 	( \
-		echo "⏳ Waiting for backend…"; \
+		printf "$(C_DIM)⏳ Waiting for backend…$(C_RESET)\n"; \
 		ready=0; \
 		for i in $$(seq 1 30); do \
 			if curl -sf http://127.0.0.1:20180/healthz >/dev/null 2>&1; then \
-				echo "✅ Backend ready"; \
+				printf "$(C_GREEN)$(C_BOLD)✅ Backend ready$(C_RESET)\n"; \
 				ready=1; \
 				break; \
 			fi; \
 			sleep 0.5; \
 		done; \
 		if [ "$$ready" -ne 1 ]; then \
-			echo "Backend did not become healthy on http://127.0.0.1:20180/healthz"; \
+			printf "$(C_YELLOW)$(C_BOLD)Backend did not become healthy$(C_RESET) on http://127.0.0.1:20180/healthz\n"; \
 			exit 1; \
 		fi; \
 		cd $(FRONTEND_DIR) && npm run dev \
@@ -95,11 +103,11 @@ clean:
 ##        Zero config — no .env required for local use.
 ##        Usage: make setup
 setup:
-	@echo "🚀 KeiRouter — one-command setup"
-	@test -d $(FRONTEND_DIR)/node_modules || ( echo "📦 Installing frontend deps…" && cd $(FRONTEND_DIR) && npm ci --quiet )
+	@printf "$(C_BOLD)$(C_CYAN)🚀 KeiRouter$(C_RESET) — one-command setup\n"
+	@test -d $(FRONTEND_DIR)/node_modules || ( printf "$(C_DIM)📦 Installing frontend deps…$(C_RESET)\n" && cd $(FRONTEND_DIR) && npm ci --quiet )
 	@cd $(BACKEND_DIR) && go mod download 2>/dev/null || true
 	@echo ""
-	@echo "✅ Dependencies ready. Starting dev servers…"
+	@printf "$(C_GREEN)$(C_BOLD)✅ Dependencies ready.$(C_RESET) Starting dev servers…\n"
 	@echo "   Backend  → http://localhost:20180"
 	@echo "   Dashboard→ http://localhost:5180"
 	@echo "   Password → keirouter"

--- a/backend/cmd/keirouter/main.go
+++ b/backend/cmd/keirouter/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mydisha/keirouter/backend/internal/app"
 	"github.com/mydisha/keirouter/backend/internal/config"
+	"github.com/mydisha/keirouter/backend/internal/prettylog"
 	"github.com/mydisha/keirouter/backend/internal/version"
 )
 
@@ -51,11 +52,31 @@ func run() error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	log := newLogger(cfg.Log)
+	log, isPretty := newLogger(cfg.Log)
 	slog.SetDefault(log)
 
 	if *healthcheck {
 		return runHealthcheck(cfg)
+	}
+
+	// Print the startup banner in pretty mode (TTY only).
+	if isPretty {
+		cacheLabel := "disabled"
+		if cfg.Cache.Enabled {
+			cacheLabel = cfg.Cache.Backend
+		}
+		dataDir := cfg.Data.Dir
+		if dataDir == "" {
+			dataDir = "~/.keirouter"
+		}
+		prettylog.PrintBannerStdout(prettylog.BannerConfig{
+			Version:  resolvedVersion,
+			Addr:     cfg.Addr(),
+			DBDriver: cfg.Database.Driver,
+			Cache:    cacheLabel,
+			DataDir:  dataDir,
+			LogLevel: cfg.Log.Level + " (pretty)",
+		})
 	}
 
 	// Cancel on SIGINT/SIGTERM for graceful shutdown.
@@ -98,8 +119,9 @@ func runHealthcheck(cfg config.Config) error {
 	return nil
 }
 
-// newLogger builds a structured logger per config.
-func newLogger(cfg config.LogConfig) *slog.Logger {
+// newLogger builds a structured logger per config. Returns the logger and
+// whether pretty (colorized) output is active.
+func newLogger(cfg config.LogConfig) (*slog.Logger, bool) {
 	var level slog.Level
 	switch cfg.Level {
 	case "debug":
@@ -114,10 +136,12 @@ func newLogger(cfg config.LogConfig) *slog.Logger {
 
 	opts := &slog.HandlerOptions{Level: level}
 	var handler slog.Handler
+	pretty := false
 	if cfg.Format == "json" {
 		handler = slog.NewJSONHandler(os.Stdout, opts)
 	} else {
-		handler = slog.NewTextHandler(os.Stdout, opts)
+		handler = prettylog.NewHandler(os.Stdout, &prettylog.Options{Level: level})
+		pretty = prettylog.IsTerminal(os.Stdout.Fd())
 	}
-	return slog.New(handler)
+	return slog.New(handler), pretty
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/knadh/koanf/providers/file v1.1.2
 	github.com/knadh/koanf/providers/structs v0.1.0
 	github.com/knadh/koanf/v2 v2.1.2
+	github.com/mattn/go-isatty v0.0.20
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/redis/go-redis/v9 v9.7.3
@@ -46,7 +47,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/guardrails"
 	"github.com/mydisha/keirouter/backend/internal/guardrails/injection"
 	"github.com/mydisha/keirouter/backend/internal/guardrails/pii"
+	"github.com/mydisha/keirouter/backend/internal/healthcheck"
 	"github.com/mydisha/keirouter/backend/internal/httputil"
 	"github.com/mydisha/keirouter/backend/internal/identity"
 	"github.com/mydisha/keirouter/backend/internal/meter"
@@ -50,6 +51,8 @@ type App struct {
 	server         *http.Server
 	keepAlive      *oauth.KeepAlive
 	guardrailAudit *guardrails.AuditWriter
+	meter          *meter.Meter
+	healthChecker  *healthcheck.Checker
 }
 
 // Build constructs the application from configuration. It opens the database,
@@ -110,6 +113,15 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 	pricing := buildPricing()
 	modelPrices := buildModelPrices()
 	mtr := meter.New(db.Usage(), pricing, modelPrices)
+	mtr.EnableAsync(meter.AsyncConfig{
+		Enabled:              cfg.Meter.Async,
+		BatchSize:            cfg.Meter.BatchSize,
+		FlushInterval:        cfg.Meter.FlushInterval,
+		QueueSize:            cfg.Meter.QueueSize,
+		FullQueuePolicy:      cfg.Meter.FullQueuePolicy,
+		ShutdownFlushTimeout: cfg.Meter.ShutdownFlushTimeout,
+		Logger:               log,
+	})
 	uh := usagehub.New()
 	mtr.SetHub(uh)
 	bud := budget.New(db.Budgets(), db.Usage())
@@ -120,8 +132,9 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 	disp.SetTokenRefresher(tokenRefresher)
 	// Resolve proxy pool bindings for accounts that have one.
 	disp.SetPoolSource(db.ProxyPools())
-	// Model-level cooldowns and round-robin chain rotation.
+	// Model-level cooldowns, round-robin chain rotation, and background health.
 	disp.SetRoutingSource(db.Routing())
+	disp.SetHealthSource(db.Health())
 	slim := slimmer.Default()
 	metrics := observ.New()
 
@@ -222,6 +235,17 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 	// tokens every 30 minutes so requests never hit a stale token.
 	keepAlive := oauth.NewKeepAlive(tokenRefresher, db.Accounts(), store.DefaultTenantID, log)
 
+	healthChecker := healthcheck.New(healthcheck.Config{
+		Enabled:              cfg.Health.Enabled,
+		Interval:             cfg.Health.Interval,
+		Timeout:              cfg.Health.Timeout,
+		MaxParallel:          cfg.Health.MaxParallel,
+		FailureThreshold:     cfg.Health.FailureThreshold,
+		SuccessThreshold:     cfg.Health.SuccessThreshold,
+		RecentModelWindow:    cfg.Health.RecentModelWindow,
+		MaxModelsPerProvider: cfg.Health.MaxModelsPerProvider,
+	}, log, db.Accounts(), db.Health(), connRegistry, v)
+
 	gw := gateway.New(gateway.Deps{
 		Config:          cfg,
 		Logger:          log,
@@ -254,6 +278,8 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 		Guardrails:      guardrailEngine,
 		GuardrailRepo:   db.Guardrails(),
 		GuardrailLogs:   db.GuardrailLogs(),
+		Health:          db.Health(),
+		HealthChecker:   healthChecker,
 	})
 
 	srv := &http.Server{
@@ -268,7 +294,7 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 	// usable without a manual "connect" step in the dashboard.
 	seedFreeAccounts(ctx, db.Accounts(), log)
 
-	return &App{cfg: cfg, log: log, db: db, accounts: db.Accounts(), server: srv, keepAlive: keepAlive, guardrailAudit: guardrailAudit}, nil
+	return &App{cfg: cfg, log: log, db: db, accounts: db.Accounts(), server: srv, keepAlive: keepAlive, guardrailAudit: guardrailAudit, meter: mtr, healthChecker: healthChecker}, nil
 }
 
 // seedFreeAccounts auto-creates a default account for providers that are free
@@ -323,6 +349,12 @@ func (a *App) Run(ctx context.Context) error {
 	if a.keepAlive != nil {
 		go a.keepAlive.Run(ctx)
 	}
+	if a.meter != nil {
+		a.meter.StartAsync(ctx)
+	}
+	if a.healthChecker != nil {
+		go a.healthChecker.Run(ctx, store.DefaultTenantID)
+	}
 
 	// Background cooldown sweeper: periodically clears expired cooldowns so
 	// accounts recover automatically without a restart.
@@ -355,9 +387,12 @@ func (a *App) Run(ctx context.Context) error {
 		if err := a.server.Shutdown(shutdownCtx); err != nil {
 			return err
 		}
-		// Drain pending guardrail audit rows before closing the DB.
+		// Drain pending guardrail audit and usage rows before closing the DB.
 		if a.guardrailAudit != nil {
 			a.guardrailAudit.Stop(5 * time.Second)
+		}
+		if a.meter != nil {
+			a.meter.Close(a.cfg.Meter.ShutdownFlushTimeout)
 		}
 		return a.db.Close()
 	case err := <-errCh:

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -23,6 +23,8 @@ type Config struct {
 	Database DatabaseConfig `koanf:"database"`
 	Security SecurityConfig `koanf:"security"`
 	Cache    CacheConfig    `koanf:"cache"`
+	Meter    MeterConfig    `koanf:"meter"`
+	Health   HealthConfig   `koanf:"health"`
 	Log      LogConfig      `koanf:"log"`
 	Data     DataConfig     `koanf:"data"`
 }
@@ -104,6 +106,34 @@ type CacheConfig struct {
 	EmbeddingDims int `koanf:"embedding_dims"`
 }
 
+// MeterConfig controls usage metering writes.
+type MeterConfig struct {
+	// Async enables buffered/batched DB writes for usage rows.
+	Async bool `koanf:"async"`
+	// BatchSize is the maximum records per flush.
+	BatchSize int `koanf:"batch_size"`
+	// FlushInterval bounds how long records wait in memory.
+	FlushInterval time.Duration `koanf:"flush_interval"`
+	// QueueSize is the buffered event capacity.
+	QueueSize int `koanf:"queue_size"`
+	// FullQueuePolicy is "sync" (fallback direct write) or "drop".
+	FullQueuePolicy string `koanf:"full_queue_policy"`
+	// ShutdownFlushTimeout bounds final drain on shutdown.
+	ShutdownFlushTimeout time.Duration `koanf:"shutdown_flush_timeout"`
+}
+
+// HealthConfig controls background account/model health probes.
+type HealthConfig struct {
+	Enabled              bool          `koanf:"enabled"`
+	Interval             time.Duration `koanf:"interval"`
+	Timeout              time.Duration `koanf:"timeout"`
+	MaxParallel          int           `koanf:"max_parallel"`
+	FailureThreshold     int           `koanf:"failure_threshold"`
+	SuccessThreshold     int           `koanf:"success_threshold"`
+	RecentModelWindow    time.Duration `koanf:"recent_model_window"`
+	MaxModelsPerProvider int           `koanf:"max_models_per_provider"`
+}
+
 // LogConfig controls structured logging.
 type LogConfig struct {
 	// Level: debug, info, warn, error.
@@ -147,6 +177,24 @@ func Default() Config {
 			EmbeddingProvider:   "hash",
 			EmbeddingModel:      "text-embedding-3-small",
 			EmbeddingDims:       1536,
+		},
+		Meter: MeterConfig{
+			Async:                true,
+			BatchSize:            100,
+			FlushInterval:        time.Second,
+			QueueSize:            10000,
+			FullQueuePolicy:      "sync",
+			ShutdownFlushTimeout: 5 * time.Second,
+		},
+		Health: HealthConfig{
+			Enabled:              true,
+			Interval:             30 * time.Second,
+			Timeout:              5 * time.Second,
+			MaxParallel:          8,
+			FailureThreshold:     2,
+			SuccessThreshold:     1,
+			RecentModelWindow:    24 * time.Hour,
+			MaxModelsPerProvider: 8,
 		},
 		Log: LogConfig{Level: "info", Format: "text"},
 	}
@@ -203,6 +251,44 @@ func (c Config) validate() error {
 	}
 	if c.Server.Port < 1 || c.Server.Port > 65535 {
 		return fmt.Errorf("server.port out of range: %d", c.Server.Port)
+	}
+	if c.Meter.BatchSize <= 0 {
+		c.Meter.BatchSize = 100
+	}
+	if c.Meter.FlushInterval <= 0 {
+		c.Meter.FlushInterval = time.Second
+	}
+	if c.Meter.QueueSize <= 0 {
+		c.Meter.QueueSize = 10000
+	}
+	switch c.Meter.FullQueuePolicy {
+	case "", "sync", "drop":
+	default:
+		return fmt.Errorf("meter.full_queue_policy must be sync or drop, got %q", c.Meter.FullQueuePolicy)
+	}
+	if c.Meter.ShutdownFlushTimeout <= 0 {
+		c.Meter.ShutdownFlushTimeout = 5 * time.Second
+	}
+	if c.Health.Interval <= 0 {
+		c.Health.Interval = 30 * time.Second
+	}
+	if c.Health.Timeout <= 0 {
+		c.Health.Timeout = 5 * time.Second
+	}
+	if c.Health.MaxParallel <= 0 {
+		c.Health.MaxParallel = 8
+	}
+	if c.Health.FailureThreshold <= 0 {
+		c.Health.FailureThreshold = 2
+	}
+	if c.Health.SuccessThreshold <= 0 {
+		c.Health.SuccessThreshold = 1
+	}
+	if c.Health.RecentModelWindow <= 0 {
+		c.Health.RecentModelWindow = 24 * time.Hour
+	}
+	if c.Health.MaxModelsPerProvider <= 0 {
+		c.Health.MaxModelsPerProvider = 8
 	}
 	return nil
 }

--- a/backend/internal/dispatch/dispatch.go
+++ b/backend/internal/dispatch/dispatch.go
@@ -89,6 +89,11 @@ type TokenRefresher interface {
 	ForceRefresh(ctx context.Context, acc store.Account) (store.Account, error)
 }
 
+// HealthSource reports background account/model health state.
+type HealthSource interface {
+	IsUnhealthy(ctx context.Context, accountID, model string) (bool, error)
+}
+
 // RoutingSource provides model-level cooldowns and chain rotation state.
 type RoutingSource interface {
 	SetModelCooldown(ctx context.Context, accountID, model string, until time.Time) error
@@ -110,6 +115,7 @@ type Dispatcher struct {
 	pools     proxy.PoolSource
 	refresher TokenRefresher
 	routing   RoutingSource
+	health    HealthSource
 	// defaultCooldown is applied to an account when an error carries no
 	// upstream-specified Retry-After.
 	defaultCooldown time.Duration
@@ -135,6 +141,9 @@ func (d *Dispatcher) SetPoolSource(p proxy.PoolSource) { d.pools = p }
 
 // SetRoutingSource installs the model-cooldown and chain-rotation backend.
 func (d *Dispatcher) SetRoutingSource(r RoutingSource) { d.routing = r }
+
+// SetHealthSource installs background account/model health state.
+func (d *Dispatcher) SetHealthSource(h HealthSource) { d.health = h }
 
 // PlanOptions carries per-request strategy configuration.
 type PlanOptions struct {
@@ -234,6 +243,14 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 				locked, _ := d.routing.IsModelCooldownActive(ctx, acc.ID, target.Model)
 				if locked {
 					lastReason = fmt.Sprintf("account %s model %s on cooldown", acc.ID, target.Model)
+					continue
+				}
+			}
+			// Background health checker: skip known-unhealthy account/model rows.
+			if d.health != nil {
+				unhealthy, _ := d.health.IsUnhealthy(ctx, acc.ID, target.Model)
+				if unhealthy {
+					lastReason = fmt.Sprintf("account %s model %s unhealthy", acc.ID, target.Model)
 					continue
 				}
 			}

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -66,6 +66,8 @@ func (s *Server) mountAdmin(r chi.Router) {
 	r.Get("/usage/models", s.adminModelUsage)
 	r.Get("/usage/stream", s.adminUsageStream)
 	r.Get("/quota", s.adminQuotaUsage)
+	r.Get("/health/accounts", s.adminListAccountHealth)
+	r.Post("/health/check-now", s.adminRunHealthCheck)
 	r.Get("/console", s.adminConsoleLog)
 	r.Delete("/console", s.adminConsoleClear)
 	r.Get("/console/stream", s.adminConsoleStream)

--- a/backend/internal/gateway/health.go
+++ b/backend/internal/gateway/health.go
@@ -1,0 +1,65 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+func (s *Server) adminListAccountHealth(w http.ResponseWriter, r *http.Request) {
+	if s.health == nil {
+		writeError(w, http.StatusInternalServerError, "health repository not configured")
+		return
+	}
+	rows, err := s.health.List(r.Context(), adminTenant)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "internal server error"))
+		return
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, h := range rows {
+		out = append(out, accountHealthJSON(h))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"health": out})
+}
+
+func (s *Server) adminRunHealthCheck(w http.ResponseWriter, r *http.Request) {
+	if s.healthChecker == nil {
+		writeError(w, http.StatusInternalServerError, "health checker not configured")
+		return
+	}
+	ctx, cancel := contextWithTimeout(r, s.cfg.Health.Timeout*time.Duration(max(1, s.cfg.Health.MaxParallel)))
+	defer cancel()
+	s.healthChecker.CheckOnce(ctx, adminTenant)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+}
+
+func accountHealthJSON(h store.AccountHealth) map[string]any {
+	row := map[string]any{
+		"id":                    h.ID,
+		"tenant_id":             h.TenantID,
+		"account_id":            h.AccountID,
+		"provider":              h.Provider,
+		"model":                 h.Model,
+		"status":                h.Status,
+		"latency_ms":            h.LatencyMS,
+		"consecutive_failures":  h.ConsecutiveFailures,
+		"consecutive_successes": h.ConsecutiveSuccesses,
+		"last_checked_at":       h.LastCheckedAt,
+		"last_error":            h.LastError,
+		"updated_at":            h.UpdatedAt,
+	}
+	if h.LastOKAt != nil {
+		row["last_ok_at"] = *h.LastOKAt
+	}
+	return row
+}
+
+func contextWithTimeout(r *http.Request, d time.Duration) (context.Context, context.CancelFunc) {
+	if d <= 0 {
+		d = 30 * time.Second
+	}
+	return context.WithTimeout(r.Context(), d)
+}

--- a/backend/internal/gateway/server.go
+++ b/backend/internal/gateway/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
 	"github.com/mydisha/keirouter/backend/internal/fastjson"
 	"github.com/mydisha/keirouter/backend/internal/guardrails"
+	"github.com/mydisha/keirouter/backend/internal/healthcheck"
 	"github.com/mydisha/keirouter/backend/internal/identity"
 	"github.com/mydisha/keirouter/backend/internal/oauth"
 	"github.com/mydisha/keirouter/backend/internal/observ"
@@ -76,6 +77,8 @@ type Server struct {
 	guardrails      *guardrails.Engine
 	guardrailRepo   *store.GuardrailRepo
 	guardrailLogs   *store.GuardrailLogRepo
+	health          *store.HealthRepo
+	healthChecker   *healthcheck.Checker
 	router          chi.Router
 }
 
@@ -115,6 +118,8 @@ type Deps struct {
 	Guardrails      *guardrails.Engine
 	GuardrailRepo   *store.GuardrailRepo
 	GuardrailLogs   *store.GuardrailLogRepo
+	Health          *store.HealthRepo
+	HealthChecker   *healthcheck.Checker
 }
 
 // New builds a gateway Server and wires its routes.
@@ -172,6 +177,8 @@ func New(d Deps) *Server {
 		guardrails:      d.Guardrails,
 		guardrailRepo:   d.GuardrailRepo,
 		guardrailLogs:   d.GuardrailLogs,
+		health:          d.Health,
+		healthChecker:   d.HealthChecker,
 	}
 	s.router = s.routes()
 	startSystemCollector(d.Resources)

--- a/backend/internal/healthcheck/healthcheck.go
+++ b/backend/internal/healthcheck/healthcheck.go
@@ -1,0 +1,232 @@
+package healthcheck
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/mydisha/keirouter/backend/internal/store"
+	"github.com/mydisha/keirouter/backend/internal/vault"
+)
+
+// ConnectorSource resolves provider connectors.
+type ConnectorSource interface {
+	Get(provider string) (core.Connector, error)
+}
+
+// Config controls the background health checker.
+type Config struct {
+	Enabled              bool
+	Interval             time.Duration
+	Timeout              time.Duration
+	MaxParallel          int
+	FailureThreshold     int
+	SuccessThreshold     int
+	RecentModelWindow    time.Duration
+	MaxModelsPerProvider int
+}
+
+// Checker probes configured provider accounts and records account/model health.
+type Checker struct {
+	cfg      Config
+	log      *slog.Logger
+	accounts *store.AccountRepo
+	health   *store.HealthRepo
+	conns    ConnectorSource
+	vault    *vault.Vault
+}
+
+// New builds a Checker.
+func New(cfg Config, log *slog.Logger, accounts *store.AccountRepo, health *store.HealthRepo, conns ConnectorSource, vault *vault.Vault) *Checker {
+	if cfg.Interval <= 0 {
+		cfg.Interval = 30 * time.Second
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+	if cfg.MaxParallel <= 0 {
+		cfg.MaxParallel = 8
+	}
+	if cfg.FailureThreshold <= 0 {
+		cfg.FailureThreshold = 2
+	}
+	if cfg.SuccessThreshold <= 0 {
+		cfg.SuccessThreshold = 1
+	}
+	if cfg.RecentModelWindow <= 0 {
+		cfg.RecentModelWindow = 24 * time.Hour
+	}
+	if cfg.MaxModelsPerProvider <= 0 {
+		cfg.MaxModelsPerProvider = 8
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Checker{cfg: cfg, log: log, accounts: accounts, health: health, conns: conns, vault: vault}
+}
+
+// Run starts periodic probes until ctx is cancelled.
+func (c *Checker) Run(ctx context.Context, tenantID string) {
+	if c == nil || !c.cfg.Enabled {
+		return
+	}
+	c.CheckOnce(ctx, tenantID)
+	ticker := time.NewTicker(c.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.CheckOnce(ctx, tenantID)
+		}
+	}
+}
+
+// CheckOnce probes all enabled accounts for a tenant.
+func (c *Checker) CheckOnce(ctx context.Context, tenantID string) {
+	if c == nil || c.accounts == nil || c.health == nil || c.conns == nil || c.vault == nil {
+		return
+	}
+	accounts, err := c.accounts.ListByTenant(ctx, tenantID)
+	if err != nil {
+		c.log.Warn("health check: list accounts failed", "err", err)
+		return
+	}
+	recent, _ := c.health.RecentAccountModels(ctx, tenantID, time.Now().Add(-c.cfg.RecentModelWindow), len(accounts)*c.cfg.MaxModelsPerProvider)
+
+	modelsByAccount := map[string][]string{}
+	for _, h := range recent {
+		if len(modelsByAccount[h.AccountID]) >= c.cfg.MaxModelsPerProvider {
+			continue
+		}
+		modelsByAccount[h.AccountID] = appendUnique(modelsByAccount[h.AccountID], h.Model)
+	}
+
+	sem := make(chan struct{}, c.cfg.MaxParallel)
+	var wg sync.WaitGroup
+	for _, acc := range accounts {
+		if acc.Disabled || acc.NeedsReconnect {
+			continue
+		}
+		models := modelsByAccount[acc.ID]
+		if len(models) == 0 {
+			models = []string{"__all__"}
+		}
+		for _, model := range models {
+			acc := acc
+			model := model
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					return
+				}
+				c.probe(ctx, acc, model)
+			}()
+		}
+	}
+	wg.Wait()
+}
+
+func (c *Checker) probe(ctx context.Context, acc store.Account, model string) {
+	conn, err := c.conns.Get(acc.Provider)
+	if err != nil {
+		c.record(ctx, acc, model, 0, err)
+		return
+	}
+	creds, err := c.vault.Open(acc)
+	if err != nil {
+		c.record(ctx, acc, model, 0, err)
+		return
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	defer cancel()
+
+	start := time.Now()
+	if model == "__all__" {
+		if v, ok := conn.(core.Validator); ok {
+			err = v.Validate(probeCtx, creds)
+		} else {
+			err = nil
+		}
+	} else {
+		max := 8
+		req := &core.ChatRequest{
+			Model: model,
+			Messages: []core.Message{{
+				Role: core.RoleUser,
+				Content: []core.ContentPart{{
+					Type: core.PartText,
+					Text: "ping",
+				}},
+			}},
+			MaxTokens: &max,
+			Metadata: core.RequestMetadata{
+				TenantID: acc.TenantID,
+				Provider: acc.Provider,
+			},
+		}
+		_, err = conn.Chat(probeCtx, req, creds)
+	}
+	c.record(ctx, acc, model, int(time.Since(start).Milliseconds()), err)
+}
+
+func (c *Checker) record(ctx context.Context, acc store.Account, model string, latencyMS int, probeErr error) {
+	now := time.Now()
+	prev, err := c.health.Get(ctx, acc.ID, model)
+	if err != nil && err != store.ErrNotFound {
+		c.log.Debug("health check: read previous state failed", "account", acc.ID, "model", model, "err", err)
+	}
+	h := prev
+	if h.ID == "" {
+		h.ID = uuid.NewString()
+		h.TenantID = acc.TenantID
+		h.AccountID = acc.ID
+		h.Provider = acc.Provider
+		h.Model = model
+	}
+	h.LatencyMS = latencyMS
+	h.LastCheckedAt = now
+	h.UpdatedAt = now
+	if probeErr == nil {
+		h.ConsecutiveSuccesses++
+		h.ConsecutiveFailures = 0
+		h.LastError = ""
+		h.LastOKAt = &now
+		if h.ConsecutiveSuccesses >= c.cfg.SuccessThreshold {
+			h.Status = "healthy"
+		} else if h.Status == "" {
+			h.Status = "degraded"
+		}
+	} else {
+		h.ConsecutiveFailures++
+		h.ConsecutiveSuccesses = 0
+		h.LastError = probeErr.Error()
+		if h.ConsecutiveFailures >= c.cfg.FailureThreshold {
+			h.Status = "unhealthy"
+		} else {
+			h.Status = "degraded"
+		}
+	}
+	if err := c.health.Upsert(ctx, h); err != nil {
+		c.log.Warn("health check: upsert failed", "account", acc.ID, "model", model, "err", err)
+	}
+}
+
+func appendUnique(in []string, value string) []string {
+	for _, existing := range in {
+		if existing == value {
+			return in
+		}
+	}
+	return append(in, value)
+}

--- a/backend/internal/meter/meter.go
+++ b/backend/internal/meter/meter.go
@@ -8,6 +8,9 @@ package meter
 
 import (
 	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -19,19 +22,27 @@ import (
 
 // Price holds per-million-token rates in USD.
 type Price struct {
-	InputPerM        float64 // standard input tokens
-	OutputPerM       float64 // standard output tokens
-	CachedInputPerM  float64 // cache-read input tokens (often 50-90% off standard)
-	CacheWritePerM   float64 // cache-write input tokens (often 25% above standard)
-	ReasoningPerM    float64 // reasoning/extended-thinking output tokens
+	InputPerM       float64 // standard input tokens
+	OutputPerM      float64 // standard output tokens
+	CachedInputPerM float64 // cache-read input tokens (often 50-90% off standard)
+	CacheWritePerM  float64 // cache-write input tokens (often 25% above standard)
+	ReasoningPerM   float64 // reasoning/extended-thinking output tokens
+}
+
+// UsageStore is the persistence surface Meter needs. *store.UsageRepo satisfies
+// it for both SQLite and Postgres.
+type UsageStore interface {
+	Record(ctx context.Context, u store.UsageRecord) error
+	RecordBatch(ctx context.Context, records []store.UsageRecord) error
 }
 
 // Meter records usage rows and computes cost from a pricing table.
 type Meter struct {
-	usage       *store.UsageRepo
-	pricing     map[string]Price   // provider-level fallback
-	modelPrices map[string]Price   // provider/model-level (e.g. "openai/gpt-4o")
-	hub         *usagehub.Hub      // notifies subscribers of new usage records
+	usage       UsageStore
+	pricing     map[string]Price // provider-level fallback
+	modelPrices map[string]Price // provider/model-level (e.g. "openai/gpt-4o")
+	hub         *usagehub.Hub    // notifies subscribers of new usage records
+	async       *AsyncWriter
 }
 
 // SetHub installs a usage event hub. When set, the meter publishes an event
@@ -40,7 +51,7 @@ type Meter struct {
 func (m *Meter) SetHub(h *usagehub.Hub) { m.hub = h }
 
 // New builds a Meter backed by a usage repo and pricing tables.
-func New(usage *store.UsageRepo, pricing map[string]Price, modelPrices map[string]Price) *Meter {
+func New(usage UsageStore, pricing map[string]Price, modelPrices map[string]Price) *Meter {
 	if pricing == nil {
 		pricing = map[string]Price{}
 	}
@@ -48,6 +59,40 @@ func New(usage *store.UsageRepo, pricing map[string]Price, modelPrices map[strin
 		modelPrices = map[string]Price{}
 	}
 	return &Meter{usage: usage, pricing: pricing, modelPrices: modelPrices}
+}
+
+// AsyncConfig configures the buffered usage writer.
+type AsyncConfig struct {
+	Enabled              bool
+	BatchSize            int
+	FlushInterval        time.Duration
+	QueueSize            int
+	FullQueuePolicy      string // "sync" or "drop"
+	ShutdownFlushTimeout time.Duration
+	Logger               *slog.Logger
+}
+
+// EnableAsync installs a buffered, batched usage writer. Call StartAsync after
+// construction and Close on shutdown.
+func (m *Meter) EnableAsync(cfg AsyncConfig) {
+	if !cfg.Enabled {
+		return
+	}
+	m.async = NewAsyncWriter(m.usage, cfg)
+}
+
+// StartAsync starts the async writer loop when configured.
+func (m *Meter) StartAsync(ctx context.Context) {
+	if m.async != nil {
+		m.async.Start(ctx)
+	}
+}
+
+// Close drains pending async usage records.
+func (m *Meter) Close(timeout time.Duration) {
+	if m.async != nil {
+		m.async.Close(timeout)
+	}
 }
 
 // Event captures the facts about one completed (or cached) request.
@@ -65,9 +110,9 @@ type Event struct {
 	TTFT      time.Duration // time-to-first-token (0 if not measured)
 
 	// Token-saving analytics.
-	SlimStats    *SlimSnapshot // nil when RTK did not fire
-	CavemanActive bool         // caveman output compression was active
-	TerseActive   bool         // terse output compression was active
+	SlimStats     *SlimSnapshot // nil when RTK did not fire
+	CavemanActive bool          // caveman output compression was active
+	TerseActive   bool          // terse output compression was active
 }
 
 // SlimSnapshot captures the RTK slimmer's per-request compression results.
@@ -154,7 +199,7 @@ func (m *Meter) Record(ctx context.Context, ev Event) (int64, error) {
 		rec.SlimTokensSaved = ev.SlimStats.TokensSaved
 		rec.SlimRules = ev.SlimStats.Rules
 	}
-	if err := m.usage.Record(ctx, rec); err != nil {
+	if err := m.recordUsage(ctx, rec); err != nil {
 		return cost, err
 	}
 	// Notify SSE subscribers of the new usage record for near-real-time
@@ -168,6 +213,193 @@ func (m *Meter) Record(ctx context.Context, ev Event) (int64, error) {
 		})
 	}
 	return cost, nil
+}
+
+func (m *Meter) recordUsage(ctx context.Context, rec store.UsageRecord) error {
+	if m.async != nil {
+		return m.async.Record(ctx, rec)
+	}
+	return m.usage.Record(ctx, rec)
+}
+
+// AsyncStats exposes runtime counters for the async usage writer.
+type AsyncStats struct {
+	Queued       int
+	Written      int64
+	Failed       int64
+	Dropped      int64
+	SyncFallback int64
+	Flushes      int64
+}
+
+// AsyncWriter serializes usage writes through a single buffered queue and
+// flushes records in batches. One writer goroutine is especially friendly to
+// SQLite while Postgres benefits from fewer round-trips.
+type AsyncWriter struct {
+	store           UsageStore
+	batchSize       int
+	flushInterval   time.Duration
+	fullQueuePolicy string
+	log             *slog.Logger
+
+	ch     chan store.UsageRecord
+	once   sync.Once
+	done   chan struct{}
+	closed atomic.Bool
+
+	written      atomic.Int64
+	failed       atomic.Int64
+	dropped      atomic.Int64
+	syncFallback atomic.Int64
+	flushes      atomic.Int64
+}
+
+// NewAsyncWriter constructs an AsyncWriter with sane fallbacks for invalid
+// config. The caller must call Start.
+func NewAsyncWriter(usageStore UsageStore, cfg AsyncConfig) *AsyncWriter {
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 100
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = time.Second
+	}
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = 10000
+	}
+	if cfg.FullQueuePolicy == "" {
+		cfg.FullQueuePolicy = "sync"
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &AsyncWriter{
+		store:           usageStore,
+		batchSize:       cfg.BatchSize,
+		flushInterval:   cfg.FlushInterval,
+		fullQueuePolicy: cfg.FullQueuePolicy,
+		log:             cfg.Logger,
+		ch:              make(chan store.UsageRecord, cfg.QueueSize),
+		done:            make(chan struct{}),
+	}
+}
+
+// Start launches the flush loop once.
+func (w *AsyncWriter) Start(ctx context.Context) {
+	w.once.Do(func() {
+		go w.run(ctx)
+	})
+}
+
+// Record enqueues a usage record. If the queue is full, it either performs a
+// synchronous fallback write or drops the record based on config.
+func (w *AsyncWriter) Record(ctx context.Context, rec store.UsageRecord) error {
+	if w.closed.Load() {
+		w.syncFallback.Add(1)
+		return w.store.Record(ctx, rec)
+	}
+	select {
+	case w.ch <- rec:
+		return nil
+	default:
+		if w.fullQueuePolicy == "drop" {
+			w.dropped.Add(1)
+			return nil
+		}
+		w.syncFallback.Add(1)
+		return w.store.Record(ctx, rec)
+	}
+}
+
+// Close stops accepting new async work and waits for the loop to drain.
+func (w *AsyncWriter) Close(timeout time.Duration) {
+	if !w.closed.CompareAndSwap(false, true) {
+		return
+	}
+	close(w.ch)
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-w.done:
+	case <-timer.C:
+		w.log.Warn("usage async writer shutdown timed out", "queued", len(w.ch))
+	}
+}
+
+// Stats returns current writer counters.
+func (w *AsyncWriter) Stats() AsyncStats {
+	return AsyncStats{
+		Queued:       len(w.ch),
+		Written:      w.written.Load(),
+		Failed:       w.failed.Load(),
+		Dropped:      w.dropped.Load(),
+		SyncFallback: w.syncFallback.Load(),
+		Flushes:      w.flushes.Load(),
+	}
+}
+
+func (w *AsyncWriter) run(ctx context.Context) {
+	defer close(w.done)
+	ticker := time.NewTicker(w.flushInterval)
+	defer ticker.Stop()
+
+	batch := make([]store.UsageRecord, 0, w.batchSize)
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		if err := w.store.RecordBatch(context.Background(), batch); err != nil {
+			w.failed.Add(int64(len(batch)))
+			w.log.Warn("usage batch write failed; retrying records individually", "count", len(batch), "err", err)
+			for _, rec := range batch {
+				if err := w.store.Record(context.Background(), rec); err != nil {
+					w.failed.Add(1)
+					w.log.Warn("usage sync retry failed", "err", err)
+				} else {
+					w.written.Add(1)
+				}
+			}
+		} else {
+			w.written.Add(int64(len(batch)))
+			w.flushes.Add(1)
+		}
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			for {
+				select {
+				case rec, ok := <-w.ch:
+					if !ok {
+						flush()
+						return
+					}
+					batch = append(batch, rec)
+					if len(batch) >= w.batchSize {
+						flush()
+					}
+				default:
+					flush()
+					return
+				}
+			}
+		case rec, ok := <-w.ch:
+			if !ok {
+				flush()
+				return
+			}
+			batch = append(batch, rec)
+			if len(batch) >= w.batchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		}
+	}
 }
 
 // PricingFromCatalog builds a provider-level pricing table from provider specs.

--- a/backend/internal/prettylog/banner.go
+++ b/backend/internal/prettylog/banner.go
@@ -1,0 +1,103 @@
+package prettylog
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// BannerConfig holds the values rendered into the startup banner.
+type BannerConfig struct {
+	Version  string
+	Addr     string
+	DBDriver string
+	Cache    string // e.g. "disabled", "memory", "redis"
+	DataDir  string
+	LogLevel string
+}
+
+const logo = `
+  ██   ██ ███████  ██ ██████   ██████  ██    ██ ████████ ███████ ██████
+  ██  ██  ██      ██  ██   ██ ██    ██ ██    ██    ██    ██      ██   ██
+  █████   █████   ██  ██████  ██    ██ ██    ██    ██    █████   ██████
+  ██  ██  ██      ██  ██   ██ ██    ██ ██    ██    ██    ██      ██   ██
+  ██   ██ ███████  ██ ██   ██  ██████   ██████     ██    ███████ ██   ██`
+
+// PrintBanner writes the startup banner and config summary to w. It is a
+// no-op when w is not a terminal, keeping production output clean.
+func PrintBanner(w io.Writer, cfg BannerConfig) {
+	if f, ok := w.(interface{ Fd() uintptr }); ok {
+		if !IsTerminal(f.Fd()) {
+			return
+		}
+	}
+
+	rows := []struct {
+		label, value string
+	}{
+		{"HTTP", "http://" + cfg.Addr},
+		{"DB", cfg.DBDriver},
+		{"Cache", cfg.Cache},
+		{"Data", cfg.DataDir},
+		{"Log", cfg.LogLevel},
+	}
+
+	versionLine := fmt.Sprintf("  KeiRouter %s", cfg.Version)
+
+	// Box must be wide enough for the widest content row or the logo (~70 chars).
+	const logoWidth = 70
+	maxLen := logoWidth
+	if l := len(versionLine); l > maxLen {
+		maxLen = l
+	}
+	for _, r := range rows {
+		l := len(r.label) + 4 + len(r.value)
+		if l > maxLen {
+			maxLen = l
+		}
+	}
+	boxW := maxLen + 4
+
+	hLine := strings.Repeat("─", boxW)
+	top := ansiCyan + "  ╭" + hLine + "╮" + ansiReset
+	bot := ansiCyan + "  ╰" + hLine + "╯" + ansiReset
+	side := ansiCyan + "  │" + ansiReset
+
+	fmt.Fprintln(w)
+	for _, line := range strings.Split(logo, "\n") {
+		if line != "" {
+			fmt.Fprintf(w, "  %s%s%s\n", ansiCyan, line, ansiReset)
+		}
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, top)
+	fmt.Fprintf(w, "%s%s%s\n", side, padRow(versionLine, boxW), ansiReset)
+	fmt.Fprintf(w, "%s%s%s\n", side, padRow("", boxW), ansiReset)
+	for _, r := range rows {
+		content := fmt.Sprintf("  %s%s%s  %s",
+			ansiBold, r.label, ansiReset, r.value)
+		rawLen := len(r.label) + 4 + len(r.value)
+		gap := boxW - rawLen
+		if gap < 0 {
+			gap = 0
+		}
+		fmt.Fprintf(w, "%s%s%s%s\n",
+			side, content, strings.Repeat(" ", gap), ansiReset)
+	}
+	fmt.Fprintln(w, bot)
+	fmt.Fprintln(w)
+}
+
+func padRow(s string, width int) string {
+	gap := width - len(s)
+	if gap < 0 {
+		gap = 0
+	}
+	return s + strings.Repeat(" ", gap)
+}
+
+// PrintBannerStdout is a convenience wrapper for the common case.
+func PrintBannerStdout(cfg BannerConfig) {
+	PrintBanner(os.Stdout, cfg)
+}

--- a/backend/internal/prettylog/handler.go
+++ b/backend/internal/prettylog/handler.go
@@ -1,0 +1,197 @@
+// Package prettylog provides a TTY-aware slog handler and startup banner for
+// KeiRouter's CLI output. When stdout is a terminal it renders colorized,
+// compact log lines; when piped or redirected it falls back to plain text so
+// CI logs and log aggregators stay parseable.
+package prettylog
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// ANSI escape codes.
+const (
+	ansiReset  = "\033[0m"
+	ansiBold   = "\033[1m"
+	ansiDim    = "\033[2m"
+	ansiRed    = "\033[31m"
+	ansiGreen  = "\033[32m"
+	ansiYellow = "\033[33m"
+	ansiCyan   = "\033[36m"
+	ansiGray   = "\033[90m"
+)
+
+// Options configures the handler.
+type Options struct {
+	Level slog.Level
+}
+
+// Handler is a slog.Handler that renders colorized, compact output when
+// writing to a terminal, and falls back to plain text otherwise.
+type Handler struct {
+	w       io.Writer
+	level   slog.Level
+	pretty  bool
+	mu      *sync.Mutex
+	attrs   []slog.Attr
+	groups  []string
+}
+
+// NewHandler creates a handler. If w's file descriptor is a terminal, pretty
+// mode is enabled; otherwise it falls back to plain text.
+func NewHandler(w io.Writer, opts *Options) *Handler {
+	level := slog.LevelInfo
+	if opts != nil {
+		level = opts.Level
+	}
+
+	pretty := false
+	if f, ok := w.(interface{ Fd() uintptr }); ok {
+		pretty = IsTerminal(f.Fd())
+	}
+
+	return &Handler{
+		w:      w,
+		level:  level,
+		pretty: pretty,
+		mu:     &sync.Mutex{},
+	}
+}
+
+func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *Handler) Handle(_ context.Context, r slog.Record) error {
+	var sb strings.Builder
+	sb.Grow(256)
+
+	if h.pretty {
+		h.renderPretty(&sb, r)
+	} else {
+		h.renderPlain(&sb, r)
+	}
+
+	h.mu.Lock()
+	_, err := io.WriteString(h.w, sb.String())
+	h.mu.Unlock()
+	return err
+}
+
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	clone := *h
+	clone.attrs = append(clone.attrs[:len(clone.attrs):len(clone.attrs)], attrs...)
+	return &clone
+}
+
+func (h *Handler) WithGroup(name string) slog.Handler {
+	clone := *h
+	clone.groups = append(clone.groups[:len(clone.groups):len(clone.groups)], name)
+	return &clone
+}
+
+// renderPretty produces: "15:04:05 ● message    key=value key=value\n"
+func (h *Handler) renderPretty(sb *strings.Builder, r slog.Record) {
+	ts := r.Time.Format("15:04:05")
+	sb.WriteString(ansiGray)
+	sb.WriteString(ts)
+	sb.WriteString(ansiReset)
+	sb.WriteByte(' ')
+
+	icon, color := levelStyle(r.Level)
+	sb.WriteString(color)
+	sb.WriteString(icon)
+	sb.WriteString(ansiReset)
+	sb.WriteByte(' ')
+
+	sb.WriteString(r.Message)
+
+	// Collect static attrs.
+	var pairs []string
+	for _, a := range h.attrs {
+		pairs = append(pairs, formatAttr(a, true))
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		pairs = append(pairs, formatAttr(a, true))
+		return true
+	})
+
+	if len(pairs) > 0 {
+		// Pad message to align attributes.
+		msgLen := len(r.Message)
+		pad := 36 - msgLen
+		if pad < 2 {
+			pad = 2
+		}
+		sb.WriteString(strings.Repeat(" ", pad))
+		sb.WriteString(ansiGray)
+		sb.WriteString(strings.Join(pairs, " "))
+		sb.WriteString(ansiReset)
+	}
+	sb.WriteByte('\n')
+}
+
+// renderPlain produces: "time=15:04:05 level=INFO msg=\"message\" key=value\n"
+func (h *Handler) renderPlain(sb *strings.Builder, r slog.Record) {
+	sb.WriteString("time=")
+	sb.WriteString(r.Time.Format("15:04:05"))
+	sb.WriteString(" level=")
+	sb.WriteString(levelString(r.Level))
+	sb.WriteString(" msg=")
+	sb.WriteString(quoteIfNeeded(r.Message))
+
+	for _, a := range h.attrs {
+		sb.WriteByte(' ')
+		sb.WriteString(formatAttr(a, false))
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		sb.WriteByte(' ')
+		sb.WriteString(formatAttr(a, false))
+		return true
+	})
+	sb.WriteByte('\n')
+}
+
+func levelStyle(l slog.Level) (icon, color string) {
+	switch {
+	case l >= slog.LevelError:
+		return "✖", ansiBold + ansiRed
+	case l >= slog.LevelWarn:
+		return "▲", ansiYellow
+	case l >= slog.LevelInfo:
+		return "●", ansiGreen
+	default:
+		return "◆", ansiGray
+	}
+}
+
+func levelString(l slog.Level) string {
+	switch {
+	case l >= slog.LevelError:
+		return "ERROR"
+	case l >= slog.LevelWarn:
+		return "WARN"
+	case l >= slog.LevelInfo:
+		return "INFO"
+	default:
+		return "DEBUG"
+	}
+}
+
+func formatAttr(a slog.Attr, pretty bool) string {
+	if pretty {
+		return fmt.Sprintf("%s=%s", a.Key, a.Value.String())
+	}
+	return fmt.Sprintf("%s=%s", a.Key, quoteIfNeeded(a.Value.String()))
+}
+
+func quoteIfNeeded(s string) string {
+	if strings.ContainsAny(s, " \"\t\n=") {
+		return fmt.Sprintf("%q", s)
+	}
+	return s
+}

--- a/backend/internal/prettylog/isatty.go
+++ b/backend/internal/prettylog/isatty.go
@@ -1,0 +1,19 @@
+package prettylog
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// IsTerminal reports whether the given file descriptor is connected to a
+// terminal. Used to auto-enable pretty output during development while keeping
+// plain text in CI/production (piped or redirected stdout).
+func IsTerminal(fd uintptr) bool {
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
+// StdoutIsTTY is a convenience check for the common case.
+func StdoutIsTTY() bool {
+	return IsTerminal(os.Stdout.Fd())
+}

--- a/backend/internal/store/migrations/0018_account_health.sql
+++ b/backend/internal/store/migrations/0018_account_health.sql
@@ -1,0 +1,20 @@
+-- Background health probe status per account/model.
+CREATE TABLE IF NOT EXISTS account_health (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    status TEXT NOT NULL,
+    latency_ms INTEGER NOT NULL DEFAULT 0,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    consecutive_successes INTEGER NOT NULL DEFAULT 0,
+    last_ok_at TEXT,
+    last_checked_at TEXT NOT NULL,
+    last_error TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL,
+    UNIQUE(account_id, model)
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_health_tenant_status ON account_health(tenant_id, status);
+CREATE INDEX IF NOT EXISTS idx_account_health_account_model ON account_health(account_id, model);

--- a/backend/internal/store/models.go
+++ b/backend/internal/store/models.go
@@ -226,6 +226,25 @@ type AccountAffinity struct {
 	UpdatedAt time.Time
 }
 
+// AccountHealth stores background probe status for one account/model pair.
+// Model "__all__" means provider/account-level health when no specific model is
+// known. The dispatcher treats unhealthy rows as a soft skip.
+type AccountHealth struct {
+	ID                   string
+	TenantID             string
+	AccountID            string
+	Provider             string
+	Model                string
+	Status               string // healthy | degraded | unhealthy
+	LatencyMS            int
+	ConsecutiveFailures  int
+	ConsecutiveSuccesses int
+	LastOKAt             *time.Time
+	LastCheckedAt        time.Time
+	LastError            string
+	UpdatedAt            time.Time
+}
+
 // ResourceSample is one resource_samples row. Nullable fields use pointers so
 // platform-unsupported signals (open FDs, load average) round-trip as NULL.
 type ResourceSample struct {

--- a/backend/internal/store/repo_health.go
+++ b/backend/internal/store/repo_health.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// HealthRepo persists background account/model health probe results.
+type HealthRepo struct{ db *DB }
+
+// Health returns the account health repository.
+func (db *DB) Health() *HealthRepo { return &HealthRepo{db: db} }
+
+const accountHealthColumns = `id, tenant_id, account_id, provider, model, status,
+	latency_ms, consecutive_failures, consecutive_successes, last_ok_at,
+	last_checked_at, last_error, updated_at`
+
+// Upsert inserts or updates one account/model health row.
+func (r *HealthRepo) Upsert(ctx context.Context, h AccountHealth) error {
+	q := r.db.rebind(`INSERT INTO account_health (` + accountHealthColumns + `)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(account_id, model) DO UPDATE SET
+			tenant_id = excluded.tenant_id,
+			provider = excluded.provider,
+			status = excluded.status,
+			latency_ms = excluded.latency_ms,
+			consecutive_failures = excluded.consecutive_failures,
+			consecutive_successes = excluded.consecutive_successes,
+			last_ok_at = excluded.last_ok_at,
+			last_checked_at = excluded.last_checked_at,
+			last_error = excluded.last_error,
+			updated_at = excluded.updated_at`)
+	_, err := r.db.sql.ExecContext(ctx, q,
+		h.ID, h.TenantID, h.AccountID, h.Provider, h.Model, h.Status,
+		h.LatencyMS, h.ConsecutiveFailures, h.ConsecutiveSuccesses, nullTime(h.LastOKAt),
+		formatTime(h.LastCheckedAt), h.LastError, formatTime(h.UpdatedAt))
+	if err != nil {
+		return fmt.Errorf("store: upsert account health: %w", err)
+	}
+	return nil
+}
+
+// Get returns one account/model health row.
+func (r *HealthRepo) Get(ctx context.Context, accountID, model string) (AccountHealth, error) {
+	q := r.db.rebind(`SELECT ` + accountHealthColumns + ` FROM account_health WHERE account_id = ? AND model = ?`)
+	h, err := scanAccountHealth(r.db.sql.QueryRowContext(ctx, q, accountID, model).Scan)
+	if err == sql.ErrNoRows {
+		return AccountHealth{}, ErrNotFound
+	}
+	if err != nil {
+		return AccountHealth{}, fmt.Errorf("store: get account health: %w", err)
+	}
+	return h, nil
+}
+
+// IsUnhealthy reports whether the specific model or provider-level row is
+// unhealthy for this account.
+func (r *HealthRepo) IsUnhealthy(ctx context.Context, accountID, model string) (bool, error) {
+	q := r.db.rebind(`SELECT status FROM account_health
+		WHERE account_id = ? AND model IN (?, '__all__')`)
+	rows, err := r.db.sql.QueryContext(ctx, q, accountID, model)
+	if err != nil {
+		return false, fmt.Errorf("store: check account health: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var status string
+		if err := rows.Scan(&status); err != nil {
+			return false, err
+		}
+		if status == "unhealthy" {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// List returns health rows for a tenant.
+func (r *HealthRepo) List(ctx context.Context, tenantID string) ([]AccountHealth, error) {
+	q := r.db.rebind(`SELECT ` + accountHealthColumns + `
+		FROM account_health WHERE tenant_id = ?
+		ORDER BY provider, account_id, model`)
+	rows, err := r.db.sql.QueryContext(ctx, q, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("store: list account health: %w", err)
+	}
+	defer rows.Close()
+	var out []AccountHealth
+	for rows.Next() {
+		h, err := scanAccountHealth(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
+// RecentAccountModels returns recently used account/model pairs to health-check.
+func (r *HealthRepo) RecentAccountModels(ctx context.Context, tenantID string, since time.Time, limit int) ([]AccountHealth, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	q := r.db.rebind(`SELECT COALESCE(account_id, ''), provider, model, MAX(created_at)
+		FROM usage_records
+		WHERE tenant_id = ? AND created_at >= ? AND COALESCE(account_id, '') != '' AND model != ''
+		GROUP BY account_id, provider, model
+		ORDER BY MAX(created_at) DESC
+		LIMIT ?`)
+	rows, err := r.db.sql.QueryContext(ctx, q, tenantID, formatTime(since), limit)
+	if err != nil {
+		return nil, fmt.Errorf("store: recent account models: %w", err)
+	}
+	defer rows.Close()
+	var out []AccountHealth
+	for rows.Next() {
+		var h AccountHealth
+		var ignored string
+		if err := rows.Scan(&h.AccountID, &h.Provider, &h.Model, &ignored); err != nil {
+			return nil, err
+		}
+		h.TenantID = tenantID
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
+func scanAccountHealth(scan func(dest ...any) error) (AccountHealth, error) {
+	var (
+		h       AccountHealth
+		lastOK  sql.NullString
+		checked string
+		updated string
+	)
+	if err := scan(
+		&h.ID, &h.TenantID, &h.AccountID, &h.Provider, &h.Model, &h.Status,
+		&h.LatencyMS, &h.ConsecutiveFailures, &h.ConsecutiveSuccesses, &lastOK,
+		&checked, &h.LastError, &updated,
+	); err != nil {
+		return AccountHealth{}, err
+	}
+	if lastOK.Valid {
+		t := parseTime(lastOK.String)
+		h.LastOKAt = &t
+	}
+	h.LastCheckedAt = parseTime(checked)
+	h.UpdatedAt = parseTime(updated)
+	return h, nil
+}

--- a/backend/internal/store/repo_usage.go
+++ b/backend/internal/store/repo_usage.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -15,7 +17,54 @@ func (db *DB) Usage() *UsageRepo { return &UsageRepo{db: db} }
 
 // Record inserts a usage row for a completed request.
 func (r *UsageRepo) Record(ctx context.Context, u UsageRecord) error {
-	q := r.db.rebind(`
+	if err := insertUsage(ctx, r.db.sql, r.db.rebind, u); err != nil {
+		return fmt.Errorf("store: record usage: %w", err)
+	}
+	return nil
+}
+
+// RecordBatch inserts multiple usage rows in one transaction. It is compatible
+// with both SQLite and Postgres because placeholders are rebound through DB.
+func (r *UsageRepo) RecordBatch(ctx context.Context, records []UsageRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	tx, err := r.db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("store: begin usage batch: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	const cols = 22
+	var b strings.Builder
+	b.WriteString(`INSERT INTO usage_records
+		(id, tenant_id, project_id, api_key_id, provider, model, account_id, client,
+		 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
+		 cost_micros, cache_hit, latency_ms, ttft_ms,
+		 slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+		 created_at) VALUES `)
+	args := make([]any, 0, len(records)*cols)
+	for i, u := range records {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+		args = append(args, usageArgs(u)...)
+	}
+	q := r.db.rebind(b.String())
+	if _, err := tx.ExecContext(ctx, q, args...); err != nil {
+		return fmt.Errorf("store: record usage batch: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: commit usage batch: %w", err)
+	}
+	return nil
+}
+
+func insertUsage(ctx context.Context, exec interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, rebind func(string) string, u UsageRecord) error {
+	q := rebind(`
 		INSERT INTO usage_records
 			(id, tenant_id, project_id, api_key_id, provider, model, account_id, client,
 			 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
@@ -23,17 +72,19 @@ func (r *UsageRepo) Record(ctx context.Context, u UsageRecord) error {
 			 slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
 			 created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-	_, err := r.db.sql.ExecContext(ctx, q,
+	_, err := exec.ExecContext(ctx, q, usageArgs(u)...)
+	return err
+}
+
+func usageArgs(u UsageRecord) []any {
+	return []any{
 		u.ID, u.TenantID, nullString(u.ProjectID), nullString(u.APIKeyID),
 		u.Provider, u.Model, nullString(u.AccountID), u.Client,
 		u.PromptTokens, u.CompletionTokens, u.CachedTokens, u.CacheWriteTokens,
 		u.CostMicros, boolToInt(u.CacheHit), u.LatencyMS, u.TTFTMS,
 		u.SlimBytesSaved, u.SlimTokensSaved, u.SlimRules, boolToInt(u.CavemanActive), boolToInt(u.TerseActive),
-		formatTime(u.CreatedAt))
-	if err != nil {
-		return fmt.Errorf("store: record usage: %w", err)
+		formatTime(u.CreatedAt),
 	}
-	return nil
 }
 
 // SpendSince returns total cost in micros for a budget scope since the given

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,6 +44,29 @@ security:
   # remain blocked.
   allow_private_base_url: false
 
+meter:
+  # Buffered/batched usage writes. Keeps request latency low and reduces DB
+  # round-trips for both SQLite and Postgres.
+  async: true
+  batch_size: 100
+  flush_interval: 1s
+  queue_size: 10000
+  # When queue is full: "sync" writes inline to avoid data loss, "drop" drops.
+  full_queue_policy: sync
+  shutdown_flush_timeout: 5s
+
+health:
+  # Background account/model health checks. Unhealthy account/model pairs are
+  # skipped by dispatch until probes recover.
+  enabled: true
+  interval: 30s
+  timeout: 5s
+  max_parallel: 8
+  failure_threshold: 2
+  success_threshold: 1
+  recent_model_window: 24h
+  max_models_per_provider: 8
+
 cache:
   # Semantic response cache. Off by default. When enabled, repeated or
   # near-identical prompts are served from cache for zero upstream cost.

--- a/go.work.sum
+++ b/go.work.sum
@@ -29,10 +29,12 @@ golang.org/x/exp v0.0.0-20231108232855-2478ac86f678 h1:mchzmB1XO2pMaKFRqk/+MV3mg
 golang.org/x/exp v0.0.0-20231108232855-2478ac86f678/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
 golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
 golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
 golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
 golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
+golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
## Summary

- Add async/batched usage writer to reduce request-path DB write overhead
- Add background account/model health checker with persisted health state
- Skip unhealthy account/model pairs during dispatch
- Add health admin endpoints for listing account health and triggering checks
- Add configuration for metering and health checks
- Add account_health migration and repository
- Add pretty startup logging already present on this branch

## Details

### Async usage writer
- Buffers usage records in memory
- Flushes records in batches via `UsageRepo.RecordBatch`
- Supports SQLite and Postgres through existing SQL rebinding
- Falls back to sync writes when queue is full by default
- Drains pending records during shutdown

### Account/model health checks
- Adds `account_health` table
- Probes enabled accounts periodically
- Uses recent account/model usage where available
- Records healthy/degraded/unhealthy status
- Dispatcher skips known unhealthy account/model pairs

### Admin API
- `GET /api/health/accounts`
- `POST /api/health/check-now`

## Testing

```bash
go test ./backend/internal/...
```
