### PR TITLE
fix(kiro): always attach profileArn to chat requests

### DIFF
--- a/backend/internal/connectors/kiro.go
+++ b/backend/internal/connectors/kiro.go
@@ -53,6 +53,49 @@ func isKiroAPIKey(creds core.Credentials) bool {
 	return creds.Extra["kiro_auth_method"] == "api_key"
 }
 
+// Public default CodeWhisperer profile ARNs (us-east-1), keyed by auth method.
+// Used when an OAuth/social connection could not resolve its own profileArn.
+// Builder ID / IDC sign-ins and social (Google/GitHub/imported) sign-ins map to
+// different shared profiles. Kiro upstream now rejects a generateAssistantResponse
+// request without a profileArn (400 "profileArn is required for this request."),
+// so an OAuth/social connection must always carry one.
+const (
+	kiroDefaultProfileArnBuilderID = "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX"
+	kiroDefaultProfileArnSocial    = "arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK"
+)
+
+// kiroDefaultProfileArn resolves the shared default profileArn for a given OAuth
+// auth method. Social sign-ins (Google/GitHub/imported Kiro IDE tokens) map to
+// the social profile; Builder ID / IDC map to the builder-id profile.
+func kiroDefaultProfileArn(authMethod string) string {
+	switch authMethod {
+	case "google", "github", "imported", "social":
+		return kiroDefaultProfileArnSocial
+	default:
+		return kiroDefaultProfileArnBuilderID
+	}
+}
+
+// kiroResolveProfileArn returns the profileArn to attach to a chat request. For
+// API-key auth, only an ARN actually resolved for the key is used — never the
+// shared default, since an ARN not owned by the key's account is rejected with
+// 403. For OAuth/social auth the connection's resolved ARN is preferred, falling
+// back to the shared default keyed by auth method so the request always carries
+// a profileArn (the upstream 400s without one).
+func kiroResolveProfileArn(creds core.Credentials) string {
+	resolved := creds.Extra["kiro_profile_arn"]
+	if resolved == "" {
+		resolved = creds.Extra["profile_arn"]
+	}
+	if isKiroAPIKey(creds) {
+		return resolved
+	}
+	if resolved != "" {
+		return resolved
+	}
+	return kiroDefaultProfileArn(creds.Extra["kiro_auth_method"])
+}
+
 // kiroAPIKey resolves the raw API key from the credentials. The key may arrive
 // in the dedicated APIKey field or, for imported connections, as the access
 // token.
@@ -324,7 +367,7 @@ func (c *Kiro) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaRe
 	// CodeWhisperer 403 the request ("bearer token invalid"). OAuth/social may
 	// fall back to the default placeholder.
 	if profileArn == "" && !isAPIKey {
-		profileArn = "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX"
+		profileArn = kiroDefaultProfileArn(authMethod)
 	}
 
 	authHeaders := map[string]string{
@@ -621,14 +664,14 @@ func (c *Kiro) Chat(ctx context.Context, req *core.ChatRequest, creds core.Crede
 // Stream performs a streaming call, parsing the AWS EventStream into canonical
 // chunks.
 func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Credentials, cfg core.StreamConfig) (<-chan core.StreamChunk, error) {
-	// API-key credentials are scoped to a CodeWhisperer profile resolved at
-	// connect time; the request body must carry that profileArn or the upstream
-	// rejects it with 403. OAuth/social tokens send no profileArn.
-	var profileArn string
-	if isKiroAPIKey(creds) {
-		profileArn = creds.Extra["kiro_profile_arn"]
-	}
+	// Every Kiro chat request must carry a profileArn — the upstream rejects a
+	// request without one (400 "profileArn is required for this request."). For
+	// API-key auth only the ARN resolved for the key is sent (a foreign ARN
+	// 403s). For OAuth/social the connection's resolved ARN is used, falling
+	// back to the shared default profile for the auth method.
+	profileArn := kiroResolveProfileArn(creds)
 	body, err := c.codec.RenderRequestWithProfile(req, profileArn)
+
 	if err != nil {
 		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}
 	}

--- a/backend/internal/connectors/kiro_test.go
+++ b/backend/internal/connectors/kiro_test.go
@@ -289,7 +289,78 @@ func TestKiroHeaders_OAuthHasNoTokenType(t *testing.T) {
 	}
 }
 
+func TestKiroResolveProfileArn(t *testing.T) {
+	cases := []struct {
+		name  string
+		creds core.Credentials
+		want  string
+	}{
+		{
+			name:  "oauth builder-id falls back to builder-id default",
+			creds: core.Credentials{Extra: map[string]string{"kiro_auth_method": "builder-id"}},
+			want:  kiroDefaultProfileArnBuilderID,
+		},
+		{
+			name:  "oauth idc falls back to builder-id default",
+			creds: core.Credentials{Extra: map[string]string{"kiro_auth_method": "idc"}},
+			want:  kiroDefaultProfileArnBuilderID,
+		},
+		{
+			name:  "imported social falls back to social default",
+			creds: core.Credentials{Extra: map[string]string{"kiro_auth_method": "imported"}},
+			want:  kiroDefaultProfileArnSocial,
+		},
+		{
+			name:  "google social falls back to social default",
+			creds: core.Credentials{Extra: map[string]string{"kiro_auth_method": "google"}},
+			want:  kiroDefaultProfileArnSocial,
+		},
+		{
+			name:  "no auth method falls back to builder-id default",
+			creds: core.Credentials{Extra: map[string]string{}},
+			want:  kiroDefaultProfileArnBuilderID,
+		},
+		{
+			name: "resolved kiro_profile_arn wins over default",
+			creds: core.Credentials{Extra: map[string]string{
+				"kiro_auth_method": "builder-id",
+				"kiro_profile_arn": "arn:aws:codewhisperer:us-east-1:111:profile/RESOLVED",
+			}},
+			want: "arn:aws:codewhisperer:us-east-1:111:profile/RESOLVED",
+		},
+		{
+			name: "resolved profile_arn used when kiro_profile_arn empty",
+			creds: core.Credentials{Extra: map[string]string{
+				"kiro_auth_method": "google",
+				"profile_arn":      "arn:aws:codewhisperer:us-east-1:222:profile/ALT",
+			}},
+			want: "arn:aws:codewhisperer:us-east-1:222:profile/ALT",
+		},
+		{
+			name: "api_key uses only resolved arn",
+			creds: core.Credentials{Extra: map[string]string{
+				"kiro_auth_method": "api_key",
+				"kiro_profile_arn": "arn:aws:codewhisperer:us-east-1:333:profile/KEY",
+			}},
+			want: "arn:aws:codewhisperer:us-east-1:333:profile/KEY",
+		},
+		{
+			name:  "api_key without resolved arn injects no default",
+			creds: core.Credentials{Extra: map[string]string{"kiro_auth_method": "api_key"}},
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := kiroResolveProfileArn(tc.creds); got != tc.want {
+				t.Errorf("kiroResolveProfileArn() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestKiroEndpointRetryable(t *testing.T) {
+
 	cases := []struct {
 		kind core.ErrorKind
 		want bool


### PR DESCRIPTION
## Summary
Upstream now rejects `generateAssistantResponse` without `profileArn` (400 "profileArn is required for this request."). This change ensures a `profileArn` is always attached to Kiro chat requests.

## Changes
- Add `kiroResolveProfileArn`:
  - API-key auth sends only the key-resolved ARN (a foreign ARN 403s).
  - OAuth/social prefers the resolved ARN, falling back to a shared default keyed by auth method.
- Add `kiroDefaultProfileArn` mapping social sign-ins (google/github/imported/social) to the social profile, and others to the builder-id profile.
- Use the resolver in `Stream`; replace the hardcoded ARN in `FetchQuota`.

## Tests
- Add `TestKiroResolveProfileArn` covering OAuth fallback, API-key, and resolved-ARN cases.