### PR TITLE
feat: add optional Headroom compression proxy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,13 @@ BACKEND_DIR := backend
 FRONTEND_DIR := frontend
 BIN := keirouter
 
+# Headroom proxy settings for local dev.
+# Keep Headroom opt-in so `make dev`/`make setup` remain the same lightweight
+# backend + dashboard flow unless explicitly requested.
+KEIROUTER_HEADROOM_AUTO ?= 0
+HEADROOM_PORT ?= 8787
+HEADROOM_IMAGE := ghcr.io/chopratejas/headroom:latest
+
 # ANSI colors for terminal output.
 C_RESET  := \033[0m
 C_BOLD   := \033[1m
@@ -21,21 +28,45 @@ C_GREEN  := \033[32m
 C_YELLOW := \033[33m
 C_CYAN   := \033[36m
 
-.PHONY: dev backend frontend build build-backend build-frontend test vet hooks bootstrap install setup quickstart clean docker
+.PHONY: dev backend frontend build build-backend build-frontend test vet hooks bootstrap install setup quickstart clean docker headroom
 
-## dev: run backend and frontend concurrently; Ctrl-C stops both.
+## headroom: start the optional Headroom compression proxy (Docker/native).
+headroom:
+	@if command -v docker >/dev/null 2>&1; then \
+		printf "$(C_BOLD)$(C_CYAN)Starting Headroom$(C_RESET) proxy via Docker (:$(HEADROOM_PORT))...\n"; \
+		docker run --rm --name keirouter-headroom \
+			-p 127.0.0.1:$(HEADROOM_PORT):$(HEADROOM_PORT) \
+			-e HEADROOM_HOST=0.0.0.0 \
+			-e HEADROOM_PORT=$(HEADROOM_PORT) \
+			-e HEADROOM_MODE=optimize \
+			-e HEADROOM_TELEMETRY=off \
+			$(HEADROOM_IMAGE) \
+			--port $(HEADROOM_PORT) --host 0.0.0.0; \
+	elif command -v headroom >/dev/null 2>&1; then \
+		printf "$(C_BOLD)$(C_CYAN)Starting Headroom$(C_RESET) proxy (native :$(HEADROOM_PORT))...\n"; \
+		headroom proxy --port $(HEADROOM_PORT) --host 127.0.0.1; \
+	else \
+		printf "$(C_YELLOW)Headroom unavailable: need Docker or headroom CLI. Install Docker or run: pip install 'headroom-ai[proxy]'$(C_RESET)\n"; \
+		exit 1; \
+	fi
+
+## dev: run backend and frontend concurrently; Ctrl-C stops all.
 ##      The backend starts first; frontend waits until the backend is healthy
 ##      so the Vite proxy never hits ECONNREFUSED on cold start.
+##      Set KEIROUTER_HEADROOM_AUTO=1 to also start Headroom.
 dev:
-	@printf "$(C_BOLD)$(C_CYAN)Starting KeiRouter$(C_RESET) backend (:20180) + dashboard (:5180)…\n"
-	@trap 'kill 0' INT TERM EXIT; \
+	@printf "$(C_BOLD)$(C_CYAN)Starting KeiRouter$(C_RESET) backend (:20180) + dashboard (:5180)...\n"
+	@trap 'kill 0; docker stop keirouter-headroom 2>/dev/null || true' INT TERM EXIT; \
+	if [ "$(KEIROUTER_HEADROOM_AUTO)" = "1" ]; then \
+		( $(MAKE) --no-print-directory headroom ) & \
+	fi; \
 	( cd $(BACKEND_DIR) && go run ./cmd/keirouter ) & \
 	( \
-		printf "$(C_DIM)⏳ Waiting for backend…$(C_RESET)\n"; \
+		printf "$(C_DIM)Waiting for backend...$(C_RESET)\n"; \
 		ready=0; \
 		for i in $$(seq 1 30); do \
 			if curl -sf http://127.0.0.1:20180/healthz >/dev/null 2>&1; then \
-				printf "$(C_GREEN)$(C_BOLD)✅ Backend ready$(C_RESET)\n"; \
+				printf "$(C_GREEN)$(C_BOLD)Backend ready$(C_RESET)\n"; \
 				ready=1; \
 				break; \
 			fi; \
@@ -76,7 +107,7 @@ hooks:
 	@mkdir -p "$(shell git rev-parse --git-dir)/hooks"
 	@cp scripts/hooks/pre-push "$(shell git rev-parse --git-dir)/hooks/pre-push"
 	@chmod +x "$(shell git rev-parse --git-dir)/hooks/pre-push"
-	@echo "✅ pre-push hook installed"
+	@echo "pre-push hook installed"
 
 ## test: run the backend test suite.
 test:
@@ -98,19 +129,21 @@ docker:
 clean:
 	rm -f $(BIN)
 	rm -rf $(FRONTEND_DIR)/dist
+	docker stop keirouter-headroom 2>/dev/null || true
 
 ## setup: install deps (if needed) then start dev servers.
-##        Zero config — no .env required for local use.
+##        Zero config -- no .env required for local use.
 ##        Usage: make setup
 setup:
-	@printf "$(C_BOLD)$(C_CYAN)🚀 KeiRouter$(C_RESET) — one-command setup\n"
-	@test -d $(FRONTEND_DIR)/node_modules || ( printf "$(C_DIM)📦 Installing frontend deps…$(C_RESET)\n" && cd $(FRONTEND_DIR) && npm ci --quiet )
+	@printf "$(C_BOLD)$(C_CYAN)KeiRouter$(C_RESET) -- one-command setup\n"
+	@test -d $(FRONTEND_DIR)/node_modules || ( printf "$(C_DIM)Installing frontend deps...$(C_RESET)\n" && cd $(FRONTEND_DIR) && npm ci --quiet )
 	@cd $(BACKEND_DIR) && go mod download 2>/dev/null || true
 	@echo ""
-	@printf "$(C_GREEN)$(C_BOLD)✅ Dependencies ready.$(C_RESET) Starting dev servers…\n"
-	@echo "   Backend  → http://localhost:20180"
-	@echo "   Dashboard→ http://localhost:5180"
-	@echo "   Password → keirouter"
+	@printf "$(C_GREEN)$(C_BOLD)Dependencies ready.$(C_RESET) Starting dev servers...\n"
+	@echo "   Backend   -> http://localhost:20180"
+	@echo "   Dashboard -> http://localhost:5180"
+	@echo "   Headroom  -> optional; run 'make headroom' or 'KEIROUTER_HEADROOM_AUTO=1 make dev'"
+	@echo "   Password  -> keirouter"
 	@echo ""
 	@$(MAKE) dev
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,44 @@ KeiRouter isn't just for chat! It supports everything:
 - **Web Search & Fetching** (`/v1/search`, `/v1/web/fetch`)
 - **Embeddings** (`/v1/embeddings`)
 
+## 🧠 Optional Headroom context compression
+
+Headroom is an optional context-compression proxy. KeiRouter can call its `/v1/compress` endpoint before provider routing, then keep the normal fallback, metering, and dashboard analytics flow. It is disabled by default, and `make dev` / `make setup` do not require it.
+
+Start Headroom separately when you want to use it:
+
+```bash
+make headroom
+```
+
+Or run the proxy with Docker:
+
+```bash
+docker run --rm --name keirouter-headroom \
+  -p 127.0.0.1:8787:8787 \
+  ghcr.io/chopratejas/headroom:latest
+```
+
+Then open **Dashboard → Settings → Token Saving → Headroom context compression** and enable it. The default local URL is:
+
+```text
+http://127.0.0.1:8787
+```
+
+For Docker Compose deployments, KeiRouter can use a sidecar URL such as:
+
+```text
+http://headroom:8787
+```
+
+You can also opt in to starting Headroom together with local dev servers:
+
+```bash
+KEIROUTER_HEADROOM_AUTO=1 make dev
+```
+
+If Headroom is disabled, unavailable, or returns an error, KeiRouter continues with the original request without context compression.
+
 ## 🔑 Connect via OAuth (No API Keys needed!)
 Tired of copying API keys? You can connect providers like Claude, GitHub Copilot, Gemini CLI, and more directly from the Connections page using OAuth. Just click, sign in, and KeiRouter handles securely refreshing your tokens in the background!
 

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/guardrails/pii"
 	"github.com/mydisha/keirouter/backend/internal/guardrails/topics"
 	"github.com/mydisha/keirouter/backend/internal/guardrails/toxicity"
+	"github.com/mydisha/keirouter/backend/internal/headroom"
 	"github.com/mydisha/keirouter/backend/internal/healthcheck"
 	"github.com/mydisha/keirouter/backend/internal/httputil"
 	"github.com/mydisha/keirouter/backend/internal/identity"
@@ -292,6 +293,7 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 		Meter:              mtr,
 		Budget:             bud,
 		Slimmer:            slim,
+		Headroom:           headroom.New(),
 		Metrics:            metrics,
 		Cache:              semanticCache,
 		Embedder:           embedder,

--- a/backend/internal/gateway/gemini.go
+++ b/backend/internal/gateway/gemini.go
@@ -88,6 +88,7 @@ func (s *Server) handleGeminiGenerate(w http.ResponseWriter, r *http.Request) {
 		Targets:  resolved.Targets,
 		PlanOpts: s.endpointPlanOptions(r.Context(), resolved.PlanOpts, resolved.Targets, affinityKey),
 		Slimmer:  s.slimmerConfig(),
+		Headroom: s.headroomConfig(),
 		Terse:    s.terseConfig(),
 		Caveman:  s.cavemanConfig(),
 	}

--- a/backend/internal/gateway/handlers.go
+++ b/backend/internal/gateway/handlers.go
@@ -230,6 +230,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request, dialect core
 		Targets:  resolved.Targets,
 		PlanOpts: s.endpointPlanOptions(r.Context(), resolved.PlanOpts, resolved.Targets, affinityKey),
 		Slimmer:  s.slimmerConfig(),
+		Headroom: s.headroomConfig(),
 		Terse:    s.terseConfig(),
 		Caveman:  s.cavemanConfig(),
 		Limits:   effectiveLimits,

--- a/backend/internal/gateway/insights.go
+++ b/backend/internal/gateway/insights.go
@@ -68,8 +68,9 @@ func (s *Server) adminUsageInsights(w http.ResponseWriter, r *http.Request) {
 		breakdown     []store.ProviderUsage
 		recent        []store.RecentRecord
 		timeline      []store.TimeBucket
-		ruleSavings   []store.RuleSavings
-		clientSavings []store.ClientSavings
+		ruleSavings     []store.RuleSavings
+		clientSavings   []store.ClientSavings
+		headroomSavings []store.HeadroomTransformSavings
 	)
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -94,6 +95,10 @@ func (s *Server) adminUsageInsights(w http.ResponseWriter, r *http.Request) {
 	})
 	g.Go(func() error {
 		clientSavings, _ = s.usage.SavingsByClient(gctx, adminTenant, since)
+		return nil
+	})
+	g.Go(func() error {
+		headroomSavings, _ = s.usage.SavingsByHeadroomTransform(gctx, adminTenant, since)
 		return nil
 	})
 	if err := g.Wait(); err != nil {
@@ -153,6 +158,13 @@ func (s *Server) adminUsageInsights(w http.ResponseWriter, r *http.Request) {
 		}
 		if rec.SlimRules != "" {
 			entry["slim_rules"] = rec.SlimRules
+		}
+		if rec.HeadroomActive {
+			entry["headroom_active"] = true
+			entry["headroom_tokens_saved"] = rec.HeadroomTokensSaved
+		}
+		if rec.HeadroomTransforms != "" {
+			entry["headroom_transforms"] = rec.HeadroomTransforms
 		}
 		if rec.CavemanActive {
 			entry["caveman_active"] = true
@@ -236,6 +248,16 @@ func (s *Server) adminUsageInsights(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	// Headroom savings by transform.
+	headroomTransforms := make([]map[string]any, 0, len(headroomSavings))
+	for _, hs := range headroomSavings {
+		headroomTransforms = append(headroomTransforms, map[string]any{
+			"transform":    hs.Transform,
+			"count":        hs.Count,
+			"tokens_saved": hs.TokensSaved,
+		})
+	}
+
 	writeJSONCached(w, s.insightsCache, cacheKey, map[string]any{
 		"summary": map[string]any{
 			"total_requests":     sum.TotalRequests,
@@ -251,14 +273,17 @@ func (s *Server) adminUsageInsights(w http.ResponseWriter, r *http.Request) {
 			"since":              since,
 		},
 		"savings": map[string]any{
-			"slim_bytes_saved":   sum.SlimBytesSaved,
-			"slim_tokens_saved":  sum.SlimTokensSaved,
-			"caveman_requests":   sum.CavemanRequests,
-			"terse_requests":     sum.TerseRequests,
-			"usd_saved":          usdPerToken(sum.SlimTokensSaved),
-			"usd_saved_estimate": true,
-			"rules":              rules,
-			"by_client":          byClient,
+			"slim_bytes_saved":      sum.SlimBytesSaved,
+			"slim_tokens_saved":     sum.SlimTokensSaved,
+			"headroom_requests":     sum.HeadroomRequests,
+			"headroom_tokens_saved": sum.HeadroomTokensSaved,
+			"caveman_requests":      sum.CavemanRequests,
+			"terse_requests":        sum.TerseRequests,
+			"usd_saved":             usdPerToken(sum.SlimTokensSaved + sum.HeadroomTokensSaved),
+			"usd_saved_estimate":    true,
+			"rules":                 rules,
+			"headroom_transforms":   headroomTransforms,
+			"by_client":             byClient,
 		},
 		"providers": providers,
 		"recent":    recentRows,

--- a/backend/internal/gateway/settings.go
+++ b/backend/internal/gateway/settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/caveman"
 	"github.com/mydisha/keirouter/backend/internal/connectors"
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
+	"github.com/mydisha/keirouter/backend/internal/headroom"
 	"github.com/mydisha/keirouter/backend/internal/slimmer"
 	"github.com/mydisha/keirouter/backend/internal/terse"
 )
@@ -25,6 +27,15 @@ type EndpointSettings struct {
 	// RTKEnabled toggles input-side tool-output compression (the slimmer).
 	RTKEnabled     bool   `json:"rtk_enabled"`
 	RTKFilterLevel string `json:"rtk_filter_level"` // "none", "minimal", "aggressive"
+
+	// HeadroomEnabled toggles Headroom input-side context compression through a
+	// local/sidecar Headroom proxy. It is mutually exclusive with RTK.
+	HeadroomEnabled      bool   `json:"headroom_enabled"`
+	HeadroomBaseURL      string `json:"headroom_base_url"`
+	HeadroomAPIKey       string `json:"headroom_api_key,omitempty"`
+	HeadroomTimeoutMs    int    `json:"headroom_timeout_ms"`
+	HeadroomTokenBudget  int    `json:"headroom_token_budget"`
+	HeadroomOutputShaper bool   `json:"headroom_output_shaper"`
 
 	// CavemanEnabled toggles output-side caveman compression; CavemanLevel is
 	// one of "lite", "full", "ultra".
@@ -69,6 +80,11 @@ func defaultEndpointSettings() EndpointSettings {
 	return EndpointSettings{
 		RTKEnabled:     true,
 		RTKFilterLevel: "none",
+		HeadroomEnabled:      false,
+		HeadroomBaseURL:      defaultHeadroomBaseURL(),
+		HeadroomTimeoutMs:    15000,
+		HeadroomTokenBudget:  100000,
+		HeadroomOutputShaper: false,
 		CavemanEnabled:       false,
 		CavemanLevel:         string(caveman.LevelFull),
 		TerseEnabled:         false,
@@ -119,6 +135,15 @@ func (s *Server) loadEndpointSettings(ctx context.Context) EndpointSettings {
 	if es.RTKFilterLevel == "" {
 		es.RTKFilterLevel = def.RTKFilterLevel
 	}
+	if es.HeadroomBaseURL == "" {
+		es.HeadroomBaseURL = def.HeadroomBaseURL
+	}
+	if es.HeadroomTimeoutMs == 0 {
+		es.HeadroomTimeoutMs = def.HeadroomTimeoutMs
+	}
+	if es.HeadroomTokenBudget == 0 {
+		es.HeadroomTokenBudget = def.HeadroomTokenBudget
+	}
 	if es.TerseLevel == "" {
 		es.TerseLevel = def.TerseLevel
 	}
@@ -155,12 +180,36 @@ func (s *Server) loadEndpointSettings(ctx context.Context) EndpointSettings {
 	return es
 }
 
+func defaultHeadroomBaseURL() string {
+	if v := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(os.Getenv("KEIROUTER_HEADROOM__BASE_URL")), "/")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(os.Getenv("HEADROOM_BASE_URL")), "/")); v != "" {
+		return v
+	}
+	return "http://127.0.0.1:8787"
+}
+
 // slimmerConfig resolves the slimmer (RTK) settings from endpoint settings.
 func (s *Server) slimmerConfig() slimmer.Config {
 	es := s.loadEndpointSettings(context.Background())
 	return slimmer.Config{
 		Enabled:     es.RTKEnabled,
 		FilterLevel: slimmer.ParseFilterLevel(es.RTKFilterLevel),
+	}
+}
+
+// headroomConfig resolves Headroom settings from endpoint settings.
+func (s *Server) headroomConfig() headroom.Config {
+	es := s.loadEndpointSettings(context.Background())
+	return headroom.Config{
+		Enabled:      es.HeadroomEnabled,
+		BaseURL:      es.HeadroomBaseURL,
+		APIKey:       es.HeadroomAPIKey,
+		Timeout:      time.Duration(es.HeadroomTimeoutMs) * time.Millisecond,
+		TokenBudget:  es.HeadroomTokenBudget,
+		OutputShaper: es.HeadroomOutputShaper,
+		Fallback:     true,
 	}
 }
 
@@ -195,6 +244,12 @@ func (s *Server) adminUpdateEndpointSettings(w http.ResponseWriter, r *http.Requ
 	var patch struct {
 		RTKEnabled              *bool   `json:"rtk_enabled"`
 		RTKFilterLevel          *string `json:"rtk_filter_level"`
+		HeadroomEnabled         *bool   `json:"headroom_enabled"`
+		HeadroomBaseURL         *string `json:"headroom_base_url"`
+		HeadroomAPIKey          *string `json:"headroom_api_key"`
+		HeadroomTimeoutMs       *int    `json:"headroom_timeout_ms"`
+		HeadroomTokenBudget     *int    `json:"headroom_token_budget"`
+		HeadroomOutputShaper    *bool   `json:"headroom_output_shaper"`
 		CavemanEnabled          *bool   `json:"caveman_enabled"`
 		CavemanLevel            *string `json:"caveman_level"`
 		TerseEnabled            *bool   `json:"terse_enabled"`
@@ -227,6 +282,36 @@ func (s *Server) adminUpdateEndpointSettings(w http.ResponseWriter, r *http.Requ
 			writeError(w, http.StatusBadRequest, "rtk_filter_level must be none, minimal, or aggressive")
 			return
 		}
+	}
+	if patch.HeadroomEnabled != nil {
+		current.HeadroomEnabled = *patch.HeadroomEnabled
+	}
+	if patch.HeadroomBaseURL != nil {
+		current.HeadroomBaseURL = strings.TrimRight(strings.TrimSpace(*patch.HeadroomBaseURL), "/")
+		if current.HeadroomBaseURL == "" {
+			writeError(w, http.StatusBadRequest, "headroom_base_url must not be empty")
+			return
+		}
+	}
+	if patch.HeadroomAPIKey != nil {
+		current.HeadroomAPIKey = strings.TrimSpace(*patch.HeadroomAPIKey)
+	}
+	if patch.HeadroomTimeoutMs != nil {
+		if *patch.HeadroomTimeoutMs < 1000 || *patch.HeadroomTimeoutMs > 120000 {
+			writeError(w, http.StatusBadRequest, "headroom_timeout_ms must be between 1000 and 120000")
+			return
+		}
+		current.HeadroomTimeoutMs = *patch.HeadroomTimeoutMs
+	}
+	if patch.HeadroomTokenBudget != nil {
+		if *patch.HeadroomTokenBudget < 1000 || *patch.HeadroomTokenBudget > 2000000 {
+			writeError(w, http.StatusBadRequest, "headroom_token_budget must be between 1000 and 2000000")
+			return
+		}
+		current.HeadroomTokenBudget = *patch.HeadroomTokenBudget
+	}
+	if patch.HeadroomOutputShaper != nil {
+		current.HeadroomOutputShaper = *patch.HeadroomOutputShaper
 	}
 	if patch.CavemanEnabled != nil {
 		current.CavemanEnabled = *patch.CavemanEnabled
@@ -326,6 +411,19 @@ func (s *Server) adminUpdateEndpointSettings(w http.ResponseWriter, r *http.Requ
 		} else {
 			current.TerseEnabled = false
 		}
+	}
+	if current.HeadroomEnabled && current.RTKEnabled {
+		if patch.HeadroomEnabled != nil && *patch.HeadroomEnabled {
+			current.RTKEnabled = false
+		} else if patch.RTKEnabled != nil && *patch.RTKEnabled {
+			current.HeadroomEnabled = false
+		} else {
+			current.RTKEnabled = false
+		}
+	}
+	if current.HeadroomOutputShaper {
+		current.CavemanEnabled = false
+		current.TerseEnabled = false
 	}
 
 	raw, err := json.Marshal(current)

--- a/backend/internal/headroom/headroom.go
+++ b/backend/internal/headroom/headroom.go
@@ -1,0 +1,279 @@
+// Package headroom integrates KeiRouter with the Headroom compression proxy.
+// It calls Headroom's compression-only HTTP API and applies the returned
+// OpenAI-format messages back to KeiRouter's canonical request model.
+package headroom
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+// Config controls Headroom compression for one request.
+type Config struct {
+	Enabled      bool
+	BaseURL      string
+	APIKey       string
+	Timeout      time.Duration
+	TokenBudget  int
+	OutputShaper bool
+	Fallback     bool
+	IncludeTools bool
+}
+
+// Stats captures exact savings returned by Headroom.
+type Stats struct {
+	TokensBefore     int
+	TokensAfter      int
+	TokensSaved      int
+	CompressionRatio float64
+	Transforms       []string
+	CCRHashes        []string
+}
+
+// Client calls the Headroom proxy.
+type Client struct {
+	http *http.Client
+}
+
+// New builds a Headroom client.
+func New() *Client { return &Client{http: http.DefaultClient} }
+
+// Compress sends req to Headroom, mutating req in place on success. It returns
+// nil stats when disabled, when Headroom reports no compression, or when the
+// request contains content we intentionally do not translate.
+func (c *Client) Compress(ctx context.Context, req *core.ChatRequest, cfg Config) (*Stats, error) {
+	if req == nil || !cfg.Enabled {
+		return nil, nil
+	}
+	if containsUnsupportedParts(req) {
+		return nil, nil
+	}
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "http://127.0.0.1:8787"
+	}
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+
+	msgs := toOpenAIMessages(req)
+	if len(msgs) == 0 {
+		return nil, nil
+	}
+	body := map[string]any{
+		"messages": msgs,
+		"model":    req.Model,
+		"fallback": true,
+	}
+	if cfg.TokenBudget > 0 {
+		body["tokenBudget"] = cfg.TokenBudget
+		body["token_budget"] = cfg.TokenBudget
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	hreq, err := http.NewRequestWithContext(callCtx, http.MethodPost, baseURL+"/v1/compress", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	hreq.Header.Set("Content-Type", "application/json")
+	if cfg.APIKey != "" {
+		hreq.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+
+	hc := c.http
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	resp, err := hc.Do(hreq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("headroom: status %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+
+	var out compressResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	if len(out.Messages) == 0 {
+		return nil, errors.New("headroom: empty messages response")
+	}
+	applyOpenAIMessages(req, out.Messages)
+
+	stats := &Stats{
+		TokensBefore:     out.TokensBefore,
+		TokensAfter:      out.TokensAfter,
+		TokensSaved:      out.TokensSaved,
+		CompressionRatio: out.CompressionRatio,
+		Transforms:       out.TransformsApplied,
+		CCRHashes:        out.CCRHashes,
+	}
+	if stats.TokensSaved <= 0 && stats.TokensBefore > 0 && stats.TokensAfter > 0 && stats.TokensBefore > stats.TokensAfter {
+		stats.TokensSaved = stats.TokensBefore - stats.TokensAfter
+	}
+	if stats.TokensSaved <= 0 && len(stats.Transforms) == 0 {
+		return nil, nil
+	}
+	return stats, nil
+}
+
+type compressResponse struct {
+	Messages          []openAIMessage `json:"messages"`
+	TokensBefore      int             `json:"tokens_before"`
+	TokensAfter       int             `json:"tokens_after"`
+	TokensSaved       int             `json:"tokens_saved"`
+	CompressionRatio  float64         `json:"compression_ratio"`
+	TransformsApplied []string        `json:"transforms_applied"`
+	CCRHashes         []string        `json:"ccr_hashes"`
+}
+
+type openAIMessage struct {
+	Role       string           `json:"role"`
+	Content    any              `json:"content,omitempty"`
+	Name       string           `json:"name,omitempty"`
+	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+type openAIToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"function"`
+}
+
+func containsUnsupportedParts(req *core.ChatRequest) bool {
+	for _, m := range req.Messages {
+		for _, p := range m.Content {
+			if p.Type == core.PartImage || p.Type == core.PartAudio || p.Type == core.PartThinking {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func toOpenAIMessages(req *core.ChatRequest) []openAIMessage {
+	out := make([]openAIMessage, 0, len(req.Messages)+1)
+	if strings.TrimSpace(req.System) != "" {
+		out = append(out, openAIMessage{Role: "system", Content: req.System})
+	}
+	for _, m := range req.Messages {
+		om := openAIMessage{Role: string(m.Role), Name: m.Name}
+		var texts []string
+		for _, p := range m.Content {
+			switch p.Type {
+			case core.PartText:
+				if p.Text != "" {
+					texts = append(texts, p.Text)
+				}
+			case core.PartToolResult:
+				if p.ToolResult != nil {
+					om.Role = "tool"
+					om.ToolCallID = p.ToolResult.CallID
+					om.Content = p.ToolResult.Content
+				}
+			case core.PartToolCall:
+				if p.ToolCall != nil {
+					var tc openAIToolCall
+					tc.ID = p.ToolCall.ID
+					tc.Type = "function"
+					tc.Function.Name = p.ToolCall.Name
+					tc.Function.Arguments = p.ToolCall.Arguments
+					om.ToolCalls = append(om.ToolCalls, tc)
+				}
+			}
+		}
+		if om.Content == nil && len(texts) > 0 {
+			om.Content = strings.Join(texts, "\n")
+		}
+		out = append(out, om)
+	}
+	return out
+}
+
+func applyOpenAIMessages(req *core.ChatRequest, msgs []openAIMessage) {
+	req.System = ""
+	req.Messages = nil
+	for _, om := range msgs {
+		if om.Role == "system" || om.Role == "developer" {
+			if req.System != "" {
+				req.System += "\n\n"
+			}
+			req.System += contentText(om.Content)
+			continue
+		}
+		m := core.Message{Role: role(om.Role), Name: om.Name}
+		if om.Role == "tool" {
+			m.Content = append(m.Content, core.ContentPart{Type: core.PartToolResult, ToolResult: &core.ToolResult{CallID: om.ToolCallID, Content: contentText(om.Content)}})
+			req.Messages = append(req.Messages, m)
+			continue
+		}
+		if txt := contentText(om.Content); txt != "" {
+			m.Content = append(m.Content, core.ContentPart{Type: core.PartText, Text: txt})
+		}
+		for _, tc := range om.ToolCalls {
+			m.Content = append(m.Content, core.ContentPart{Type: core.PartToolCall, ToolCall: &core.ToolCall{ID: tc.ID, Name: tc.Function.Name, Arguments: tc.Function.Arguments}})
+		}
+		req.Messages = append(req.Messages, m)
+	}
+}
+
+func role(r string) core.Role {
+	switch r {
+	case "assistant":
+		return core.RoleAssistant
+	case "tool":
+		return core.RoleTool
+	default:
+		return core.RoleUser
+	}
+}
+
+func contentText(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	case []any:
+		var b strings.Builder
+		for _, item := range x {
+			if m, ok := item.(map[string]any); ok {
+				if m["type"] == "text" {
+					if s, ok := m["text"].(string); ok {
+						b.WriteString(s)
+					}
+				}
+			}
+		}
+		return b.String()
+	default:
+		b, _ := json.Marshal(x)
+		var s string
+		if json.Unmarshal(b, &s) == nil {
+			return s
+		}
+		return string(b)
+	}
+}

--- a/backend/internal/headroom/headroom_test.go
+++ b/backend/internal/headroom/headroom_test.go
@@ -1,0 +1,147 @@
+package headroom
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressNoopsWhenDisabled(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	req := textRequest("gpt-4o", "long context")
+	stats, err := New().Compress(context.Background(), req, Config{Enabled: false, BaseURL: srv.URL})
+
+	require.NoError(t, err)
+	require.Nil(t, stats)
+	require.False(t, called)
+	require.Equal(t, "long context", req.Messages[0].TextContent())
+}
+
+func TestCompressCallsProxyAndAppliesResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/compress", r.URL.Path)
+		require.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "gpt-4o", body["model"])
+		require.EqualValues(t, 12000, body["tokenBudget"])
+		require.EqualValues(t, 12000, body["token_budget"])
+		require.Len(t, body["messages"], 2) // system + user
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"messages":[
+				{"role":"system","content":"compressed system"},
+				{"role":"user","content":"short context"}
+			],
+			"tokens_before":100,
+			"tokens_after":25,
+			"tokens_saved":75,
+			"compression_ratio":0.25,
+			"transforms_applied":["smart-crusher"],
+			"ccr_hashes":["abc123"]
+		}`))
+	}))
+	defer srv.Close()
+
+	req := textRequest("gpt-4o", "long context")
+	req.System = "verbose system"
+	stats, err := New().Compress(context.Background(), req, Config{
+		Enabled:     true,
+		BaseURL:     srv.URL + "/",
+		APIKey:      "test-key",
+		Timeout:     time.Second,
+		TokenBudget: 12000,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.Equal(t, 100, stats.TokensBefore)
+	require.Equal(t, 25, stats.TokensAfter)
+	require.Equal(t, 75, stats.TokensSaved)
+	require.Equal(t, []string{"smart-crusher"}, stats.Transforms)
+	require.Equal(t, []string{"abc123"}, stats.CCRHashes)
+	require.Equal(t, "compressed system", req.System)
+	require.Len(t, req.Messages, 1)
+	require.Equal(t, "short context", req.Messages[0].TextContent())
+}
+
+func TestCompressDerivesTokensSavedWhenMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"messages":[{"role":"user","content":"short"}],
+			"tokens_before":50,
+			"tokens_after":20
+		}`))
+	}))
+	defer srv.Close()
+
+	req := textRequest("gpt-4o", "long")
+	stats, err := New().Compress(context.Background(), req, Config{Enabled: true, BaseURL: srv.URL})
+
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.Equal(t, 30, stats.TokensSaved)
+}
+
+func TestCompressReturnsErrorWithoutMutatingOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "proxy unavailable", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	req := textRequest("gpt-4o", "original context")
+	stats, err := New().Compress(context.Background(), req, Config{Enabled: true, BaseURL: srv.URL})
+
+	require.Error(t, err)
+	require.Nil(t, stats)
+	require.Equal(t, "original context", req.Messages[0].TextContent())
+}
+
+func TestCompressSkipsUnsupportedMultimodalParts(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	req := &core.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []core.Message{{
+			Role: core.RoleUser,
+			Content: []core.ContentPart{
+				{Type: core.PartText, Text: "describe this"},
+				{Type: core.PartImage, Media: &core.MediaPayload{URL: "https://example.com/image.png"}},
+			},
+		}},
+	}
+	stats, err := New().Compress(context.Background(), req, Config{Enabled: true, BaseURL: srv.URL})
+
+	require.NoError(t, err)
+	require.Nil(t, stats)
+	require.False(t, called)
+}
+
+func textRequest(model, text string) *core.ChatRequest {
+	return &core.ChatRequest{
+		Model: model,
+		Messages: []core.Message{{
+			Role:    core.RoleUser,
+			Content: []core.ContentPart{{Type: core.PartText, Text: text}},
+		}},
+	}
+}

--- a/backend/internal/meter/meter.go
+++ b/backend/internal/meter/meter.go
@@ -111,6 +111,7 @@ type Event struct {
 
 	// Token-saving analytics.
 	SlimStats     *SlimSnapshot // nil when RTK did not fire
+	HeadroomStats *HeadroomSnapshot // nil when Headroom did not fire
 	CavemanActive bool          // caveman output compression was active
 	TerseActive   bool          // terse output compression was active
 }
@@ -120,6 +121,16 @@ type SlimSnapshot struct {
 	BytesSaved  int
 	TokensSaved int
 	Rules       string // comma-separated rule names that fired
+}
+
+// HeadroomSnapshot captures Headroom's exact per-request compression result.
+type HeadroomSnapshot struct {
+	TokensBefore     int
+	TokensAfter      int
+	TokensSaved      int
+	CompressionRatio float64
+	Transforms       string // comma-separated transform names
+	CCRHashes        string // comma-separated CCR hashes
 }
 
 // resolvePrice looks up the price for a provider/model pair. It tries
@@ -198,6 +209,15 @@ func (m *Meter) Record(ctx context.Context, ev Event) (int64, error) {
 		rec.SlimBytesSaved = ev.SlimStats.BytesSaved
 		rec.SlimTokensSaved = ev.SlimStats.TokensSaved
 		rec.SlimRules = ev.SlimStats.Rules
+	}
+	if ev.HeadroomStats != nil {
+		rec.HeadroomActive = true
+		rec.HeadroomTokensBefore = ev.HeadroomStats.TokensBefore
+		rec.HeadroomTokensAfter = ev.HeadroomStats.TokensAfter
+		rec.HeadroomTokensSaved = ev.HeadroomStats.TokensSaved
+		rec.HeadroomCompressionRatio = ev.HeadroomStats.CompressionRatio
+		rec.HeadroomTransforms = ev.HeadroomStats.Transforms
+		rec.HeadroomCCRHashes = ev.HeadroomStats.CCRHashes
 	}
 	if err := m.recordUsage(ctx, rec); err != nil {
 		return cost, err

--- a/backend/internal/observ/metrics.go
+++ b/backend/internal/observ/metrics.go
@@ -29,6 +29,8 @@ type Metrics struct {
 
 	// Token-saving analytics.
 	SlimBytesSaved  *prometheus.CounterVec // by rule
+	HeadroomTokensSaved *prometheus.CounterVec // by transform
+	HeadroomRequests prometheus.Counter
 	CavemanRequests prometheus.Counter     // requests with caveman active
 	TerseRequests   prometheus.Counter     // requests with terse active
 
@@ -97,6 +99,14 @@ func New() *Metrics {
 			Name: "keirouter_slim_bytes_saved_total",
 			Help: "Total bytes saved by RTK slimmer, labeled by rule.",
 		}, []string{"rule"}),
+		HeadroomTokensSaved: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "keirouter_headroom_tokens_saved_total",
+			Help: "Total exact input tokens saved by Headroom, labeled by transform.",
+		}, []string{"transform"}),
+		HeadroomRequests: factory.NewCounter(prometheus.CounterOpts{
+			Name: "keirouter_headroom_requests_total",
+			Help: "Total requests where Headroom compression was active.",
+		}),
 		CavemanRequests: factory.NewCounter(prometheus.CounterOpts{
 			Name: "keirouter_caveman_requests_total",
 			Help: "Total requests with caveman output compression active.",
@@ -178,6 +188,14 @@ func (m *Metrics) SetCacheSize(n int) {
 func (m *Metrics) RecordSlimSavings(rule string, bytesSaved int) {
 	if bytesSaved > 0 {
 		m.SlimBytesSaved.WithLabelValues(rule).Add(float64(bytesSaved))
+	}
+}
+
+// RecordHeadroomSavings records exact tokens saved by Headroom.
+func (m *Metrics) RecordHeadroomSavings(transform string, tokensSaved int) {
+	if tokensSaved > 0 {
+		m.HeadroomTokensSaved.WithLabelValues(transform).Add(float64(tokensSaved))
+		m.HeadroomRequests.Inc()
 	}
 }
 

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/core"
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
 	"github.com/mydisha/keirouter/backend/internal/guardrails"
+	"github.com/mydisha/keirouter/backend/internal/headroom"
 	"github.com/mydisha/keirouter/backend/internal/limits"
 	"github.com/mydisha/keirouter/backend/internal/meter"
 	"github.com/mydisha/keirouter/backend/internal/normalizer"
@@ -51,6 +52,7 @@ type Pipeline struct {
 	meter      *meter.Meter
 	budget     *budget.Engine
 	slimmer    *slimmer.Engine
+	headroom   *headroom.Client
 	metrics    *observ.Metrics
 	cache      *cache.Cache
 	embedder   cache.Embedder
@@ -69,6 +71,7 @@ type Deps struct {
 	Meter      *meter.Meter
 	Budget     *budget.Engine
 	Slimmer    *slimmer.Engine
+	Headroom   *headroom.Client
 	Metrics    *observ.Metrics
 	Cache      *cache.Cache
 	Embedder   cache.Embedder
@@ -97,6 +100,7 @@ func New(d Deps) *Pipeline {
 		meter:      d.Meter,
 		budget:     d.Budget,
 		slimmer:    d.Slimmer,
+		headroom:   d.Headroom,
 		metrics:    d.Metrics,
 		cache:      d.Cache,
 		embedder:   d.Embedder,
@@ -143,6 +147,7 @@ type Options struct {
 	// compresses bulky tool outputs on the input side; Terse and Caveman inject
 	// system-prompt directives that reduce output tokens.
 	Slimmer slimmer.Config
+	Headroom headroom.Config
 	Terse   terse.Config
 	Caveman caveman.Config
 	// Limits carries already-resolved per-key rate limits. Zero values mean unlimited.
@@ -158,6 +163,7 @@ type Result struct {
 	CostMicros int64
 	Latency    time.Duration
 	SlimStats  *slimmer.Stats
+	HeadroomStats *headroom.Stats
 	CacheHit   bool
 }
 
@@ -215,11 +221,14 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 		p.metrics.RecordCache(false)
 	}
 
-	slimStats := p.applyTokenSaving(req, opts)
+	slimStats, headStats := p.applyTokenSaving(ctx, req, opts)
 	if slimStats != nil {
 		p.log.Debug("slimmer stats", "saved", slimStats.Saved(), "hits", len(slimStats.Hits))
 	}
-	save := buildSaveState(slimStats, opts)
+	if headStats != nil {
+		p.log.Debug("headroom stats", "saved_tokens", headStats.TokensSaved, "transforms", strings.Join(headStats.Transforms, ","))
+	}
+	save := buildSaveState(slimStats, headStats, opts)
 
 	required := capability.Required(req)
 	attempts, err := p.planWithCooldownRetry(ctx, req.Metadata.TenantID, opts.Targets, required, opts.PlanOpts)
@@ -298,6 +307,7 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 			CostMicros: cost,
 			Latency:    latency,
 			SlimStats:  slimStats,
+			HeadroomStats: headStats,
 		}, nil
 	}
 
@@ -365,8 +375,8 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 		return nil, &core.ProviderError{Kind: core.ErrPolicyBlocked, Message: gres.Reason}
 	}
 
-	slimStats := p.applyTokenSaving(req, opts)
-	save := buildSaveState(slimStats, opts)
+	slimStats, headStats := p.applyTokenSaving(ctx, req, opts)
+	save := buildSaveState(slimStats, headStats, opts)
 
 	required := capability.Required(req)
 	scope := budget.Scope{TenantID: req.Metadata.TenantID, ProjectID: req.Metadata.ProjectID, APIKeyID: req.Metadata.APIKeyID}
@@ -894,28 +904,40 @@ func (p *Pipeline) planWithCooldownRetry(ctx context.Context, tenantID string, t
 // (terse, caveman) token-saving transforms in place. Terse and caveman both
 // inject system-prompt directives; if both are enabled, terse runs first and
 // caveman appends after, but in practice only one output-saver is used.
-func (p *Pipeline) applyTokenSaving(req *core.ChatRequest, opts Options) *slimmer.Stats {
+func (p *Pipeline) applyTokenSaving(ctx context.Context, req *core.ChatRequest, opts Options) (*slimmer.Stats, *headroom.Stats) {
 	// Normalize tool call IDs and fix missing tool results before any
 	// downstream processing. This ensures Anthropic-compatible IDs and
 	// complete tool_use/tool_result pairs.
 	normalizer.Apply(req)
 
 	var stats *slimmer.Stats
-	if p.slimmer != nil && opts.Slimmer.Enabled {
+	var hstats *headroom.Stats
+	if p.headroom != nil && opts.Headroom.Enabled {
+		var err error
+		hstats, err = p.headroom.Compress(ctx, req, opts.Headroom)
+		if err != nil {
+			p.log.Warn("headroom compression failed; continuing uncompressed", "err", err)
+		} else if hstats != nil {
+			p.log.Debug("headroom compressed request", "saved_tokens", hstats.TokensSaved, "transforms", strings.Join(hstats.Transforms, ","))
+		}
+	} else if p.slimmer != nil && opts.Slimmer.Enabled {
 		stats = p.slimmer.Compress(req, opts.Slimmer)
 		if stats != nil {
 			p.log.Debug("slimmer compressed request", "saved_bytes", stats.Saved(), "hits", len(stats.Hits))
 		}
 	}
-	terse.Apply(req, opts.Terse)
-	caveman.Apply(req, opts.Caveman)
-	return stats
+	if !opts.Headroom.OutputShaper {
+		terse.Apply(req, opts.Terse)
+		caveman.Apply(req, opts.Caveman)
+	}
+	return stats, hstats
 }
 
 // saveState captures which token-saving features were active and their results
 // for a single request, so the meter can persist them.
 type saveState struct {
 	slimSnap *meter.SlimSnapshot
+	headroom *meter.HeadroomSnapshot
 	caveman  bool
 	terse    bool
 }
@@ -940,10 +962,20 @@ func splitRuleNames(s string) []string {
 
 // buildSaveState converts pipeline-level token-saving results into a snapshot
 // suitable for the meter. Returns nil when no features were active.
-func buildSaveState(stats *slimmer.Stats, opts Options) *saveState {
+func buildSaveState(stats *slimmer.Stats, hstats *headroom.Stats, opts Options) *saveState {
 	save := &saveState{
-		caveman: opts.Caveman.Enabled,
-		terse:   opts.Terse.Enabled,
+		caveman: opts.Caveman.Enabled && !opts.Headroom.OutputShaper,
+		terse:   opts.Terse.Enabled && !opts.Headroom.OutputShaper,
+	}
+	if hstats != nil {
+		save.headroom = &meter.HeadroomSnapshot{
+			TokensBefore:     hstats.TokensBefore,
+			TokensAfter:      hstats.TokensAfter,
+			TokensSaved:      hstats.TokensSaved,
+			CompressionRatio: hstats.CompressionRatio,
+			Transforms:       strings.Join(hstats.Transforms, ","),
+			CCRHashes:        strings.Join(hstats.CCRHashes, ","),
+		}
 	}
 	if stats != nil && stats.Saved() > 0 {
 		// Build comma-separated rule names from hits.
@@ -964,7 +996,7 @@ func buildSaveState(stats *slimmer.Stats, opts Options) *saveState {
 			Rules:       ruleNames,
 		}
 	}
-	if save.slimSnap == nil && !save.caveman && !save.terse {
+	if save.slimSnap == nil && save.headroom == nil && !save.caveman && !save.terse {
 		return nil
 	}
 	return save
@@ -997,6 +1029,7 @@ func (p *Pipeline) recordWithTTFT(ctx context.Context, meta core.RequestMetadata
 	}
 	if save != nil {
 		ev.SlimStats = save.slimSnap
+		ev.HeadroomStats = save.headroom
 		ev.CavemanActive = save.caveman
 		ev.TerseActive = save.terse
 	}
@@ -1020,6 +1053,14 @@ func (p *Pipeline) recordWithTTFT(ctx context.Context, meta core.RequestMetadata
 			if save.slimSnap != nil {
 				for _, rule := range splitRuleNames(save.slimSnap.Rules) {
 					p.metrics.RecordSlimSavings(rule, save.slimSnap.BytesSaved)
+				}
+			}
+			if save.headroom != nil {
+				for _, transform := range splitRuleNames(save.headroom.Transforms) {
+					p.metrics.RecordHeadroomSavings(transform, save.headroom.TokensSaved)
+				}
+				if save.headroom.Transforms == "" {
+					p.metrics.RecordHeadroomSavings("unknown", save.headroom.TokensSaved)
 				}
 			}
 			if save.caveman {

--- a/backend/internal/store/migrations/0021_headroom_savings.sql
+++ b/backend/internal/store/migrations/0021_headroom_savings.sql
@@ -1,0 +1,12 @@
+-- Add Headroom token-saving analytics columns.
+-- Headroom reports exact token counts from its compression proxy, unlike RTK's
+-- byte/4 estimate, so store both systems separately and aggregate in analytics.
+ALTER TABLE usage_records ADD COLUMN headroom_active INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN headroom_tokens_before INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN headroom_tokens_after INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN headroom_tokens_saved INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN headroom_compression_ratio REAL NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN headroom_transforms TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN headroom_ccr_hashes TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_usage_headroom_savings ON usage_records(tenant_id, created_at, headroom_tokens_saved);

--- a/backend/internal/store/models.go
+++ b/backend/internal/store/models.go
@@ -141,6 +141,13 @@ type UsageRecord struct {
 	SlimBytesSaved   int    // bytes removed by RTK slimmer (input-side compression)
 	SlimTokensSaved  int    // estimated tokens saved by RTK (bytes/4)
 	SlimRules        string // comma-separated rule names that fired (e.g. "git-diff,grep")
+	HeadroomActive   bool   // Headroom compression was active
+	HeadroomTokensBefore int // exact input tokens before Headroom compression
+	HeadroomTokensAfter  int // exact input tokens after Headroom compression
+	HeadroomTokensSaved  int // exact tokens saved by Headroom
+	HeadroomCompressionRatio float64 // Headroom tokens_after/tokens_before
+	HeadroomTransforms string // comma-separated Headroom transforms
+	HeadroomCCRHashes  string // comma-separated CCR hashes
 	CavemanActive    bool   // caveman output compression was active
 	TerseActive      bool   // terse output compression was active
 	CreatedAt        time.Time

--- a/backend/internal/store/repo_usage.go
+++ b/backend/internal/store/repo_usage.go
@@ -35,20 +35,22 @@ func (r *UsageRepo) RecordBatch(ctx context.Context, records []UsageRecord) erro
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	const cols = 22
+	const cols = 29
 	var b strings.Builder
 	b.WriteString(`INSERT INTO usage_records
 		(id, tenant_id, project_id, api_key_id, provider, model, account_id, client,
 		 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
 		 cost_micros, cache_hit, latency_ms, ttft_ms,
 		 slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+		 headroom_active, headroom_tokens_before, headroom_tokens_after, headroom_tokens_saved,
+		 headroom_compression_ratio, headroom_transforms, headroom_ccr_hashes,
 		 created_at) VALUES `)
 	args := make([]any, 0, len(records)*cols)
 	for i, u := range records {
 		if i > 0 {
 			b.WriteString(",")
 		}
-		b.WriteString("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+		b.WriteString("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 		args = append(args, usageArgs(u)...)
 	}
 	q := r.db.rebind(b.String())
@@ -70,8 +72,10 @@ func insertUsage(ctx context.Context, exec interface {
 			 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
 			 cost_micros, cache_hit, latency_ms, ttft_ms,
 			 slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+			 headroom_active, headroom_tokens_before, headroom_tokens_after, headroom_tokens_saved,
+			 headroom_compression_ratio, headroom_transforms, headroom_ccr_hashes,
 			 created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	_, err := exec.ExecContext(ctx, q, usageArgs(u)...)
 	return err
 }
@@ -83,6 +87,8 @@ func usageArgs(u UsageRecord) []any {
 		u.PromptTokens, u.CompletionTokens, u.CachedTokens, u.CacheWriteTokens,
 		u.CostMicros, boolToInt(u.CacheHit), u.LatencyMS, u.TTFTMS,
 		u.SlimBytesSaved, u.SlimTokensSaved, u.SlimRules, boolToInt(u.CavemanActive), boolToInt(u.TerseActive),
+		boolToInt(u.HeadroomActive), u.HeadroomTokensBefore, u.HeadroomTokensAfter, u.HeadroomTokensSaved,
+		u.HeadroomCompressionRatio, u.HeadroomTransforms, u.HeadroomCCRHashes,
 		formatTime(u.CreatedAt),
 	}
 }
@@ -208,6 +214,8 @@ type Summary struct {
 	SuccessCount     int64 // requests that succeeded (latency > 0 or cache hit)
 	SlimBytesSaved   int64 // total bytes saved by RTK slimmer
 	SlimTokensSaved  int64 // total estimated tokens saved by RTK
+	HeadroomRequests int64 // requests where Headroom compressed input
+	HeadroomTokensSaved int64 // exact tokens saved by Headroom
 	CavemanRequests  int64 // requests where caveman was active
 	TerseRequests    int64 // requests where terse was active
 }
@@ -228,6 +236,8 @@ func (r *UsageRepo) Summarize(ctx context.Context, tenantID string, since time.T
 			COUNT(CASE WHEN latency_ms > 0 OR cache_hit = 1 THEN 1 END),
 			COALESCE(SUM(slim_bytes_saved), 0),
 			COALESCE(SUM(slim_tokens_saved), 0),
+			COALESCE(SUM(headroom_active), 0),
+			COALESCE(SUM(headroom_tokens_saved), 0),
 			COALESCE(SUM(caveman_active), 0),
 			COALESCE(SUM(terse_active), 0)
 		FROM usage_records
@@ -237,7 +247,7 @@ func (r *UsageRepo) Summarize(ctx context.Context, tenantID string, since time.T
 		&s.TotalRequests, &s.PromptTokens, &s.CompletionTokens,
 		&s.CachedTokens, &s.CacheWriteTokens, &s.CostMicros, &s.CacheHits, &s.AvgTTFTMS,
 		&s.AvgLatencyMS, &s.SuccessCount,
-		&s.SlimBytesSaved, &s.SlimTokensSaved, &s.CavemanRequests, &s.TerseRequests)
+		&s.SlimBytesSaved, &s.SlimTokensSaved, &s.HeadroomRequests, &s.HeadroomTokensSaved, &s.CavemanRequests, &s.TerseRequests)
 	if err != nil {
 		return Summary{}, fmt.Errorf("store: summarize usage: %w", err)
 	}
@@ -261,6 +271,8 @@ func (r *UsageRepo) SummarizeByKey(ctx context.Context, keyID string, since time
 			COUNT(CASE WHEN latency_ms > 0 OR cache_hit = 1 THEN 1 END),
 			COALESCE(SUM(slim_bytes_saved), 0),
 			COALESCE(SUM(slim_tokens_saved), 0),
+			COALESCE(SUM(headroom_active), 0),
+			COALESCE(SUM(headroom_tokens_saved), 0),
 			COALESCE(SUM(caveman_active), 0),
 			COALESCE(SUM(terse_active), 0)
 		FROM usage_records
@@ -270,7 +282,7 @@ func (r *UsageRepo) SummarizeByKey(ctx context.Context, keyID string, since time
 		&s.TotalRequests, &s.PromptTokens, &s.CompletionTokens,
 		&s.CachedTokens, &s.CacheWriteTokens, &s.CostMicros, &s.CacheHits, &s.AvgTTFTMS,
 		&s.AvgLatencyMS, &s.SuccessCount,
-		&s.SlimBytesSaved, &s.SlimTokensSaved, &s.CavemanRequests, &s.TerseRequests)
+		&s.SlimBytesSaved, &s.SlimTokensSaved, &s.HeadroomRequests, &s.HeadroomTokensSaved, &s.CavemanRequests, &s.TerseRequests)
 	if err != nil {
 		return Summary{}, fmt.Errorf("store: summarize usage by key: %w", err)
 	}
@@ -334,6 +346,9 @@ type RecentRecord struct {
 	SlimBytesSaved   int    // bytes saved by RTK slimmer
 	SlimTokensSaved  int    // estimated tokens saved by RTK
 	SlimRules        string // comma-separated rule names that fired
+	HeadroomActive   bool
+	HeadroomTokensSaved int
+	HeadroomTransforms string
 	CavemanActive    bool
 	TerseActive      bool
 	CreatedAt        time.Time
@@ -347,7 +362,9 @@ func (r *UsageRepo) Recent(ctx context.Context, tenantID string, limit int) ([]R
 	q := r.db.rebind(`
 		SELECT id, provider, model, prompt_tokens, completion_tokens, cached_tokens,
 		       cache_write_tokens, cost_micros, cache_hit, latency_ms, ttft_ms,
-		       slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+		       slim_bytes_saved, slim_tokens_saved, slim_rules,
+		       headroom_active, headroom_tokens_saved, headroom_transforms,
+		       caveman_active, terse_active,
 		       created_at
 		FROM usage_records
 		WHERE tenant_id = ?
@@ -363,17 +380,19 @@ func (r *UsageRepo) Recent(ctx context.Context, tenantID string, limit int) ([]R
 	for rows.Next() {
 		var (
 			rec                      RecentRecord
-			cacheHit, caveman, terse int
+			cacheHit, caveman, terse, headroom int
 			createdAt                string
 		)
 		if err := rows.Scan(&rec.ID, &rec.Provider, &rec.Model, &rec.PromptTokens,
 			&rec.CompletionTokens, &rec.CachedTokens, &rec.CacheWriteTokens,
 			&rec.CostMicros, &cacheHit, &rec.LatencyMS, &rec.TTFTMS,
-			&rec.SlimBytesSaved, &rec.SlimTokensSaved, &rec.SlimRules, &caveman, &terse,
+			&rec.SlimBytesSaved, &rec.SlimTokensSaved, &rec.SlimRules,
+			&headroom, &rec.HeadroomTokensSaved, &rec.HeadroomTransforms, &caveman, &terse,
 			&createdAt); err != nil {
 			return nil, err
 		}
 		rec.CacheHit = cacheHit != 0
+		rec.HeadroomActive = headroom != 0
 		rec.CavemanActive = caveman != 0
 		rec.TerseActive = terse != 0
 		rec.CreatedAt = parseTime(createdAt)
@@ -664,6 +683,8 @@ type ClientSavings struct {
 	Requests        int64 // requests from this client in the window
 	SlimBytesSaved  int64 // bytes saved by RTK slimmer
 	SlimTokensSaved int64 // estimated tokens saved by RTK (bytes/4)
+	HeadroomRequests int64 // requests where Headroom compressed input
+	HeadroomTokensSaved int64 // exact tokens saved by Headroom
 	CavemanRequests int64 // requests where caveman was active
 	TerseRequests   int64 // requests where terse was active
 }
@@ -678,12 +699,14 @@ func (r *UsageRepo) SavingsByClient(ctx context.Context, tenantID string, since 
 			COUNT(*),
 			COALESCE(SUM(slim_bytes_saved), 0),
 			COALESCE(SUM(slim_tokens_saved), 0),
+			COALESCE(SUM(headroom_active), 0),
+			COALESCE(SUM(headroom_tokens_saved), 0),
 			COALESCE(SUM(caveman_active), 0),
 			COALESCE(SUM(terse_active), 0)
 		FROM usage_records
 		WHERE tenant_id = ? AND created_at >= ?
 		GROUP BY client
-		ORDER BY COALESCE(SUM(slim_tokens_saved), 0) DESC`)
+		ORDER BY COALESCE(SUM(slim_tokens_saved + headroom_tokens_saved), 0) DESC`)
 	rows, err := r.db.sql.QueryContext(ctx, q, tenantID, formatTime(since))
 	if err != nil {
 		return nil, fmt.Errorf("store: savings by client: %w", err)
@@ -694,12 +717,62 @@ func (r *UsageRepo) SavingsByClient(ctx context.Context, tenantID string, since 
 	for rows.Next() {
 		var c ClientSavings
 		if err := rows.Scan(&c.Client, &c.Requests, &c.SlimBytesSaved,
-			&c.SlimTokensSaved, &c.CavemanRequests, &c.TerseRequests); err != nil {
+			&c.SlimTokensSaved, &c.HeadroomRequests, &c.HeadroomTokensSaved, &c.CavemanRequests, &c.TerseRequests); err != nil {
 			return nil, err
 		}
 		out = append(out, c)
 	}
 	return out, rows.Err()
+}
+
+// HeadroomTransformSavings aggregates exact Headroom token savings by transform.
+type HeadroomTransformSavings struct {
+	Transform   string
+	Count       int64
+	TokensSaved int64
+}
+
+// SavingsByHeadroomTransform returns per-transform savings from Headroom.
+func (r *UsageRepo) SavingsByHeadroomTransform(ctx context.Context, tenantID string, since time.Time) ([]HeadroomTransformSavings, error) {
+	q := r.db.rebind(`
+		SELECT headroom_transforms, headroom_tokens_saved
+		FROM usage_records
+		WHERE tenant_id = ? AND created_at >= ? AND headroom_tokens_saved > 0`)
+	rows, err := r.db.sql.QueryContext(ctx, q, tenantID, formatTime(since))
+	if err != nil {
+		return nil, fmt.Errorf("store: headroom savings by transform: %w", err)
+	}
+	defer rows.Close()
+
+	totals := map[string]*HeadroomTransformSavings{}
+	for rows.Next() {
+		var transforms string
+		var tokensSaved int64
+		if err := rows.Scan(&transforms, &tokensSaved); err != nil {
+			return nil, err
+		}
+		parts := splitRules(transforms)
+		if len(parts) == 0 {
+			parts = []string{"headroom"}
+		}
+		perTransform := tokensSaved / int64(len(parts))
+		for _, name := range parts {
+			if _, ok := totals[name]; !ok {
+				totals[name] = &HeadroomTransformSavings{Transform: name}
+			}
+			totals[name].Count++
+			totals[name].TokensSaved += perTransform
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]HeadroomTransformSavings, 0, len(totals))
+	for _, rs := range totals {
+		out = append(out, *rs)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TokensSaved > out[j].TokensSaved })
+	return out, nil
 }
 
 // splitRules splits a comma-separated rule string into individual names,

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,24 @@
 name: keirouter
 
 services:
+  headroom:
+    image: ghcr.io/chopratejas/headroom:code-nonroot
+    restart: unless-stopped
+    environment:
+      HEADROOM_HOST: "0.0.0.0"
+      HEADROOM_PORT: "8787"
+      HEADROOM_MODE: "optimize"
+      HEADROOM_TELEMETRY: "off"
+      HEADROOM_SAVINGS_PATH: /data/proxy_savings.json
+    volumes:
+      - headroom-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8787/stats"]
+      interval: 30s
+      timeout: 5s
+      start-period: 15s
+      retries: 3
+
   keirouter:
     build:
       context: .
@@ -15,6 +33,9 @@ services:
         SOURCE_COMMIT: ${SOURCE_COMMIT:-}
     image: ${KEIROUTER_IMAGE:-ghcr.io/mydisha/keirouter:latest}
     restart: unless-stopped
+    depends_on:
+      headroom:
+        condition: service_healthy
     ports:
       - "${KEIROUTER_PORT:-20180}:20180"
     volumes:
@@ -27,6 +48,8 @@ services:
       KEIROUTER_SECURITY__ALLOW_PRIVATE_BASE_URL: ${KEIROUTER_SECURITY__ALLOW_PRIVATE_BASE_URL:-false}
       KEIROUTER_SECURITY__MASTER_KEY: ${KEIROUTER_MASTER_KEY:-}
       KEIROUTER_LOG__FORMAT: ${KEIROUTER_LOG_FORMAT:-json}
+      KEIROUTER_HEADROOM__BASE_URL: "http://headroom:8787"
 
 volumes:
   keirouter-data:
+  headroom-data:

--- a/frontend/src/components/SavingsBreakdown.tsx
+++ b/frontend/src/components/SavingsBreakdown.tsx
@@ -46,13 +46,15 @@ function prettyClient(id: string): string {
 
 export function TokenSavingsBreakdown({ savings, totalRequests, insights, period }: { savings: TokenSavings; totalRequests: number; insights: UsageInsights; period: string }) {
   const rules = savings.rules || [];
+  const headroomTransforms = savings.headroom_transforms || [];
   const maxBytes = Math.max(...rules.map((r) => r.bytes_saved), 1);
   const totalCavemanPct = totalRequests > 0 ? ((savings.caveman_requests / totalRequests) * 100).toFixed(1) : "0";
   const totalTersePct = totalRequests > 0 ? ((savings.terse_requests / totalRequests) * 100).toFixed(0) : "0";
-  const hasSavings = savings.slim_bytes_saved > 0 || savings.caveman_requests > 0 || savings.terse_requests > 0 || rules.length > 0;
+  const totalHeadroomPct = totalRequests > 0 ? ((savings.headroom_requests / totalRequests) * 100).toFixed(1) : "0";
+  const hasSavings = savings.slim_bytes_saved > 0 || (savings.headroom_tokens_saved ?? 0) > 0 || savings.caveman_requests > 0 || savings.terse_requests > 0 || rules.length > 0 || headroomTransforms.length > 0;
   // Prefer the backend's blended USD estimate; fall back to a rough $3/M rate
   // for older payloads that predate the usd_saved field.
-  const usdSaved = savings.usd_saved ?? (savings.slim_tokens_saved / 1_000_000) * 3;
+  const usdSaved = savings.usd_saved ?? ((savings.slim_tokens_saved + (savings.headroom_tokens_saved ?? 0)) / 1_000_000) * 3;
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm overflow-hidden">
@@ -63,6 +65,12 @@ export function TokenSavingsBreakdown({ savings, totalRequests, insights, period
         </div>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-3 text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
+          {savings.headroom_requests > 0 && (
+            <span className="flex items-center gap-1.5">
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+              HDRM {totalHeadroomPct}%
+            </span>
+          )}
           {savings.caveman_requests > 0 && (
             <span className="flex items-center gap-1.5">
               <span className="h-1.5 w-1.5 rounded-full bg-purple-500" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -41,6 +41,12 @@ export interface BrandingSettings {
 export interface EndpointSettings {
   rtk_enabled: boolean;
   rtk_filter_level: string;
+  headroom_enabled: boolean;
+  headroom_base_url: string;
+  headroom_api_key?: string;
+  headroom_timeout_ms: number;
+  headroom_token_budget: number;
+  headroom_output_shaper: boolean;
   caveman_enabled: boolean;
   caveman_level: string;
   terse_enabled: boolean;
@@ -256,6 +262,9 @@ export interface RecentActivity {
   slim_bytes_saved?: number;
   slim_tokens_saved?: number;
   slim_rules?: string;
+  headroom_active?: boolean;
+  headroom_tokens_saved?: number;
+  headroom_transforms?: string;
   caveman_active?: boolean;
   terse_active?: boolean;
 }
@@ -277,14 +286,23 @@ export interface ClientSaving {
   terse_requests: number;
 }
 
+export interface HeadroomTransformSaving {
+  transform: string;
+  count: number;
+  tokens_saved: number;
+}
+
 export interface TokenSavings {
   slim_bytes_saved: number;
   slim_tokens_saved: number;
+  headroom_requests: number;
+  headroom_tokens_saved: number;
   caveman_requests: number;
   terse_requests: number;
   usd_saved?: number;
   usd_saved_estimate?: boolean;
   rules: RuleSaving[];
+  headroom_transforms?: HeadroomTransformSaving[];
   by_client?: ClientSaving[];
 }
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -4,7 +4,7 @@ import {
   Sparkles, Zap, MessageSquare, Layers, Route, Wifi, Monitor, Database, Clock,
   ArrowUpCircle, CheckCircle2, ExternalLink,
   Gauge, Eye, EyeOff, KeyRound, Download, Upload, ShieldCheck, Info,
-  Palette, Shield,
+  Palette, Shield, Cpu,
 } from "lucide-react";
 import { api, type EndpointSettings, type BrandingSettings } from "../lib/api";
 import { ChangelogMarkdown } from "../components/ChangelogMarkdown";
@@ -167,13 +167,66 @@ function SavingTab({
     <div className="space-y-4">
       <Card>
         <SectionHeader
+          title="Headroom context compression"
+          description="Compresses conversation context through an optional Headroom proxy. Start the proxy separately with `make headroom` or Docker, then enable it here. Disables RTK when enabled."
+          icon={Cpu}
+        />
+        <div className="flex items-center justify-between border-t border-[var(--border)] px-6 py-4">
+          <span className="text-sm font-medium">Enable Headroom compression</span>
+          <Toggle checked={local.headroom_enabled} onChange={(v) => update({ headroom_enabled: v, ...(v ? { rtk_enabled: false } : {}) })} />
+        </div>
+        {local.headroom_enabled && (
+          <>
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--border)] px-6 py-4">
+              <div>
+                <p className="text-sm font-medium">Proxy URL</p>
+                <p className="mt-0.5 text-xs text-[var(--text-muted)]">Use http://127.0.0.1:8787 for local dev, or http://headroom:8787 for a Docker sidecar.</p>
+              </div>
+              <Input
+                type="text"
+                value={local.headroom_base_url || "http://127.0.0.1:8787"}
+                onChange={(e) => update({ headroom_base_url: e.target.value })}
+                className="w-64 font-mono text-sm"
+                placeholder="http://127.0.0.1:8787"
+              />
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--border)] px-6 py-4">
+              <div>
+                <p className="text-sm font-medium">Token budget</p>
+                <p className="mt-0.5 text-xs text-[var(--text-muted)]">Target token count after compression</p>
+              </div>
+              <Input
+                type="number"
+                min={1000}
+                max={2000000}
+                value={local.headroom_token_budget || 100000}
+                onChange={(e) => update({ headroom_token_budget: parseInt(e.target.value) || 100000 })}
+                className="w-28 text-center"
+              />
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--border)] px-6 py-4">
+              <div>
+                <p className="text-sm font-medium">Output shaper</p>
+                <p className="mt-0.5 text-xs text-[var(--text-muted)]">Headroom also steers output verbosity (replaces Caveman/Terse)</p>
+              </div>
+              <Toggle
+                checked={local.headroom_output_shaper}
+                onChange={(v) => update({ headroom_output_shaper: v, ...(v ? { caveman_enabled: false, terse_enabled: false } : {}) })}
+              />
+            </div>
+          </>
+        )}
+      </Card>
+
+      <Card>
+        <SectionHeader
           title="RTK input compression"
           description="Compresses bulky tool outputs (diffs, greps, listings, build logs) before they reach the model. Saves input tokens. Safe by design — never corrupts content."
           icon={Zap}
         />
         <div className="flex items-center justify-between border-t border-[var(--border)] px-6 py-4">
           <span className="text-sm font-medium">Enable RTK token saver</span>
-          <Toggle checked={local.rtk_enabled} onChange={(v) => update({ rtk_enabled: v })} />
+          <Toggle checked={local.rtk_enabled} onChange={(v) => update({ rtk_enabled: v, ...(v ? { headroom_enabled: false } : {}) })} />
         </div>
         {local.rtk_enabled && (
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--border)] px-6 py-4">

--- a/frontend/src/pages/Usage.tsx
+++ b/frontend/src/pages/Usage.tsx
@@ -435,7 +435,7 @@ function ActivityChart({ series }: { series: SeriesPoint[] }) {
 
 function RecentRow({ row }: { row: RecentActivity }) {
   const success = row.latency_ms > 0;
-  const hasSavings = (row.slim_bytes_saved ?? 0) > 0 || row.caveman_active || row.terse_active;
+  const hasSavings = (row.slim_bytes_saved ?? 0) > 0 || row.caveman_active || row.terse_active || row.headroom_active;
   return (
     <tr className="transition-colors hover:bg-[var(--bg-subtle)] group">
       <td className="w-6 px-3 py-2.5">
@@ -463,6 +463,11 @@ function RecentRow({ row }: { row: RecentActivity }) {
                 {row.caveman_active && (
                   <span className="text-[9px] font-bold text-purple-600 dark:text-purple-400 uppercase tracking-widest" title="Caveman compression">
                     [CVMN]
+                  </span>
+                )}
+                {row.headroom_active && (
+                  <span className="text-[9px] font-bold text-amber-600 dark:text-amber-400 uppercase tracking-widest" title={`Headroom saved ${fmtNum(row.headroom_tokens_saved ?? 0)} tokens`}>
+                    [HDRM]
                   </span>
                 )}
                 {row.terse_active && (

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -140,19 +140,23 @@ install_deps() {
 start_dev() {
   cd "$REPO_DIR"
 
+  local hr_port="${HEADROOM_PORT:-8787}"
   echo ""
   printf "${BOLD}  ┌───────────────────────────────────────────────┐${RESET}\n"
-  printf "${BOLD}  │${RESET}  ${GREEN}Everything ready! Starting KeiRouter…${RESET}         ${BOLD}│${RESET}\n"
+  printf "${BOLD}  │${RESET}  ${GREEN}Everything ready! Starting KeiRouter...${RESET}         ${BOLD}│${RESET}\n"
   printf "${BOLD}  │${RESET}                                               ${BOLD}│${RESET}\n"
-  printf "${BOLD}  │${RESET}  ${BLUE}Backend${RESET}    → http://localhost:20180           ${BOLD}│${RESET}\n"
-  printf "${BOLD}  │${RESET}  ${BLUE}Dashboard${RESET}  → http://localhost:5180            ${BOLD}│${RESET}\n"
-  printf "${BOLD}  │${RESET}  ${BLUE}Password${RESET}   → keirouter (change on first use) ${BOLD}│${RESET}\n"
+  printf "${BOLD}  │${RESET}  ${BLUE}Backend${RESET}    -> http://localhost:20180           ${BOLD}│${RESET}\n"
+  printf "${BOLD}  │${RESET}  ${BLUE}Dashboard${RESET}  -> http://localhost:5180            ${BOLD}│${RESET}\n"
+  printf "${BOLD}  │${RESET}  ${BLUE}Headroom${RESET}   -> optional: make headroom (:${hr_port})     ${BOLD}│${RESET}\n"
+  printf "${BOLD}  │${RESET}  ${BLUE}Password${RESET}   -> keirouter (change on first use) ${BOLD}│${RESET}\n"
   printf "${BOLD}  │${RESET}                                               ${BOLD}│${RESET}\n"
-  printf "${BOLD}  │${RESET}  ${YELLOW}Press Ctrl+C to stop both servers.${RESET}            ${BOLD}│${RESET}\n"
+  printf "${BOLD}  │${RESET}  ${YELLOW}Press Ctrl+C to stop all servers.${RESET}             ${BOLD}│${RESET}\n"
   printf "${BOLD}  └───────────────────────────────────────────────┘${RESET}\n"
   echo ""
 
-  # Run make dev — which starts backend + waits for healthz + starts frontend
+  # Run make dev — starts backend + waits for healthz + starts frontend.
+  # Headroom is optional; run `make headroom` separately or
+  # `KEIROUTER_HEADROOM_AUTO=1 make dev` from the repo root.
   make dev
 }
 


### PR DESCRIPTION
## What

Adds opt-in integration with the [Headroom](https://github.com/chopratejas/headroom) compression proxy. When enabled, KeiRouter sends requests through Headroom for token compression and tracks exact savings (tokens before/after, compression ratio, transforms) alongside existing optimization modes.

## Why

Headroom reports exact token counts from its compression proxy (unlike RTK's byte/4 estimate), giving more accurate savings analytics. Integration is fully opt-in so the default `make dev` / `make setup` flow remains unchanged.

## How

- **New package** `backend/internal/headroom/` — HTTP client that sends OpenAI-format messages to Headroom, applies compressed results back to the canonical `core.ChatRequest`, and returns `Stats` (tokens before/after/saved, compression ratio, transforms, CCR hashes). Skips unsupported content parts gracefully.
- **Pipeline integration** (`pipeline.go`) — Headroom runs as a compression step in `applyTokenSaving`. When `Headroom.Enabled`, it takes precedence over Slimmer; otherwise Slimmer/Terse/Caveman run as before. Failures are non-fatal (logs a warning and continues uncompressed).
- **Persistence** — Migration `0021_headroom_savings.sql` adds `headroom_*` columns to `usage_records`; `store/models.go` and `repo_usage.go` persist and aggregate headroom stats. Separate from RTK estimates so both systems can be observed independently.
- **Observability** — `meter` and `observ/metrics` track headroom activity and savings; `gateway/insights.go` and `gateway/settings.go` expose headroom config and savings in the admin API.
- **Dev experience** — New `make headroom` target starts the proxy via Docker or native CLI. `KEIROUTER_HEADROOM_AUTO=1 make dev` auto-starts it alongside backend + dashboard. `compose.yaml` adds a `headroom` service with healthcheck and wires `KEIROUTER_HEADROOM__BASE_URL`.
- **Frontend** — Settings page gains headroom controls; Usage page and `SavingsBreakdown` component surface headroom savings separately from RTK.
- **Docs** — README and `scripts/quickstart.sh` updated with headroom setup instructions.

### Changed files (21 files, +967/-61)

| Area | Files |
|------|-------|
| Backend core | `headroom/headroom.go`, `headroom/headroom_test.go`, `pipeline/pipeline.go` |
| Storage | `store/migrations/0021_headroom_savings.sql`, `store/models.go`, `store/repo_usage.go` |
| Observability | `meter/meter.go`, `observ/metrics.go` |
| Gateway | `gateway/insights.go`, `gateway/settings.go`, `gateway/gemini.go`, `gateway/handlers.go`, `app/app.go` |
| Frontend | `pages/Settings.tsx`, `pages/Usage.tsx`, `components/SavingsBreakdown.tsx`, `lib/api.ts` |
| Infra/Docs | `Makefile`, `compose.yaml`, `README.md`, `scripts/quickstart.sh` |

## Checklist

- [x] `make test` passes
- [x] `make vet` passes
- [x] `npm run typecheck` passes (frontend changed)
- [ ] `npm run lint` — N/A (no lint script configured in `frontend/package.json`)
- [x] Documentation updated (README, quickstart)
- [x] Config example updated (compose.yaml, Makefile defaults)