### PR TITLE
feat: Headroom + Ponytail token savers, savings tracking, and shutdown/migration fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,5 @@ data/
 .vscode/*
 !.vscode/extensions.json
 *.swp
+.kiro/*
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ C_CYAN   := \033[36m
 ##      so the Vite proxy never hits ECONNREFUSED on cold start.
 dev:
 	@printf "$(C_BOLD)$(C_CYAN)Starting KeiRouter$(C_RESET) backend (:20180) + dashboard (:5180)…\n"
-	@trap 'kill 0' INT TERM EXIT; \
+	@trap 'trap - INT TERM EXIT; kill 0' INT TERM EXIT; \
 	( cd $(BACKEND_DIR) && go run ./cmd/keirouter ) & \
 	( \
 		printf "$(C_DIM)⏳ Waiting for backend…$(C_RESET)\n"; \

--- a/README.md
+++ b/README.md
@@ -21,37 +21,67 @@
 
 ---
 
-Hey there! 👋 Welcome to **KeiRouter**.
+## So, what's the deal? 🤔
 
-If you're using AI coding tools like Claude Code, Cursor, Cline, or literally any app that talks to OpenAI or Anthropic, you know the struggle: juggling API keys, hitting rate limits, and watching your token costs explode.
+You use AI coding tools — Claude Code, Cursor, Cline, or honestly anything that talks to OpenAI or Anthropic. And you know the headaches: a drawer full of API keys, rate limits that hit at the worst time, and a token bill that keeps creeping up.
 
-**KeiRouter fixes that.**
+**KeiRouter is the smart middleman that makes all of that someone else's problem.** Point your tools at one local endpoint and let it handle the boring stuff — routing each request to the right model, failing over the moment a provider taps out, caching repeat questions, and squeezing oversized prompts down *before* they ever cost you a token.
 
-You just point all your AI tools to one local endpoint on your machine. KeiRouter acts as your smart middleman—routing requests to the right AI models, automatically falling back if a service goes down, caching repeated questions to save money, and compressing big chunks of text before they even reach the AI!
+Oh, and it's written in Go. So it sips memory (~20 MB), boots instantly, ships as a single binary, and comes with a dashboard that's actually nice to look at. ✨
 
-It's built with Go, which means it’s incredibly lightweight (using barely ~20MB of RAM) and starts up instantly. Plus, it comes with a beautiful dashboard to manage everything. ✨
+> **Heads up:** KeiRouter is under active development. Peek at [Architecture](#-architecture) to see what's wired up today.
 
-> **Status:** Active development. See the [Architecture](#architecture) section for what's implemented.
+---
 
-## 🌟 Why you'll love KeiRouter
+## 📑 What's inside
 
-- 🔀 **One Endpoint to Rule Them All:** Your apps only need to speak OpenAI or Anthropic. KeiRouter handles translating your requests to whatever provider you actually want to use behind the scenes.
-- 🛡️ **Never Stop Coding:** Hit a rate limit? Provider down? KeiRouter automatically falls back to your backup models so your workflow never gets interrupted.
-- 💸 **Save Serious Cash:** 
-  - **Input Compression:** It shrinks massive logs, code diffs, and file structures before sending them to the LLM. 
-  - **Output Compression:** Tell the AI to speak in "terse mode" to cut out all the yapping and just give you the code.
-  - **Savings Dashboard:** See exactly how much money you've saved with a detailed breakdown of input and output compression ratios.
-- 💰 **Budget Engine:** Set per-key or per-organization USD and token hard limits with auto-cutoff to prevent unexpected bills.
-- 🚦 **Rate Limiting:** Protect your gateway and upstream quotas with per-key RPM, TPM, and concurrency caps. Use global defaults or assign limits through reusable plans.
-- 🛡️ **Guardrails (PII, Injection, Toxicity, Topics, Bias):** Content-safety policies layered global → provider → model → chain → API key. Indonesian-aware PII recognizers (NIK, NPWP, +62 phone), prompt-injection detection, bilingual toxicity + bias scoring, and streaming-output scanning. Bring-your-own-engine: OpenAI Moderation, Microsoft Presidio sidecar, or stay 100% offline.
-- 📋 **Plans & Policy Templates:** Create reusable budget templates with spend limits, token limits, rate limits, reset periods, allowed models, and alert thresholds. Assign plans to API keys so you define the rules once and apply them everywhere.
-- 🎨 **Branding & White-Label:** Customize the entire dashboard and portal with your own name, logo, favicon, tagline, and color palette. Perfect for teams and organizations that want a white-labeled AI gateway.
-- 🛠️ **Skills System:** Enhance your LLM interactions with built-in skills (Web Search, Image Generation, Text-to-Speech, etc.) natively routed through the gateway.
-- 🔧 **CLI Tools Auto-Config:** KeiRouter generates ready-to-paste configuration snippets for 11+ coding tools—Claude Code, Cursor, Cline, GitHub Copilot, DeepSeek, KiloCode, and more.
-- 🔐 **Super Secure:** Your API keys are encrypted with military-grade envelope encryption (AES-256-GCM). We never store plain text keys. Your local dashboard is also protected by a secure password and HMAC session cookies. Includes SSRF protection on all outbound requests.
-- 📊 **Track Everything:** Wondering where your money is going? The beautiful dashboard gives you a detailed Quota Tracker, Provider usage breakdowns, real-time API Key monitoring, TTFT (time-to-first-token) metrics, and per-key usage summaries.
-- ⚡ **Lightning Fast Caching:** Ask the same question twice? The semantic cache (powered by embeddings) remembers the answer and gives it back to you instantly, for exactly $0.00.
-- 🌐 **Usage Portal:** Give your team members a dedicated portal to view their own API key usage, quota, and token savings—no admin access needed.
+- [Highlights](#-the-good-stuff)
+- [Quick Start](#-quick-start)
+  - [Prerequisites](#prerequisites)
+  - [Pick your install](#pick-your-install)
+  - [First login](#first-login)
+  - [Connect your tools](#connect-your-tools)
+- [Token Savings](#-token-savings-where-the-money-hides)
+- [Smart Routing (Chains)](#-smart-routing-chains)
+- [Beyond Chat](#-it-does-more-than-chat)
+- [Connect via OAuth](#-skip-the-keys-oauth)
+- [Plans & Budgets](#-plans--budgets)
+- [Rate Limiting](#-rate-limiting)
+- [Guardrails](#-guardrails)
+- [Branding & White-Label](#-make-it-yours-branding)
+- [CLI Tools Auto-Config](#-cli-tools-auto-config)
+- [Usage Portal](#-usage-portal)
+- [Supported Providers](#-supported-providers-60)
+- [Configuration](#-configuration)
+- [Architecture](#-architecture)
+- [Security](#-security)
+- [Development & Contributing](#-hack-on-it)
+- [License](#-license)
+
+---
+
+## ⭐ The good stuff
+
+**Routing & reliability**
+- 🔀 **One endpoint, every provider** — Your apps speak OpenAI or Anthropic; KeiRouter quietly translates to whatever you actually want to use.
+- 🛡️ **Never stop coding** — Provider down? Rate limited? Fallback chains keep you moving like nothing happened.
+- ⚡ **Semantic cache** — Ask the same thing twice and the embedding-powered cache hands it back instantly, for a glorious $0.00.
+
+**Cost control**
+- 💸 **Five token savers** — Two on the way in, three on the way out, all on a live savings dashboard. Details in [Token Savings](#-token-savings-where-the-money-hides).
+- 💰 **Budget engine** — Per-key or per-org USD and token hard limits, with an auto-cutoff so surprise bills stay fictional.
+- 🚦 **Rate limiting** — Per-key RPM, TPM, and concurrency caps via global defaults or reusable plans.
+- 📋 **Plans & templates** — Set the rules once, slap them on any key.
+
+**Safety & governance**
+- 🛡️ **Guardrails** — PII, prompt-injection, toxicity, topics, and bias detectors layered global → provider → model → chain → key, with mid-stream output scanning and a fully-offline mode.
+- 🔐 **Locked down by default** — AES-256-GCM envelope encryption for credentials, a password-gated dashboard, HMAC sessions, and SSRF protection on outbound calls.
+
+**Operations & UX**
+- 📊 **See everything** — Quota tracker, provider breakdowns, live key monitoring, TTFT metrics, and per-key summaries.
+- 🎨 **White-label it** — Rebrand the dashboard and portal with your own name, logo, and palette.
+- 🛠️ **Skills & CLI auto-config** — Built-in skills plus copy-paste configs for 12+ coding tools.
+- 🌐 **Usage portal** — A no-admin-needed view so teammates can track their own usage and savings.
 
 <p align="center">
   <img src="assets/keirouter-providers-banner.png" alt="Manage AI Providers" width="800">
@@ -61,220 +91,196 @@ It's built with Go, which means it’s incredibly lightweight (using barely ~20M
   <img src="assets/keirouter-usage-banner.png" alt="Intelligent Routing & Topology" width="800">
 </p>
 
-## 🚀 Let's get started!
+---
 
-### 1. Install & Run
+## 🚀 Quick Start
 
-**Homebrew (macOS & Linux):**
+### Prerequisites
+
+Grab whichever path matches what's already on your machine — no need to install things you won't use:
+
+| Method | You'll need | Great for |
+|---|---|---|
+| **Homebrew** | macOS or Linux with Homebrew | The fastest way to a prebuilt binary |
+| **From source** | Go 1.24+ and Node.js 20+ | Local hacking / latest `main` |
+| **Docker** | Just Docker | Clean, isolated runs |
+| **Docker Compose** | Docker + Docker Compose | VPS / production / Coolify |
+
+### Pick your install
+
+<details open>
+<summary><strong>Option A — Homebrew (macOS &amp; Linux)</strong> · the easy button</summary>
+
 ```bash
 brew tap mydisha/keirouter https://github.com/mydisha/keirouter
 brew install keirouter
+
+keirouter -bootstrap   # mint your first API key (printed once — don't blink)
+keirouter              # fire up the server on :20180
 ```
+</details>
 
-Then:
-```bash
-keirouter -bootstrap   # create your first API key
-keirouter              # start server on :20180
-```
+<details>
+<summary><strong>Option B — One-line from source</strong> · for the tinkerers</summary>
 
-**One-Line (from source):**
+Needs **Go 1.24+** and **Node.js 20+**. No cloning, no `.env`, no config wrangling:
 
-Make sure you have Go 1.24+ and Node.js 20+, then paste this:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/mydisha/keirouter/main/scripts/quickstart.sh | bash
 ```
 
-That's it! No manual cloning, no `.env`, no config files. Everything is automatic:
-- Clones the repo to `~/keirouter`
-- Installs dependencies
-- Starts backend on `:20180` and dashboard on `:5180`
-- Default dashboard password: `keirouter`
+It clones the repo to `~/keirouter`, installs everything, and starts the backend on `:20180` and the dashboard on `:5180`.
 
-> **Already have the repo?** Just run `make setup` in the project root.
+> Already cloned it? Just `make setup` from the project root and you're off.
+</details>
 
-**Prefer Docker?** No Go/Node.js needed:
+<details>
+<summary><strong>Option C — Docker</strong> · no Go/Node, no problem</summary>
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/mydisha/keirouter/main/scripts/install.sh | bash -s -- --docker
 ```
+</details>
 
-**VPS / Coolify / Production?**
+<details>
+<summary><strong>Option D — Docker Compose</strong> · ship it (VPS / production / Coolify)</summary>
+
 ```bash
 git clone https://github.com/mydisha/keirouter.git
 cd keirouter
-cp .env.example .env   # set KEIROUTER_MASTER_KEY for production
+cp .env.example .env       # set KEIROUTER_MASTER_KEY before going to prod
 docker compose up -d --build
 ```
 
-See [deploy/README.md](deploy/README.md) for VPS, Postgres, and Coolify notes.
+VPS, PostgreSQL, and Coolify notes live in [deploy/README.md](deploy/README.md).
+</details>
 
-### 2. Set up your Dashboard
-For the local quickstart, open **http://localhost:5180**. For Docker or the installed production server, open **http://localhost:20180**.
-Log in with the default password: `keirouter` (it will ask you to change this immediately for security).
+### First login
 
-You can also create an API key directly from the terminal without the dashboard:
+| How you installed | Open this | Password |
+|---|---|---|
+| From source (quickstart / `make setup`) | http://localhost:5180 | `keirouter` |
+| Homebrew / Docker / production | http://localhost:20180 | `keirouter` |
+
+It'll nudge you to change that password the second you log in (please do 🙏). Allergic to UIs? Mint a key straight from the terminal:
+
 ```bash
-keirouter -bootstrap   # prints a kr_ key once
+keirouter -bootstrap   # prints a kr_ key, once
 ```
 
-### 3. Connect your tools
-In your favorite AI tool (like Cursor or Claude Code), set it up like this:
+### Connect your tools
+
+In your AI tool of choice (Cursor, Claude Code, Cline, you name it), set:
+
 - **Base URL:** `http://localhost:20180/v1`
-- **API Key:** Use the `kr_` key you generated in the dashboard or via bootstrap
-- **Model:** Type the provider and model (e.g., `openai/gpt-4o`) or the name of a fallback chain you created!
+- **API Key:** the `kr_` key from the dashboard or `-bootstrap`
+- **Model:** a provider model like `openai/gpt-4o`, or the name of a fallback [chain](#-smart-routing-chains) you cooked up
+
+That's it. You're routing.
+
+---
+
+## 💸 Token Savings (where the money hides)
+
+Every request runs through a deterministic token-saving pipeline **before** it gets translated to the provider's format — so the savings work the same no matter which provider you land on. There are **five savers**, each independently toggleable from **Settings → Token Saving**, and a dashboard that shows you exactly how much you clawed back.
+
+| Saver | Side | The pitch |
+|---|---|---|
+| **RTK / Slimmer** | Input | Shrinks chunky tool output (diffs, greps, listings, build logs) locally before it ever leaves your machine. |
+| **Headroom** | Input | Routes request messages through an external [Headroom](https://github.com/headroomlabs-ai/headroom) proxy for deeper compression. *Fail-open* — if the proxy sneezes, your request sails through untouched. Also sniffs out "phantom savings" so only real wins get counted. |
+| **Terse** | Output | Drops a concise-output directive so the model skips the small talk and gives you the goods. |
+| **Caveman** | Output | Terse's stronger cousin (Wenyan / 文言文 levels included) — trims output tokens by 65–75%. |
+| **Ponytail** | Output | Injects a "lazy senior dev" system prompt (`lite` / `full` / `ultra`) that nudges the model toward the smallest possible change. Stacks on top of Terse or Caveman. |
+
+> Terse and Caveman both inject a system directive, so they're mutually exclusive — pick one. Ponytail happily layers on top of either.
+
+**Pipeline order:** `normalizer → RTK → Headroom → Terse / Caveman → Ponytail → provider translation`.
+
+### Getting Headroom running
+
+Headroom is its own open-source compression proxy. KeiRouter just calls its `/v1/compress` endpoint, so you spin it up locally first. One gotcha worth shouting about: the **`headroom` CLI lives in the Python package** — the npm package is a library only, so `npm install -g headroom-ai` will leave you staring at `command not found`. Don't say we didn't warn you. 😉
+
+```bash
+# The clean way: pipx isolates the CLI and sorts out your PATH (needs Python 3.10+)
+pipx install "headroom-ai[all]"
+pipx ensurepath               # puts headroom on your PATH — then restart your shell
+
+headroom proxy --port 8787    # start the proxy
+headroom doctor               # make sure it's actually happy
+```
+
+On Ubuntu and `pip` is fighting you (PEP 668 blocks global installs)? Go `--user` and make sure `~/.local/bin` is on your `PATH`:
+
+```bash
+pip install --user "headroom-ai[all]"
+export PATH="$HOME/.local/bin:$PATH"   # drop this in ~/.zshrc or ~/.bashrc
+```
+
+Then over in **Settings → Token Saving → Headroom**: flip it on, set the **Proxy URL** to `http://localhost:8787`, and hit **Test connection** to confirm the handshake. Green check? You're golden.
+
+---
 
 ## 🧠 Smart Routing (Chains)
-Instead of just picking one model, you can create a "Chain" in the dashboard. 
 
-For example, a chain named `coding` could try:
-1. `openai/gpt-4o` (First choice)
-2. `deepseek/deepseek-chat` (If GPT-4o fails or hits a rate limit)
+Why bet on one model when you can have a backup plan? Build a **chain** in the dashboard. Say you name one `coding`:
 
-Then, in your app, just set the model to `chain:coding` (or just `coding`) and let KeiRouter do the heavy lifting!
+1. `openai/gpt-4o` — your first pick
+2. `deepseek/deepseek-chat` — steps in if the first one rate-limits or face-plants
 
-## 🔌 What else can it do?
-KeiRouter isn't just for chat! It supports everything:
-- **Image Generation** (`/v1/images/generations`)
-- **Speech-to-Text** (`/v1/audio/transcriptions`)
-- **Text-to-Speech** (`/v1/audio/speech`)
-- **Web Search & Fetching** (`/v1/search`, `/v1/web/fetch`)
-- **Embeddings** (`/v1/embeddings`)
+Then just set your app's model to `chain:coding` (or plain `coding`) and let KeiRouter sweat the failover.
 
-## 🔑 Connect via OAuth (No API Keys needed!)
-Tired of copying API keys? You can connect providers like Claude, GitHub Copilot, Gemini CLI, and more directly from the Connections page using OAuth. Just click, sign in, and KeiRouter handles securely refreshing your tokens in the background!
+---
 
-Supported OAuth/custom-auth flows include:
-- **Claude** — Anthropic OAuth
-- **GitHub Copilot** — GitHub device flow
-- **Gemini CLI** — Google device flow
-- **KiloCode** — Custom device-auth
-- **Qoder** — PKCE device-token flow
-- **CodeBuddy** (Tencent) — Browser-poll flow
-- **Cursor** — Token import flow
+## 🔌 It does more than chat
 
-## 📋 Plans & Budget Templates
-Plans let you define reusable budget policies that can be assigned to any API key. Instead of configuring limits per key, create a plan once and apply it everywhere.
+Chat completions are just the start. KeiRouter proxies the whole buffet:
 
-Each plan defines:
-- **Spend Limit** — USD budget cap (in micro-dollars for precision)
-- **Token Limit** — Maximum token usage
-- **RPM Limit** — Maximum requests per minute for each assigned API key (`0` means unlimited)
-- **TPM Limit** — Maximum estimated tokens per minute for each assigned API key (`0` means unlimited)
-- **Concurrency Limit** — Maximum in-flight requests for each assigned API key (`0` means unlimited)
-- **Reset Period** — `daily`, `weekly`, `monthly`, or `total`
-- **Allowed Models** — Restrict to specific models using wildcard patterns (e.g., `claude-*`, `gpt-4*`); empty means all models allowed
-- **Alert Threshold** — Percentage (1–100) at which alerts fire before budget exhaustion
-- **Hard Cutoff** — When enabled, requests are blocked once the budget is exhausted; when disabled, usage is tracked but not enforced
+| Capability | Endpoint |
+|---|---|
+| Image generation | `/v1/images/generations` |
+| Speech-to-text | `/v1/audio/transcriptions` |
+| Text-to-speech | `/v1/audio/speech` |
+| Embeddings | `/v1/embeddings` |
+| Web search | `/v1/search` |
+| Web fetch | `/v1/web/fetch` |
 
-A default plan is automatically created for each tenant. Plans can be managed from the dashboard's Plans page and assigned to API keys in the Keys settings.
+---
 
-## 🛡️ Guardrails
+## 🔑 Skip the keys: OAuth
 
-KeiRouter ships a built-in content-safety layer that runs detectors against every request and response. Policies are layered **global → provider → model → chain → API key** and merged at request time, so the most specific override wins.
+Copy-pasting API keys gets old fast. Connect providers straight from the **Connections** page with OAuth — sign in once, and KeiRouter quietly refreshes your tokens in the background.
 
-**Detectors out of the box:**
+| Provider | Flow |
+|---|---|
+| **Claude** | Anthropic OAuth |
+| **GitHub Copilot** | GitHub device flow |
+| **Gemini CLI** | Google device flow |
+| **KiloCode** | Custom device-auth |
+| **Qoder** | PKCE device-token flow |
+| **CodeBuddy** (Tencent) | Browser-poll flow |
+| **Cursor** | Token import flow |
 
-| Detector | What it catches | Default engine | Optional engine |
-|---|---|---|---|
-| **PII** | Email, phone, credit card, IBAN, IP, URL, **NIK / NPWP / Indonesian passport** | Native Go (Presidio-compatible) | Microsoft Presidio HTTP sidecar (PERSON / LOCATION / multilingual) |
-| **Prompt Injection** | Ignore-previous, role override, DAN, prompt-leak, safety bypass | Native regex catalog | — |
-| **Topics** | Allow-list / block-list of conversation topics | Keyword + n-gram match | Embedding similarity (semantic paraphrase detection) |
-| **Toxicity** | Profanity, hate speech, harassment, violence, sexual — bilingual id+en | Native keyword catalog | OpenAI Moderation API |
-| **Bias** (outbound) | Political, gender, ethnic, religious bias in LLM responses | Native bilingual lexicon | — |
+---
 
-**Actions per detector:** `log_only`, `warn`, `mask` (rewrite the prompt/response), or `block` (refuse with `policy_blocked`). The strictest action across detectors wins.
+## 📋 Plans & Budgets
 
-**Strategies for PII:** `redact` (`<PII>`), `replace` (`<EMAIL_ADDRESS>`), `mask` (keep edges, asterisk middle), `hash`, `anonymize`, or `block`.
+Plans are reusable budget policies you can stamp onto any API key — write the rules once, apply them everywhere. Each plan covers:
 
-**Streaming-safe:** A sliding 256-char buffer scans assistant text as chunks arrive — PII leaks or toxic output get caught mid-stream and the connection is cancelled with a policy error.
+- **Spend limit** — USD cap (micro-dollar precision, because pennies add up)
+- **Token limit** — max token usage
+- **RPM / TPM / Concurrency limits** — per assigned key (`0` = unlimited)
+- **Reset period** — `daily`, `weekly`, `monthly`, or `total`
+- **Allowed models** — wildcard patterns like `claude-*`, `gpt-4*` (empty = everything's fair game)
+- **Alert threshold** — get pinged at 1–100% of budget
+- **Hard cutoff** — block requests when the budget's gone, or just track and let it ride
 
-**Observability:** Every decision lands in the **Audit Logs** tab with full findings (entity, score, redaction). The dashboard streams new rows live via SSE. Prometheus exposes `keirouter_guardrail_decisions_total{detector,action}` and `keirouter_guardrail_eval_seconds{detector}` at `/metrics`.
+Every tenant gets a default plan out of the box. Manage them on the **Plans** page and assign them in **Keys** settings.
 
-**Compliance & hardening:**
-- **GDPR / data residency:** A per-tenant `allow_external_engines` flag forces all detectors back to their native engines so no data ever leaves the KeiRouter process.
-- **Audit retention:** `KEIROUTER_GUARDRAILS__AUDIT_RETENTION_DAYS=90` runs an hourly sweeper to drop old rows.
-- **Test endpoint rate-limited:** 10 req/min per session to prevent ReDoS / enumeration abuse.
+---
 
-**Starter templates** ship in the dashboard's "From template" picker: Indonesia PII · Strict safety · Compliance audit (log-only) · Public chatbot · Compliance alerts-only. Policies can also be exported as a JSON bundle and imported on another instance.
+## 🚦 Rate Limiting
 
-**Optional Presidio sidecar:**
-
-```bash
-docker compose -f compose.yaml -f compose.postgres.yaml -f compose.presidio.yaml up -d
-```
-
-Then set any PII policy's engine to `presidio` from the dashboard to unlock NER-based detection (`PERSON`, `LOCATION`, full multilingual coverage).
-
-## 🎨 Branding & White-Label
-Make KeiRouter your own! The branding system lets you customize the entire look and feel of both the admin dashboard and the public-facing Usage Portal.
-
-Customizable settings include:
-- **App Name** — Replace "KeiRouter" with your organization's name
-- **Logo URL** — Your custom logo (SVG/PNG)
-- **Favicon URL** — Custom browser tab icon
-- **Tagline** — Short text shown on the portal login screen
-- **Color Palette** — Choose from predefined palettes: `sage-terra`, `ocean`, `midnight`, and more
-
-All branding settings are managed from the **Settings → Branding** tab in the dashboard.
-
-## 🔧 CLI Tools Auto-Config
-KeiRouter can generate ready-to-paste configuration snippets for your favorite AI coding tools. Visit the **CLI Tools** page in the dashboard to get the exact config you need for:
-
-Claude Code · Cursor · Cline · GitHub Copilot · DeepSeek · KiloCode · OpenCode · OpenClaw · Hermes · JCode · Droid · CodeBuddy
-
-Just copy the snippet, paste it into your tool's config, and you're connected!
-
-## 🌐 Usage Portal
-The Usage Portal gives your team members a dedicated, non-admin view to monitor their own API usage. Each user can:
-- View their API key's quota and spend
-- Track token usage over time
-- See token savings from input/output compression
-- Monitor their assigned plan limits
-
-The portal is accessible at `/portal` and requires only the API key to log in—no admin credentials needed.
-
-<a name="architecture"></a>
-## 🛠️ Architecture for the curious
-Curious how it works under the hood? Here's the life of a request:
-1. **Gateway:** Receives your HTTP request and parses the AI dialect (OpenAI, Anthropic, Gemini, etc.).
-2. **Guardrails (inbound):** Runs PII / injection / toxicity / topics detectors against the prompt. Block → refuse; Mask → rewrite the prompt in place.
-3. **Pipeline:** Compresses your inputs (Slimmer), injects cost-saving prompts (Terse mode), and checks your budget limits.
-4. **Dispatch:** Picks the best provider account and handles fallbacks.
-5. **Connector & Transform:** Talks to the provider and translates the response back into the format your tool expects.
-6. **Guardrails (outbound):** Scans the response (or each chunk for streams) for leaked PII, biased phrasing, or toxic content. Block → cancel; Mask → rewrite the response.
-7. **Meter:** Logs how many tokens you used so you can view it on the dashboard.
-
-## 🌐 Supported Providers (60+)
-KeiRouter connects to a massive roster of AI providers out of the box. Here's the full list:
-
-**🧠 LLM / Chat Providers:**
-
-| Category | Providers |
-|----------|-----------|
-| **Major Cloud** | OpenAI, Anthropic, Google Gemini, Vertex AI, Azure OpenAI, AWS (Kiro) |
-| **Free / Free Tier** | OpenRouter (27+ free models), NVIDIA NIM, Ollama (Cloud & Local), Cloudflare Workers AI, BytePlus ModelArk |
-| **China / Asia** | DeepSeek, Qwen (Alibaba), GLM, Kimi (Moonshot), MiniMax, Volcengine Ark, Xiaomi MiMo, SiliconFlow, iFlow |
-| **OAuth / IDE** | Claude Code, GitHub Copilot, Cursor IDE, Cline, Kilo Code, OpenAI Codex, CodeBuddy (Tencent), Kimi Coding |
-| **Performance** | Groq, Cerebras, SambaNova, DeepInfra |
-| **Specialized** | xAI (Grok), Mistral, Perplexity, Cohere, AI21 Labs, Reka AI |
-| **Aggregators** | Together AI, Fireworks AI, Nebius AI, OpenCode, AIML API, Vercel AI Gateway |
-| **Emerging** | Blackbox AI, Chutes AI, Hyperbolic, Lepton AI, Kluster AI, MorphLLM, LongCat, Puter AI, GLHF, SumoPod, Scaleway, NLP Cloud, and many more |
-| **Custom** | Any OpenAI-compatible or Anthropic-compatible endpoint (self-hosted, proxy, etc.) |
-
-**🎨 Media & Search Providers:**
-
-| Type | Providers |
-|------|-----------|
-| **Image Generation** | OpenAI DALL·E, Gemini Imagen, Cloudflare, Fal.ai, Stability AI, Black Forest Labs, Recraft, Topaz, Runway ML, NanoBanana, HuggingFace, SD WebUI, ComfyUI |
-| **Text-to-Speech** | OpenAI TTS, NVIDIA NIM, ElevenLabs, Deepgram, Cartesia, PlayHT, AWS Polly, Google TTS, Edge TTS, Inworld, Coqui, Tortoise |
-| **Speech-to-Text** | OpenAI Whisper, Groq Whisper, Deepgram, AssemblyAI, Gemini STT, HuggingFace |
-| **Embeddings** | OpenAI, Gemini, Mistral, Together AI, Fireworks AI, Nebius, Voyage AI, Jina AI, OpenRouter |
-| **Web Search** | Tavily, Exa, Serper, Brave Search, SearXNG, Perplexity, xAI, Google PSE, Linkup, SearchAPI, You.com, OpenAI |
-| **Web Fetch** | Tavily, Exa, Firecrawl, Jina Reader |
-
-## ⚙️ Configuration
-By default, KeiRouter uses an embedded SQLite database (zero config required!). If you are deploying it for a team, you can use PostgreSQL. Just copy `config.example.yaml` and run with `-config`, or use environment variables like `KEIROUTER_SERVER__PORT=8080`. Docker/Coolify examples live in [deploy/README.md](deploy/README.md).
-
-Enable the local in-memory rate limiter for single-instance deployments:
+Keep your gateway (and your upstream quotas) from getting hammered with per-key RPM, TPM, and concurrency caps. For a single-instance setup, the in-memory limiter is all you need:
 
 ```yaml
 limits:
@@ -287,22 +293,139 @@ limits:
   cleanup_interval: 1m
 ```
 
-Default limits apply only to API keys without an assigned plan. When a key has a plan, the plan's `rpm_limit`, `tpm_limit`, and `concurrency_limit` take precedence; `0` means unlimited.
+Those defaults only apply to keys **without** a plan. The moment a key has one, the plan's `rpm_limit`, `tpm_limit`, and `concurrency_limit` take over (`0` = unlimited).
 
-## 🔒 Security Notes
-- The admin API (`/api/*`) is restricted to your local machine by default. If you expose it to the internet, put it behind a reverse proxy and set a stable `master_key`!
-- **Don't lose your master key!** It is the root of trust for all your encrypted credentials.
+---
 
-## 🧑‍💻 Development & Contributing
-Want to hack on KeiRouter?
+## 🛡️ Guardrails
+
+A built-in content-safety layer runs detectors against every request and response. Policies stack **global → provider → model → chain → API key** and merge at request time, so the most specific rule wins.
+
+| Detector | Catches | Default engine | Optional engine |
+|---|---|---|---|
+| **PII** | Email, phone, credit card, IBAN, IP, URL, **NIK / NPWP / Indonesian passport** | Native Go (Presidio-compatible) | Microsoft Presidio HTTP sidecar |
+| **Prompt Injection** | Ignore-previous, role override, DAN, prompt-leak, safety bypass | Native regex catalog | — |
+| **Topics** | Allow-list / block-list of topics | Keyword + n-gram | Embedding similarity |
+| **Toxicity** | Profanity, hate, harassment, violence, sexual (id + en) | Native catalog | OpenAI Moderation API |
+| **Bias** (outbound) | Political, gender, ethnic, religious bias in responses | Native bilingual lexicon | — |
+
+- **Actions:** `log_only`, `warn`, `mask` (rewrite it), or `block` (refuse it). Strictest action across detectors wins.
+- **PII strategies:** `redact`, `replace`, `mask`, `hash`, `anonymize`, or `block`.
+- **Streaming-safe:** a sliding 256-char buffer scans assistant output as it streams and pulls the plug mid-sentence if something leaks.
+- **Observability:** every decision shows up in **Audit Logs** (live via SSE); Prometheus serves `keirouter_guardrail_decisions_total` and `keirouter_guardrail_eval_seconds` at `/metrics`.
+- **Compliance:** a per-tenant `allow_external_engines` flag forces every detector offline; `KEIROUTER_GUARDRAILS__AUDIT_RETENTION_DAYS` controls retention; the test endpoint is capped at 10 req/min.
+
+Starter templates ship in the dashboard's "From template" picker (Indonesia PII · Strict safety · Compliance audit · Public chatbot · Alerts-only), and you can export/import policies as a JSON bundle.
+
+Want NER-based PII detection (`PERSON`, `LOCATION`, full multilingual)? Spin up the optional **Presidio sidecar**:
+
 ```bash
-make setup   # First time: installs deps + starts backend (:20180) and dashboard (:5180)
-make dev     # After first time: just starts the servers
+docker compose -f compose.yaml -f compose.postgres.yaml -f compose.presidio.yaml up -d
 ```
-Contributions are always welcome! Check out [CONTRIBUTING.md](CONTRIBUTING.md) to see how you can get involved.
 
-## 🛡️ Security Vulnerabilities
-If you find a security issue, please check [SECURITY.md](SECURITY.md) instead of opening a public issue.
+Then flip any PII policy's engine to `presidio` in the dashboard.
+
+---
+
+## 🎨 Make it yours: Branding
+
+Rebrand the admin dashboard *and* the public Usage Portal from **Settings → Branding**:
+
+- **App name** — swap "KeiRouter" for your own
+- **Logo & favicon URLs** — your SVG/PNG, your vibe
+- **Tagline** — the line on the portal login screen
+- **Color palette** — `sage-terra`, `ocean`, `midnight`, and friends
+
+---
+
+## 🔧 CLI Tools Auto-Config
+
+The **CLI Tools** page spits out ready-to-paste config snippets for the usual suspects:
+
+> Claude Code · Cursor · Cline · GitHub Copilot · DeepSeek · KiloCode · OpenCode · OpenClaw · Hermes · JCode · Droid · CodeBuddy
+
+Copy, paste into your tool's config, done.
+
+---
+
+## 🌐 Usage Portal
+
+A dedicated, no-admin-required view at `/portal` where teammates keep an eye on their own usage — quota and spend, token usage over time, compression savings, and plan limits. All it asks for is the API key. No keys to the kingdom required.
+
+---
+
+## 🌐 Supported Providers (60+)
+
+**🧠 LLM / Chat**
+
+| Category | Providers |
+|----------|-----------|
+| **Major Cloud** | OpenAI, Anthropic, Google Gemini, Vertex AI, Azure OpenAI, AWS (Kiro) |
+| **Free / Free Tier** | OpenRouter (27+ free models), NVIDIA NIM, Ollama (Cloud & Local), Cloudflare Workers AI, BytePlus ModelArk |
+| **China / Asia** | DeepSeek, Qwen (Alibaba), GLM, Kimi (Moonshot), MiniMax, Volcengine Ark, Xiaomi MiMo, SiliconFlow, iFlow |
+| **OAuth / IDE** | Claude Code, GitHub Copilot, Cursor IDE, Cline, Kilo Code, OpenAI Codex, CodeBuddy (Tencent), Kimi Coding |
+| **Performance** | Groq, Cerebras, SambaNova, DeepInfra |
+| **Specialized** | xAI (Grok), Mistral, Perplexity, Cohere, AI21 Labs, Reka AI |
+| **Aggregators** | Together AI, Fireworks AI, Nebius AI, OpenCode, AIML API, Vercel AI Gateway |
+| **Emerging** | Blackbox AI, Chutes AI, Hyperbolic, Lepton AI, Kluster AI, MorphLLM, LongCat, Puter AI, GLHF, SumoPod, Scaleway, NLP Cloud, and many more |
+| **Custom** | Any OpenAI- or Anthropic-compatible endpoint (self-hosted, proxy, etc.) |
+
+**🎨 Media & Search**
+
+| Type | Providers |
+|------|-----------|
+| **Image Generation** | OpenAI DALL·E, Gemini Imagen, Cloudflare, Fal.ai, Stability AI, Black Forest Labs, Recraft, Topaz, Runway ML, NanoBanana, HuggingFace, SD WebUI, ComfyUI |
+| **Text-to-Speech** | OpenAI TTS, NVIDIA NIM, ElevenLabs, Deepgram, Cartesia, PlayHT, AWS Polly, Google TTS, Edge TTS, Inworld, Coqui, Tortoise |
+| **Speech-to-Text** | OpenAI Whisper, Groq Whisper, Deepgram, AssemblyAI, Gemini STT, HuggingFace |
+| **Embeddings** | OpenAI, Gemini, Mistral, Together AI, Fireworks AI, Nebius, Voyage AI, Jina AI, OpenRouter |
+| **Web Search** | Tavily, Exa, Serper, Brave Search, SearXNG, Perplexity, xAI, Google PSE, Linkup, SearchAPI, You.com, OpenAI |
+| **Web Fetch** | Tavily, Exa, Firecrawl, Jina Reader |
+
+---
+
+## ⚙️ Configuration
+
+Out of the box, KeiRouter runs on an embedded **SQLite** database — zero config, zero fuss. Running it for a team? Switch to **PostgreSQL**: copy `config.example.yaml` and run with `-config`, or use environment variables like `KEIROUTER_SERVER__PORT=8080`. Docker/Coolify examples are in [deploy/README.md](deploy/README.md).
+
+---
+
+## 🛠️ Architecture
+
+Curious what happens after you hit send? Here's the life of a request:
+
+1. **Gateway** — takes your HTTP request and figures out the dialect (OpenAI, Anthropic, Gemini, …).
+2. **Guardrails (inbound)** — runs PII / injection / toxicity / topics detectors; block → refuse, mask → rewrite the prompt on the spot.
+3. **Pipeline** — runs the [token savers](#-token-savings-where-the-money-hides) (RTK → Headroom → Terse/Caveman → Ponytail) and checks your budget.
+4. **Dispatch** — picks the best provider account and juggles fallbacks.
+5. **Connector & Transform** — calls the provider, then translates the answer back into your tool's format.
+6. **Guardrails (outbound)** — scans the response (or each stream chunk) for leaked PII, bias, or toxicity; block → cancel, mask → rewrite.
+7. **Meter** — logs token usage and savings so the dashboard has something pretty to show.
+
+---
+
+## 🔒 Security
+
+- The admin API (`/api/*`) only listens to localhost by default. Exposing it? Put it behind a reverse proxy and set a stable `master_key`.
+- **Guard your master key with your life** — it's the root of trust for every encrypted credential.
+- Credentials sit behind AES-256-GCM envelope encryption; the dashboard uses password auth + HMAC session cookies; outbound requests get SSRF protection.
+
+Found a security issue? Please follow [SECURITY.md](SECURITY.md) instead of opening a public issue. 🙏
+
+---
+
+## 🧑‍💻 Hack on it
+
+```bash
+make setup   # first time: installs deps + starts backend (:20180) and dashboard (:5180)
+make dev     # after that: just start the servers
+make test    # run the backend test suite
+make build   # build the backend binary + frontend assets
+```
+
+PRs and ideas are always welcome — start with [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
 
 ## 📄 License
-MIT License - See [LICENSE](LICENSE) for details.
+
+MIT — see [LICENSE](LICENSE). Go build something cool. 🛠️

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -61,6 +62,11 @@ type App struct {
 	guardrailRetention *guardrails.RetentionSweeper
 	meter              *meter.Meter
 	healthChecker      *healthcheck.Checker
+
+	// bg tracks long-lived background workers that touch the DB (oauth
+	// keepalive, health checker, cooldown sweeper) so shutdown can wait for
+	// them to return before closing the store, avoiding a use-after-close race.
+	bg sync.WaitGroup
 }
 
 // Build constructs the application from configuration. It opens the database,
@@ -336,43 +342,43 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 	}, log, db.Accounts(), db.Health(), connRegistry, v)
 
 	gw := gateway.New(gateway.Deps{
-		Config:          cfg,
-		Logger:          log,
-		Version:         version,
-		Updates:         update.NewChecker(version, ""),
-		DB:              db,
-		Identity:        idSvc,
-		Auth:            authSvc,
-		Pipeline:        pipe,
-		Conns:           connRegistry,
-		Chains:          db.Chains(),
-		Aliases:         db.Aliases(),
-		Accounts:        db.Accounts(),
-		Pools:           db.ProxyPools(),
-		Budgets:         db.Budgets(),
-		BudgetEngine:    bud,
-		Usage:           db.Usage(),
-		Resources:       db.Resources(),
-		Settings:        db.Settings(),
-		Vault:           v,
-		Codecs:          codecs,
-		Metrics:         metrics,
-		FrontendDir:     frontendDir,
-		DataDir:         dataDir,
-		CfManager:       cfManager,
-		TsManager:       tsManager,
-		UsageHub:        uh,
-		TimeoutNotifier: timeoutNotifier,
-		ProxyNotifier:   proxyNotifier,
-		RateLimiter:     limiter,
-		Refresher:       tokenRefresher,
+		Config:               cfg,
+		Logger:               log,
+		Version:              version,
+		Updates:              update.NewChecker(version, ""),
+		DB:                   db,
+		Identity:             idSvc,
+		Auth:                 authSvc,
+		Pipeline:             pipe,
+		Conns:                connRegistry,
+		Chains:               db.Chains(),
+		Aliases:              db.Aliases(),
+		Accounts:             db.Accounts(),
+		Pools:                db.ProxyPools(),
+		Budgets:              db.Budgets(),
+		BudgetEngine:         bud,
+		Usage:                db.Usage(),
+		Resources:            db.Resources(),
+		Settings:             db.Settings(),
+		Vault:                v,
+		Codecs:               codecs,
+		Metrics:              metrics,
+		FrontendDir:          frontendDir,
+		DataDir:              dataDir,
+		CfManager:            cfManager,
+		TsManager:            tsManager,
+		UsageHub:             uh,
+		TimeoutNotifier:      timeoutNotifier,
+		ProxyNotifier:        proxyNotifier,
+		RateLimiter:          limiter,
+		Refresher:            tokenRefresher,
 		Guardrails:           guardrailEngine,
 		GuardrailRepo:        db.Guardrails(),
 		GuardrailLogs:        db.GuardrailLogs(),
 		GuardrailHub:         guardrailLogHub,
 		GuardrailTenantFlags: guardrailTenantPolicy,
-		Health:          db.Health(),
-		HealthChecker:   healthChecker,
+		Health:               db.Health(),
+		HealthChecker:        healthChecker,
 	})
 
 	srv := &http.Server{
@@ -451,19 +457,31 @@ func seedFreeAccounts(ctx context.Context, accounts *store.AccountRepo, log *slo
 func (a *App) Run(ctx context.Context) error {
 	// Launch the OAuth keepalive loop so tokens stay fresh between requests.
 	if a.keepAlive != nil {
-		go a.keepAlive.Run(ctx)
+		a.bg.Add(1)
+		go func() {
+			defer a.bg.Done()
+			a.keepAlive.Run(ctx)
+		}()
 	}
 	if a.meter != nil {
 		a.meter.StartAsync(ctx)
 	}
 	if a.healthChecker != nil {
-		go a.healthChecker.Run(ctx, store.DefaultTenantID)
+		a.bg.Add(1)
+		go func() {
+			defer a.bg.Done()
+			a.healthChecker.Run(ctx, store.DefaultTenantID)
+		}()
 	}
 
 	// Background cooldown sweeper: periodically clears expired cooldowns so
 	// accounts recover automatically without a restart.
 	if a.accounts != nil {
-		go a.runCooldownSweeper(ctx)
+		a.bg.Add(1)
+		go func() {
+			defer a.bg.Done()
+			a.runCooldownSweeper(ctx)
+		}()
 	}
 
 	errCh := make(chan error, 1)
@@ -491,6 +509,13 @@ func (a *App) Run(ctx context.Context) error {
 		if err := a.server.Shutdown(shutdownCtx); err != nil {
 			return err
 		}
+		// Wait for background workers that query the DB (oauth keepalive, health
+		// checker, cooldown sweeper) to return before closing the store. They
+		// observe ctx cancellation and exit promptly; the bounded wait prevents
+		// a slow in-flight worker from hanging shutdown while still closing the
+		// use-after-close window against db.Close() (a pure-Go SQLite handle can
+		// crash if a query races a Close).
+		a.waitForBackground(5 * time.Second)
 		// Drain pending guardrail audit and usage rows before closing the DB.
 		if a.guardrailRetention != nil {
 			a.guardrailRetention.Stop(2 * time.Second)
@@ -691,6 +716,22 @@ func buildPricing() map[string]meter.Price {
 // cooldownSweepInterval is how often the background sweeper checks for expired
 // cooldowns. Short enough to recover within seconds; long enough to be trivial.
 const cooldownSweepInterval = 15 * time.Second
+
+// waitForBackground blocks until all tracked background workers have returned
+// or the timeout elapses, whichever comes first. Bounding the wait keeps
+// shutdown responsive even if a worker is stuck in a slow network call.
+func (a *App) waitForBackground(timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		a.bg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		a.log.Warn("background workers did not stop within timeout; proceeding with shutdown")
+	}
+}
 
 // runCooldownSweeper periodically clears expired cooldowns so accounts auto-
 // recover after rate-limit / auth errors without requiring a restart.

--- a/backend/internal/consolelog/consolelog.go
+++ b/backend/internal/consolelog/consolelog.go
@@ -1,19 +1,43 @@
 // Package consolelog provides a thread-safe log buffer that captures request
 // pipeline output and streams it to dashboard clients via SSE.
+//
+// Each record is a structured Entry carrying a short, human-readable message
+// plus an optional Detail block. The dashboard renders the message inline and
+// reveals the detail on demand (click to expand), keeping the live feed easy to
+// scan while still exposing the underlying technical context (raw errors, IDs,
+// timings) when a developer needs it.
 package consolelog
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 )
 
 const maxLines = 500
 
-// Event represents a log update. If Clear is true, the client should clear its buffer.
+// Entry is a single structured console log record.
+type Entry struct {
+	// Seq is a monotonic sequence number, unique per buffer. The dashboard uses
+	// it as a stable React key and to track per-row expansion state across
+	// re-renders and ring-buffer trimming.
+	Seq uint64 `json:"seq"`
+	// Time is the formatted wall-clock time (HH:MM:SS.mmm).
+	Time string `json:"time"`
+	// Level is one of DEBUG, INFO, WARN, ERROR, LOG.
+	Level string `json:"level"`
+	// Message is the short, human-readable summary shown inline.
+	Message string `json:"msg"`
+	// Detail is optional technical context revealed when the row is expanded
+	// (raw error text, identifiers, byte counts, etc.). Empty when there is
+	// nothing extra to show.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Event represents a log update. If Clear is true, the client should clear its
+// buffer; otherwise Entry holds the appended record.
 type Event struct {
-	Line  string
+	Entry Entry
 	Clear bool
 }
 
@@ -31,49 +55,57 @@ func NewListener(bufSize int) *Listener {
 	return &Listener{C: make(chan Event, bufSize)}
 }
 
-// Buffer is a ring buffer of log lines with pub/sub for SSE streaming.
+// Buffer is a ring buffer of log entries with pub/sub for SSE streaming.
 type Buffer struct {
 	mu        sync.RWMutex
-	lines     []string
+	entries   []Entry
 	listeners map[*Listener]struct{}
+	seq       uint64 // guarded by mu; monotonic entry counter
 }
 
 // New creates an empty log buffer.
 func New() *Buffer {
 	return &Buffer{
-		lines:     make([]string, 0, 128),
+		entries:   make([]Entry, 0, 128),
 		listeners: make(map[*Listener]struct{}),
 	}
 }
 
-// Lines returns a snapshot of all buffered log lines.
-func (b *Buffer) Lines() []string {
+// Entries returns a snapshot of all buffered log entries.
+func (b *Buffer) Entries() []Entry {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
-	out := make([]string, len(b.lines))
-	copy(out, b.lines)
+	out := make([]Entry, len(b.entries))
+	copy(out, b.entries)
 	return out
 }
 
-// Append adds a log line and notifies all listeners.
-func (b *Buffer) Append(line string) {
+// add appends an entry and notifies all listeners.
+func (b *Buffer) add(level, message, detail string) {
 	b.mu.Lock()
-	b.lines = append(b.lines, line)
-	if len(b.lines) > maxLines {
+	b.seq++
+	e := Entry{
+		Seq:     b.seq,
+		Time:    time.Now().Format("15:04:05.000"),
+		Level:   level,
+		Message: message,
+		Detail:  detail,
+	}
+	b.entries = append(b.entries, e)
+	if len(b.entries) > maxLines {
 		// Use copy instead of sub-slicing to release the old backing array for GC.
-		n := copy(b.lines, b.lines[len(b.lines)-maxLines:])
-		b.lines = b.lines[:n]
+		n := copy(b.entries, b.entries[len(b.entries)-maxLines:])
+		b.entries = b.entries[:n]
 	}
 	b.mu.Unlock()
 
-	ev := Event{Line: line}
-	b.publish(ev)
+	b.publish(Event{Entry: e})
 }
 
 // Clear resets the buffer and notifies all listeners.
 func (b *Buffer) Clear() {
 	b.mu.Lock()
-	b.lines = b.lines[:0]
+	b.entries = b.entries[:0]
 	b.mu.Unlock()
 
 	b.publish(Event{Clear: true})
@@ -106,16 +138,15 @@ func (b *Buffer) Unsubscribe(l *Listener) {
 	b.mu.Unlock()
 }
 
-// Logf appends a formatted log line with timestamp and level tag.
+// Log appends a human-readable message at the given level with an optional
+// detail block. Pass an empty detail when there is nothing extra to surface.
 // Levels: LOG, INFO, WARN, ERROR, DEBUG.
+func (b *Buffer) Log(level, message, detail string) {
+	b.add(level, message, detail)
+}
+
+// Logf appends a formatted, message-only log line (no detail block). Retained
+// for call sites that only need a one-liner.
 func (b *Buffer) Logf(level, format string, args ...any) {
-	var sb strings.Builder
-	sb.Grow(128)
-	sb.WriteByte('[')
-	sb.WriteString(time.Now().Format("15:04:05.000"))
-	sb.WriteString("] [")
-	sb.WriteString(level)
-	sb.WriteString("] ")
-	fmt.Fprintf(&sb, format, args...)
-	b.Append(sb.String())
+	b.add(level, fmt.Sprintf(format, args...), "")
 }

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -94,6 +94,7 @@ func (s *Server) mountAdmin(r chi.Router) {
 
 	r.Get("/settings/endpoint", s.adminGetEndpointSettings)
 	r.Post("/settings/endpoint", s.adminUpdateEndpointSettings)
+	r.Post("/settings/headroom-test", s.adminTestHeadroom)
 	r.Get("/settings/access", s.adminGetAccessSettings)
 	r.Post("/settings/access", s.adminUpdateAccessSettings)
 	r.Get("/settings/database", s.adminExportDatabase)
@@ -1801,8 +1802,8 @@ func (s *Server) adminConsoleStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Accel-Buffering", "no")
 
 	// Send initial history.
-	lines := s.consoleLog.Lines()
-	initData, _ := json.Marshal(map[string]any{"type": "init", "logs": lines})
+	entries := s.consoleLog.Entries()
+	initData, _ := json.Marshal(map[string]any{"type": "init", "logs": entries})
 	fmt.Fprintf(w, "data: %s\n\n", initData)
 	flusher.Flush()
 
@@ -1824,7 +1825,7 @@ func (s *Server) adminConsoleStream(w http.ResponseWriter, r *http.Request) {
 			if ev.Clear {
 				data, _ = json.Marshal(map[string]any{"type": "clear"})
 			} else {
-				data, _ = json.Marshal(map[string]any{"type": "line", "line": ev.Line})
+				data, _ = json.Marshal(map[string]any{"type": "line", "log": ev.Entry})
 			}
 			fmt.Fprintf(w, "data: %s\n\n", data)
 			flusher.Flush()
@@ -1866,7 +1867,7 @@ func (s *Server) adminExportDatabase(w http.ResponseWriter, r *http.Request) {
 		}
 		if portable {
 			if err := s.exportPortableSecrets(out, a, passphrase); err != nil {
-				s.consoleLog.Logf("ERROR", "portable export failed for account %s: %v", a.ID, err)
+				s.consoleLog.Log("ERROR", fmt.Sprintf("Portable export failed for account %s", a.ID), err.Error())
 				writeError(w, http.StatusInternalServerError, "portable export failed: cannot re-key account "+a.ID+" (master key mismatch?)")
 				return
 			}
@@ -2030,7 +2031,7 @@ func (s *Server) adminImportDatabase(w http.ResponseWriter, r *http.Request) {
 				}
 				if portable {
 					if err := s.importPortableSecrets(&acc, a.PortableSecret, passphrase); err != nil {
-						s.consoleLog.Logf("ERROR", "portable import failed for account %s: %v", acc.ID, err)
+						s.consoleLog.Log("ERROR", fmt.Sprintf("Portable import failed for account %s", acc.ID), err.Error())
 						writeError(w, http.StatusBadRequest, "portable import failed: wrong passphrase or corrupt backup")
 						return
 					}

--- a/backend/internal/gateway/console_format.go
+++ b/backend/internal/gateway/console_format.go
@@ -1,0 +1,71 @@
+package gateway
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// This file holds small presentation helpers used to render the human-readable
+// console log shown on the dashboard. They format raw numbers (bytes, durations,
+// token counts) into something a person can scan at a glance.
+
+// humanBytes formats a byte count using binary units (B, KB, MB, ...).
+func humanBytes(n int) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := int64(n) / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+// humanDuration formats a millisecond duration as a compact, readable string.
+func humanDuration(ms int) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	secs := float64(ms) / 1000
+	if secs < 60 {
+		return fmt.Sprintf("%.1fs", secs)
+	}
+	mins := int(secs) / 60
+	rem := secs - float64(mins*60)
+	return fmt.Sprintf("%dm %.0fs", mins, rem)
+}
+
+// humanInt formats an integer with thousands separators (e.g. 45119 -> 45,119).
+func humanInt(n int) string {
+	s := strconv.Itoa(n)
+	neg := strings.HasPrefix(s, "-")
+	if neg {
+		s = s[1:]
+	}
+	var b strings.Builder
+	pre := len(s) % 3
+	if pre > 0 {
+		b.WriteString(s[:pre])
+	}
+	for i := pre; i < len(s); i += 3 {
+		if b.Len() > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(s[i : i+3])
+	}
+	if neg {
+		return "-" + b.String()
+	}
+	return b.String()
+}
+
+// plural returns "s" when n != 1, for simple pluralization.
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/backend/internal/gateway/gemini.go
+++ b/backend/internal/gateway/gemini.go
@@ -90,6 +90,8 @@ func (s *Server) handleGeminiGenerate(w http.ResponseWriter, r *http.Request) {
 		Slimmer:  s.slimmerConfig(),
 		Terse:    s.terseConfig(),
 		Caveman:  s.cavemanConfig(),
+		Headroom: s.headroomConfig(),
+		Ponytail: s.ponytailConfig(),
 	}
 
 	if req.Stream {

--- a/backend/internal/gateway/handlers.go
+++ b/backend/internal/gateway/handlers.go
@@ -33,22 +33,31 @@ func (s *Server) logRequest(keyName, provider, model string, tokens int, costMic
 	if s.consoleLog == nil {
 		return
 	}
-	level := "INFO"
+
 	if err != nil {
-		level = "ERROR"
-	} else if latencyMs > 8000 {
+		detail := fmt.Sprintf("Key:      %s\nProvider: %s\nModel:    %s\nLatency:  %dms\n\n%v",
+			keyName, provider, model, latencyMs, err)
+		s.consoleLog.Log("ERROR",
+			fmt.Sprintf("Request failed · %s · %s", model, humanDuration(latencyMs)),
+			detail)
+		return
+	}
+
+	level := "INFO"
+	if latencyMs > 8000 {
 		level = "WARN"
 	}
 	cost := float64(costMicros) / 1_000_000
-	cache := ""
+	cacheNote := ""
 	if cacheHit {
-		cache = " · cache"
+		cacheNote = " · cache hit"
 	}
-	s.consoleLog.Logf(level, "[%s] %s · %s · %d tok · $%.4f · %dms%s",
-		keyName, provider, model, tokens, cost, latencyMs, cache)
-	if err != nil {
-		s.consoleLog.Logf("ERROR", "  └─ %v", err)
-	}
+	msg := fmt.Sprintf("Request completed · %s · %s tokens · $%.4f · %s%s",
+		model, humanInt(tokens), cost, humanDuration(latencyMs), cacheNote)
+	detail := fmt.Sprintf(
+		"Key:      %s\nProvider: %s\nModel:    %s\nTokens:   %s\nCost:     $%.4f\nLatency:  %dms\nCache:    %v",
+		keyName, provider, model, humanInt(tokens), cost, latencyMs, cacheHit)
+	s.consoleLog.Log(level, msg, detail)
 }
 
 // handleOpenAIChat serves /v1/chat/completions in the OpenAI dialect.
@@ -135,27 +144,29 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request, dialect core
 	tenantID := tenantOf(key)
 	client := detectClient(r)
 
-	s.consoleLog.Logf("DEBUG", "→ %s %s · dialect=%s · client=%s · key=%s (%s)",
-		r.Method, r.URL.Path, dialect, client, key.Name, key.ID)
+	s.consoleLog.Log("DEBUG",
+		fmt.Sprintf("New request from %q (%s API)", client, dialect),
+		fmt.Sprintf("Method: %s\nPath:   %s\nClient: %s\nDialect: %s\nKey:    %s (%s)",
+			r.Method, r.URL.Path, client, dialect, key.Name, key.ID))
 
 	codec, err := s.codecs.Codec(dialect)
 	if err != nil {
-		s.consoleLog.Logf("ERROR", "unsupported dialect: %s", dialect)
+		s.consoleLog.Log("ERROR", fmt.Sprintf("Unsupported API dialect: %s", dialect), "")
 		writeError(w, http.StatusInternalServerError, "unsupported dialect")
 		return
 	}
 
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBodyBytes))
 	if err != nil {
-		s.consoleLog.Logf("ERROR", "failed to read body: %v", err)
+		s.consoleLog.Log("ERROR", "Failed to read request body", err.Error())
 		writeError(w, http.StatusBadRequest, "failed to read request body")
 		return
 	}
-	s.consoleLog.Logf("DEBUG", "  body read: %d bytes", len(body))
+	s.consoleLog.Log("DEBUG", fmt.Sprintf("Read request body (%s)", humanBytes(len(body))), "")
 
 	req, err := codec.ParseRequest(body)
 	if err != nil {
-		s.consoleLog.Logf("ERROR", "parse failed: %v", err)
+		s.consoleLog.Log("ERROR", "Failed to parse request body", err.Error())
 		writeError(w, http.StatusBadRequest, "invalid request: "+err.Error())
 		return
 	}
@@ -170,18 +181,24 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request, dialect core
 		RequestID:     chimiddleware.GetReqID(r.Context()),
 	}
 
-	s.consoleLog.Logf("DEBUG", "  model=%s · stream=%v · messages=%d · tenant=%s · key=%s (%s)",
-		req.Model, req.Stream, len(req.Messages), tenantID, key.Name, key.ID)
+	streamNote := ""
+	if req.Stream {
+		streamNote = " · streaming"
+	}
+	s.consoleLog.Log("DEBUG",
+		fmt.Sprintf("Routing %q · %d message%s%s", req.Model, len(req.Messages), plural(len(req.Messages)), streamNote),
+		fmt.Sprintf("Model:    %s\nMessages: %d\nStream:   %v\nTenant:   %s\nKey:      %s (%s)",
+			req.Model, len(req.Messages), req.Stream, tenantID, key.Name, key.ID))
 
 	resolved, err := resolveTargets(r.Context(), s.chains, s.aliases, tenantID, req.Model)
 	if err != nil {
 		var bad badModelError
 		if errors.As(err, &bad) {
-			s.consoleLog.Logf("WARN", "bad model: %s", bad.Error())
+			s.consoleLog.Log("WARN", fmt.Sprintf("Unknown model %q", req.Model), bad.Error())
 			writeError(w, http.StatusBadRequest, bad.Error())
 			return
 		}
-		s.consoleLog.Logf("ERROR", "resolve targets failed: %v", err)
+		s.consoleLog.Log("ERROR", fmt.Sprintf("Failed to resolve model %q", req.Model), err.Error())
 		writeError(w, http.StatusInternalServerError, "failed to resolve model")
 		return
 	}
@@ -200,20 +217,34 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request, dialect core
 	if len(resolved.Targets) > 0 {
 		filtered, ferr := s.filterAllowedTargets(r.Context(), key.ID, resolved.Targets)
 		if ferr != nil {
-			s.consoleLog.Logf("ERROR", "model access check failed: %v", ferr)
+			s.consoleLog.Log("ERROR", "Model access check failed", ferr.Error())
 			writeError(w, http.StatusInternalServerError, "model access check failed")
 			return
 		}
 		if len(filtered) == 0 {
-			s.consoleLog.Logf("WARN", "model access denied: key=%s (%s) model=%s", key.Name, key.ID, req.Model)
+			s.consoleLog.Log("WARN",
+				fmt.Sprintf("Access denied · key %q may not use %q", key.Name, req.Model),
+				fmt.Sprintf("Key:   %s (%s)\nModel: %s", key.Name, key.ID, req.Model))
 			writeError(w, http.StatusForbidden, "access denied: this API key is not permitted to use model "+req.Model)
 			return
 		}
 		resolved.Targets = filtered
 	}
 
-	for i, t := range resolved.Targets {
-		s.consoleLog.Logf("DEBUG", "  target[%d]: %s/%s", i, t.Provider, t.Model)
+	if len(resolved.Targets) > 0 {
+		primary := resolved.Targets[0]
+		var tb strings.Builder
+		for i, t := range resolved.Targets {
+			if i > 0 {
+				tb.WriteByte('\n')
+			}
+			fmt.Fprintf(&tb, "%d. %s/%s", i+1, t.Provider, t.Model)
+		}
+		msg := fmt.Sprintf("Resolved to %s/%s", primary.Provider, primary.Model)
+		if len(resolved.Targets) > 1 {
+			msg = fmt.Sprintf("%s (+%d fallback%s)", msg, len(resolved.Targets)-1, plural(len(resolved.Targets)-1))
+		}
+		s.consoleLog.Log("DEBUG", msg, tb.String())
 	}
 	affinityKey := requestAffinityKey(r, req)
 	req.Metadata.ContextAffinityKey = affinityKey
@@ -221,7 +252,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request, dialect core
 
 	effectiveLimits, err := s.effectiveLimits(r.Context(), key)
 	if err != nil {
-		s.consoleLog.Logf("ERROR", "limit resolution failed: %v", err)
+		s.consoleLog.Log("ERROR", "Failed to resolve rate limits", err.Error())
 		writeError(w, http.StatusInternalServerError, "limit resolution failed")
 		return
 	}
@@ -232,15 +263,17 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request, dialect core
 		Slimmer:  s.slimmerConfig(),
 		Terse:    s.terseConfig(),
 		Caveman:  s.cavemanConfig(),
+		Headroom: s.headroomConfig(),
+		Ponytail: s.ponytailConfig(),
 		Limits:   effectiveLimits,
 	}
 
 	if req.Stream {
-		s.consoleLog.Logf("DEBUG", "  entering stream path")
+		s.consoleLog.Log("DEBUG", "Dispatching as streaming response", "")
 		s.streamChat(w, r, codec, req, opts, key.Name)
 		return
 	}
-	s.consoleLog.Logf("DEBUG", "  entering unary path")
+	s.consoleLog.Log("DEBUG", "Dispatching as standard response", "")
 	s.unaryChat(w, r, codec, req, opts, key.Name)
 }
 
@@ -266,11 +299,11 @@ func (s *Server) effectiveLimits(ctx context.Context, key store.APIKey) (limits.
 // unaryChat runs a non-streaming request and renders the response.
 func (s *Server) unaryChat(w http.ResponseWriter, r *http.Request, codec transform.Codec, req *core.ChatRequest, opts pipeline.Options, keyName string) {
 	start := time.Now()
-	s.consoleLog.Logf("DEBUG", "  ▶ pipeline.Chat() start")
+	s.consoleLog.Log("DEBUG", "Sending request to provider…", "")
 	result, err := s.pipeline.Chat(r.Context(), req, opts)
 	latency := int(time.Since(start).Milliseconds())
 	if err != nil {
-		s.consoleLog.Logf("ERROR", "  ✖ pipeline.Chat() failed after %dms: %v", latency, err)
+		s.consoleLog.Log("ERROR", fmt.Sprintf("Provider request failed after %s", humanDuration(latency)), err.Error())
 		s.logRequest(keyName, req.Model, req.Model, 0, 0, latency, false, err)
 		s.writeProviderError(w, err)
 		return
@@ -278,13 +311,15 @@ func (s *Server) unaryChat(w http.ResponseWriter, r *http.Request, codec transfo
 
 	out, err := codec.RenderResponse(result.Response)
 	if err != nil {
-		s.consoleLog.Logf("ERROR", "  ✖ render failed: %v", err)
+		s.consoleLog.Log("ERROR", "Failed to render provider response", err.Error())
 		writeError(w, http.StatusInternalServerError, "failed to render response")
 		return
 	}
 	tokens := result.Response.Usage.PromptTokens + result.Response.Usage.CompletionTokens
-	s.consoleLog.Logf("DEBUG", "  ✔ [%s] %s/%s · %d tok · acct=%s · cache=%v · %dms",
-		keyName, result.Provider, result.Model, tokens, result.AccountID, result.CacheHit, latency)
+	s.consoleLog.Log("DEBUG",
+		fmt.Sprintf("Response from %s/%s · %s tokens · %s", result.Provider, result.Model, humanInt(tokens), humanDuration(latency)),
+		fmt.Sprintf("Provider: %s\nModel:    %s\nTokens:   %s\nAccount:  %s\nCache:    %v\nLatency:  %dms",
+			result.Provider, result.Model, humanInt(tokens), result.AccountID, result.CacheHit, latency))
 	s.logRequest(keyName, result.Provider, result.Model, tokens, result.CostMicros, latency, result.CacheHit, nil)
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-KeiRouter-Provider", result.Provider)
@@ -312,17 +347,18 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 	}
 
 	start := time.Now()
-	s.consoleLog.Logf("DEBUG", "  ▶ pipeline.Stream() start")
+	s.consoleLog.Log("DEBUG", "Opening stream to provider…", "")
 	result, err := s.pipeline.Stream(r.Context(), req, opts)
 	if err != nil {
 		latency := int(time.Since(start).Milliseconds())
-		s.consoleLog.Logf("ERROR", "  ✖ pipeline.Stream() failed after %dms: %v", latency, err)
+		s.consoleLog.Log("ERROR", fmt.Sprintf("Stream failed to start after %s", humanDuration(latency)), err.Error())
 		s.logRequest(keyName, req.Model, req.Model, 0, 0, latency, false, err)
 		s.writeProviderError(w, err)
 		return
 	}
-	s.consoleLog.Logf("DEBUG", "  ✔ [%s] stream connected: %s/%s · acct=%s",
-		keyName, result.Provider, result.Model, result.AccountID)
+	s.consoleLog.Log("DEBUG",
+		fmt.Sprintf("Streaming from %s/%s", result.Provider, result.Model),
+		fmt.Sprintf("Provider: %s\nModel:    %s\nAccount:  %s", result.Provider, result.Model, result.AccountID))
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -340,7 +376,7 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 		defer result.DirectBody.Close()
 		n, cpErr := io.Copy(w, result.DirectBody)
 		if cpErr != nil && !isClientDisconnect(cpErr) {
-			s.consoleLog.Logf("ERROR", "  ✖ direct pipe error after %d bytes: %v", n, cpErr)
+			s.consoleLog.Log("ERROR", fmt.Sprintf("Stream interrupted after %s", humanBytes(int(n))), cpErr.Error())
 			s.log.Warn("direct pipe error", "bytes", n, "err", cpErr)
 		}
 		flusher.Flush()
@@ -351,7 +387,7 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 			result.DirectUsageFunc()
 		}
 		latency := int(time.Since(start).Milliseconds())
-		s.consoleLog.Logf("DEBUG", "  ✔ [%s] direct pipe done: %d bytes · %dms", keyName, n, latency)
+		s.consoleLog.Log("DEBUG", fmt.Sprintf("Stream finished · %s · %s", humanBytes(int(n)), humanDuration(latency)), "")
 		s.logRequest(keyName, result.Provider, result.Model, 0, 0, latency, false, nil)
 		return
 	}
@@ -400,7 +436,7 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 				}
 				for _, ev := range events {
 					if _, werr := bw.Write(ev); werr != nil {
-						s.consoleLog.Logf("WARN", "  client disconnected after %d chunks", chunkCount)
+						s.consoleLog.Log("WARN", fmt.Sprintf("Client disconnected after %d chunks", chunkCount), "")
 						return
 					}
 				}
@@ -416,7 +452,7 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 		}
 		for _, ev := range events {
 			if _, werr := bw.Write(ev); werr != nil {
-				s.consoleLog.Logf("WARN", "  client disconnected after %d chunks", chunkCount)
+				s.consoleLog.Log("WARN", fmt.Sprintf("Client disconnected after %d chunks", chunkCount), "")
 				return
 			}
 		}
@@ -428,7 +464,7 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 
 	for chunk := range result.Chunks {
 		if chunk.Type == core.ChunkError {
-			s.consoleLog.Logf("ERROR", "  ✖ stream chunk error: %v", chunk.Err)
+			s.consoleLog.Log("ERROR", "Provider stream error", fmt.Sprintf("%v", chunk.Err))
 			s.log.Warn("stream error", "err", chunk.Err)
 			break
 		}
@@ -461,7 +497,10 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 	flusher.Flush()
 
 	latency := int(time.Since(streamStart).Milliseconds())
-	s.consoleLog.Logf("DEBUG", "  ✔ [%s] stream done: %d chunks · %d tok · %dms", keyName, chunkCount, totalTokens, latency)
+	s.consoleLog.Log("DEBUG",
+		fmt.Sprintf("Stream complete · %d chunks · %s tokens · %s", chunkCount, humanInt(totalTokens), humanDuration(latency)),
+		fmt.Sprintf("Provider: %s\nModel:    %s\nChunks:   %d\nTokens:   %s\nLatency:  %dms",
+			result.Provider, result.Model, chunkCount, humanInt(totalTokens), latency))
 	s.logRequest(keyName, result.Provider, result.Model, totalTokens, 0, latency, false, nil)
 }
 

--- a/backend/internal/gateway/insights.go
+++ b/backend/internal/gateway/insights.go
@@ -222,17 +222,20 @@ func (s *Server) adminUsageInsights(w http.ResponseWriter, r *http.Request) {
 	for _, cs := range clientSavings {
 		// Skip clients that produced no optimization at all, so the breakdown
 		// shows only where optimization actually helped.
-		if cs.SlimTokensSaved == 0 && cs.CavemanRequests == 0 && cs.TerseRequests == 0 {
+		if cs.SlimTokensSaved == 0 && cs.CavemanRequests == 0 && cs.TerseRequests == 0 &&
+			cs.HeadroomTokensSaved == 0 && cs.PonytailRequests == 0 {
 			continue
 		}
 		byClient = append(byClient, map[string]any{
-			"client":           cs.Client,
-			"requests":         cs.Requests,
-			"bytes_saved":      cs.SlimBytesSaved,
-			"tokens_saved":     cs.SlimTokensSaved,
-			"usd_saved":        usdPerToken(cs.SlimTokensSaved),
-			"caveman_requests": cs.CavemanRequests,
-			"terse_requests":   cs.TerseRequests,
+			"client":                cs.Client,
+			"requests":              cs.Requests,
+			"bytes_saved":           cs.SlimBytesSaved,
+			"tokens_saved":          cs.SlimTokensSaved,
+			"usd_saved":             usdPerToken(cs.SlimTokensSaved),
+			"caveman_requests":      cs.CavemanRequests,
+			"terse_requests":        cs.TerseRequests,
+			"headroom_tokens_saved": cs.HeadroomTokensSaved,
+			"ponytail_requests":     cs.PonytailRequests,
 		})
 	}
 
@@ -251,14 +254,17 @@ func (s *Server) adminUsageInsights(w http.ResponseWriter, r *http.Request) {
 			"since":              since,
 		},
 		"savings": map[string]any{
-			"slim_bytes_saved":   sum.SlimBytesSaved,
-			"slim_tokens_saved":  sum.SlimTokensSaved,
-			"caveman_requests":   sum.CavemanRequests,
-			"terse_requests":     sum.TerseRequests,
-			"usd_saved":          usdPerToken(sum.SlimTokensSaved),
-			"usd_saved_estimate": true,
-			"rules":              rules,
-			"by_client":          byClient,
+			"slim_bytes_saved":      sum.SlimBytesSaved,
+			"slim_tokens_saved":     sum.SlimTokensSaved,
+			"caveman_requests":      sum.CavemanRequests,
+			"terse_requests":        sum.TerseRequests,
+			"headroom_tokens_saved": sum.HeadroomTokensSaved,
+			"headroom_requests":     sum.HeadroomRequests,
+			"ponytail_requests":     sum.PonytailRequests,
+			"usd_saved":             usdPerToken(sum.SlimTokensSaved),
+			"usd_saved_estimate":    true,
+			"rules":                 rules,
+			"by_client":             byClient,
 		},
 		"providers": providers,
 		"recent":    recentRows,
@@ -524,8 +530,7 @@ func (s *Server) adminUsageStream(w http.ResponseWriter, r *http.Request) {
 
 // adminConsoleLog returns the buffered log lines from the console log.
 func (s *Server) adminConsoleLog(w http.ResponseWriter, r *http.Request) {
-	lines := s.consoleLog.Lines()
-	writeJSON(w, http.StatusOK, map[string]any{"logs": lines})
+	writeJSON(w, http.StatusOK, map[string]any{"logs": s.consoleLog.Entries()})
 }
 
 // ---- proxy pools ------------------------------------------------------------

--- a/backend/internal/gateway/middleware.go
+++ b/backend/internal/gateway/middleware.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -36,16 +37,18 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		key, err := s.identity.Authenticate(r.Context(), token)
 		if err != nil {
 			if errors.Is(err, identity.ErrUnauthorized) {
-				s.consoleLog.Logf("WARN", "auth rejected: invalid key for %s %s", r.Method, r.URL.Path)
+				s.consoleLog.Log("WARN", "Rejected request · invalid API key",
+					fmt.Sprintf("%s %s", r.Method, r.URL.Path))
 				writeError(w, http.StatusUnauthorized, "invalid API key")
 				return
 			}
 			s.log.Error("auth lookup failed", "err", err)
-			s.consoleLog.Logf("ERROR", "auth lookup failed: %v", err)
+			s.consoleLog.Log("ERROR", "Authentication lookup failed", err.Error())
 			writeError(w, http.StatusInternalServerError, "authentication error")
 			return
 		}
-		s.consoleLog.Logf("DEBUG", "auth ok: key=%s (%s) · %s %s", key.Name, key.ID, r.Method, r.URL.Path)
+		s.consoleLog.Log("DEBUG", fmt.Sprintf("Authenticated key %q", key.Name),
+			fmt.Sprintf("Key:     %s (%s)\nRequest: %s %s", key.Name, key.ID, r.Method, r.URL.Path))
 
 		ctx := context.WithValue(r.Context(), apiKeyCtxKey, key)
 		next.ServeHTTP(w, r.WithContext(ctx))

--- a/backend/internal/gateway/settings.go
+++ b/backend/internal/gateway/settings.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -11,6 +13,8 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/caveman"
 	"github.com/mydisha/keirouter/backend/internal/connectors"
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
+	"github.com/mydisha/keirouter/backend/internal/headroom"
+	"github.com/mydisha/keirouter/backend/internal/ponytail"
 	"github.com/mydisha/keirouter/backend/internal/slimmer"
 	"github.com/mydisha/keirouter/backend/internal/terse"
 )
@@ -35,6 +39,16 @@ type EndpointSettings struct {
 	// the compact TERSE format for token-efficient context.
 	TerseEnabled bool   `json:"terse_enabled"`
 	TerseLevel   string `json:"terse_level"`
+
+	// Headroom (input-side proxy compression).
+	HeadroomEnabled              bool   `json:"headroom_enabled"`
+	HeadroomURL                  string `json:"headroom_url"`
+	HeadroomCompressUserMessages bool   `json:"headroom_compress_user_messages"`
+	HeadroomTimeoutMs            int    `json:"headroom_timeout_ms"`
+
+	// Ponytail (output-side system-prompt injection).
+	PonytailEnabled bool   `json:"ponytail_enabled"`
+	PonytailLevel   string `json:"ponytail_level"` // "lite" | "full" | "ultra"
 
 	// Routing strategy fields.
 	RoutingStrategy  string `json:"routing_strategy"`   // "fill-first" | "round-robin" | "smart-round-robin"
@@ -67,19 +81,25 @@ type EndpointSettings struct {
 // defaultEndpointSettings returns the defaults: RTK on, caveman/terse off.
 func defaultEndpointSettings() EndpointSettings {
 	return EndpointSettings{
-		RTKEnabled:           true,
-		RTKFilterLevel:       "none",
-		CavemanEnabled:       false,
-		CavemanLevel:         string(caveman.LevelFull),
-		TerseEnabled:         false,
-		TerseLevel:           "medium",
-		StickyLimit:          3,
-		ComboStrategy:        "fallback",
-		ComboStickyLimit:     1,
-		OutboundProxyEnabled: false,
-		OutboundProxyURL:     "",
-		OutboundNoProxy:      "",
-		RateLimitsEnabled:    true,
+		RTKEnabled:                   true,
+		RTKFilterLevel:               "none",
+		CavemanEnabled:               false,
+		CavemanLevel:                 string(caveman.LevelFull),
+		TerseEnabled:                 false,
+		TerseLevel:                   "medium",
+		HeadroomEnabled:              false,
+		HeadroomURL:                  "",
+		HeadroomCompressUserMessages: false,
+		HeadroomTimeoutMs:            3000,
+		PonytailEnabled:              false,
+		PonytailLevel:                string(ponytail.LevelFull),
+		StickyLimit:                  3,
+		ComboStrategy:                "fallback",
+		ComboStickyLimit:             1,
+		OutboundProxyEnabled:         false,
+		OutboundProxyURL:             "",
+		OutboundNoProxy:              "",
+		RateLimitsEnabled:            true,
 		// Timeout defaults (ms). Generous bounds to
 		// accommodate slow upstream providers and reasoning models.
 		// Keep account routing context-sticky by default: repeated turns from
@@ -152,6 +172,15 @@ func (s *Server) loadEndpointSettings(ctx context.Context) EndpointSettings {
 	if es.RequestTimeoutMs == 0 {
 		es.RequestTimeoutMs = def.RequestTimeoutMs
 	}
+	// Backfill saver defaults for settings that predate this feature. The
+	// remaining Headroom/Ponytail fields use Go zero-values (false/"") that
+	// already match their defaults.
+	if es.HeadroomTimeoutMs == 0 {
+		es.HeadroomTimeoutMs = def.HeadroomTimeoutMs
+	}
+	if es.PonytailLevel == "" {
+		es.PonytailLevel = def.PonytailLevel
+	}
 	return es
 }
 
@@ -176,11 +205,73 @@ func (s *Server) cavemanConfig() caveman.Config {
 	return caveman.Config{Enabled: es.CavemanEnabled, Level: caveman.Level(es.CavemanLevel)}
 }
 
+// headroomConfig resolves Headroom (input-side proxy compression) settings.
+func (s *Server) headroomConfig() headroom.Config {
+	es := s.loadEndpointSettings(context.Background())
+	return headroom.Config{
+		Enabled:              es.HeadroomEnabled,
+		URL:                  es.HeadroomURL,
+		CompressUserMessages: es.HeadroomCompressUserMessages,
+		Timeout:              time.Duration(es.HeadroomTimeoutMs) * time.Millisecond,
+	}
+}
+
+// ponytailConfig resolves Ponytail (output-side system-prompt injection) settings.
+func (s *Server) ponytailConfig() ponytail.Config {
+	es := s.loadEndpointSettings(context.Background())
+	return ponytail.Config{Enabled: es.PonytailEnabled, Level: ponytail.Level(es.PonytailLevel)}
+}
+
 // ---- admin endpoints --------------------------------------------------------
 
 // adminGetEndpointSettings returns the current token-saving preferences.
 func (s *Server) adminGetEndpointSettings(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.loadEndpointSettings(r.Context()))
+}
+
+// adminTestHeadroom probes a Headroom proxy to confirm it is running. It accepts
+// an optional JSON body {"url": "...", "timeout_ms": N}; when omitted it falls
+// back to the saved Headroom settings. This lets the dashboard validate a proxy
+// before (or after) saving, without ever leaking credentials: the probe result
+// only carries a masked endpoint.
+func (s *Server) adminTestHeadroom(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		URL       *string `json:"url"`
+		TimeoutMs *int    `json:"timeout_ms"`
+	}
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+	}
+
+	es := s.loadEndpointSettings(r.Context())
+
+	url := es.HeadroomURL
+	if body.URL != nil {
+		url = *body.URL
+	}
+	if strings.TrimSpace(url) == "" {
+		writeError(w, http.StatusBadRequest, "headroom_url is required to test the connection")
+		return
+	}
+
+	timeoutMs := es.HeadroomTimeoutMs
+	if body.TimeoutMs != nil {
+		timeoutMs = *body.TimeoutMs
+	}
+	if timeoutMs < 1000 || timeoutMs > 60000 {
+		writeError(w, http.StatusBadRequest, "headroom_timeout_ms must be between 1000 and 60000 ms")
+		return
+	}
+
+	result := headroom.New(nil).Probe(r.Context(), headroom.Config{
+		Enabled: true,
+		URL:     url,
+		Timeout: time.Duration(timeoutMs) * time.Millisecond,
+	})
+	writeJSON(w, http.StatusOK, result)
 }
 
 // adminUpdateEndpointSettings persists token-saving preferences. It accepts a
@@ -193,12 +284,20 @@ func (s *Server) adminUpdateEndpointSettings(w http.ResponseWriter, r *http.Requ
 	current := s.loadEndpointSettings(r.Context())
 
 	var patch struct {
-		RTKEnabled              *bool   `json:"rtk_enabled"`
-		RTKFilterLevel          *string `json:"rtk_filter_level"`
-		CavemanEnabled          *bool   `json:"caveman_enabled"`
-		CavemanLevel            *string `json:"caveman_level"`
-		TerseEnabled            *bool   `json:"terse_enabled"`
-		TerseLevel              *string `json:"terse_level"`
+		RTKEnabled     *bool   `json:"rtk_enabled"`
+		RTKFilterLevel *string `json:"rtk_filter_level"`
+		CavemanEnabled *bool   `json:"caveman_enabled"`
+		CavemanLevel   *string `json:"caveman_level"`
+		TerseEnabled   *bool   `json:"terse_enabled"`
+		TerseLevel     *string `json:"terse_level"`
+
+		HeadroomEnabled              *bool   `json:"headroom_enabled"`
+		HeadroomURL                  *string `json:"headroom_url"`
+		HeadroomCompressUserMessages *bool   `json:"headroom_compress_user_messages"`
+		HeadroomTimeoutMs            *int    `json:"headroom_timeout_ms"`
+		PonytailEnabled              *bool   `json:"ponytail_enabled"`
+		PonytailLevel                *string `json:"ponytail_level"`
+
 		RoutingStrategy         *string `json:"routing_strategy"`
 		StickyLimit             *int    `json:"sticky_limit"`
 		ComboStrategy           *string `json:"combo_strategy"`
@@ -247,6 +346,39 @@ func (s *Server) adminUpdateEndpointSettings(w http.ResponseWriter, r *http.Requ
 			return
 		}
 		current.TerseLevel = *patch.TerseLevel
+	}
+	if patch.HeadroomEnabled != nil {
+		current.HeadroomEnabled = *patch.HeadroomEnabled
+	}
+	if patch.HeadroomURL != nil {
+		current.HeadroomURL = *patch.HeadroomURL
+	}
+	if patch.HeadroomCompressUserMessages != nil {
+		current.HeadroomCompressUserMessages = *patch.HeadroomCompressUserMessages
+	}
+	if patch.HeadroomTimeoutMs != nil {
+		if *patch.HeadroomTimeoutMs < 1000 || *patch.HeadroomTimeoutMs > 60000 {
+			writeError(w, http.StatusBadRequest, "headroom_timeout_ms must be between 1000 and 60000 ms")
+			return
+		}
+		current.HeadroomTimeoutMs = *patch.HeadroomTimeoutMs
+	}
+	if patch.PonytailEnabled != nil {
+		current.PonytailEnabled = *patch.PonytailEnabled
+	}
+	if patch.PonytailLevel != nil {
+		if !ponytail.ValidLevel(ponytail.Level(*patch.PonytailLevel)) {
+			writeError(w, http.StatusBadRequest, "ponytail_level must be lite, full, or ultra")
+			return
+		}
+		current.PonytailLevel = *patch.PonytailLevel
+	}
+	// Headroom requires a proxy URL when enabled. Validate the effective value
+	// after merging so partial patches (enabling without a URL, or clearing the
+	// URL while enabled) are rejected before persistence.
+	if current.HeadroomEnabled && strings.TrimSpace(current.HeadroomURL) == "" {
+		writeError(w, http.StatusBadRequest, "headroom_url is required when Headroom is enabled")
+		return
 	}
 	if patch.RoutingStrategy != nil {
 		normalized, ok := normalizeAccountRoutingStrategy(*patch.RoutingStrategy)

--- a/backend/internal/headroom/compressor.go
+++ b/backend/internal/headroom/compressor.go
@@ -6,12 +6,24 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
+
+// defaultMaxConcurrentCompress bounds how many compression calls may be in
+// flight at once. The reference Headroom proxy defaults to a single worker with
+// modest rpm/tpm limits, so an unbounded burst from an active coding session
+// stampedes it into 503s (or crashes it). Capping concurrency keeps the proxy
+// healthy; requests beyond the cap fail open (uncompressed) instead of piling
+// on. Override with KEIROUTER_HEADROOM_MAX_CONCURRENCY.
+const defaultMaxConcurrentCompress = 4
 
 // Compressor wraps a fail-open HTTP client and a logger. It compresses a
 // request's messages by calling an external Headroom proxy and replacing the
@@ -20,6 +32,9 @@ import (
 type Compressor struct {
 	client *http.Client
 	log    *slog.Logger
+	// sem bounds concurrent in-flight compression calls (see
+	// defaultMaxConcurrentCompress).
+	sem chan struct{}
 }
 
 // New constructs a Compressor. The HTTP client deliberately has NO client-level
@@ -33,7 +48,20 @@ func New(log *slog.Logger) *Compressor {
 	return &Compressor{
 		client: &http.Client{},
 		log:    log,
+		sem:    make(chan struct{}, resolveMaxConcurrency()),
 	}
+}
+
+// resolveMaxConcurrency reads the concurrency cap from the environment, falling
+// back to the default. Values below 1 are ignored.
+func resolveMaxConcurrency() int {
+	n := defaultMaxConcurrentCompress
+	if v := strings.TrimSpace(os.Getenv("KEIROUTER_HEADROOM_MAX_CONCURRENCY")); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed >= 1 {
+			n = parsed
+		}
+	}
+	return n
 }
 
 // compressRequest is the JSON body POSTed to Compress_Endpoint.
@@ -74,18 +102,29 @@ func (c *Compressor) Compress(ctx context.Context, req *core.ChatRequest, cfg Co
 		return &Stats{}
 	}
 
+	// Bound concurrent calls so a burst never stampedes (or crashes) a small
+	// single-worker proxy. When every slot is busy, skip compression for this
+	// request (fail-open) rather than pile on and trigger 503s.
+	select {
+	case c.sem <- struct{}{}:
+		defer func() { <-c.sem }()
+	default:
+		c.log.Debug("headroom: concurrency cap reached; skipping compression (fail-open)")
+		return &Stats{}
+	}
+
 	// Capture the outbound JSON size before the call so phantom-savings can be
 	// judged against the real payload, not the proxy's token claim.
 	bytesBefore := jsonBytes(toOpenAIMessages(req))
 
-	resp, err := c.callCompress(ctx, req, cfg)
+	resp, attempts, err := c.callCompress(ctx, req, cfg)
 	if err != nil {
-		c.logFailOpen(cfg.URL, err)
+		c.logFailOpen(cfg.URL, attempts, err)
 		return &Stats{}
 	}
 	if resp == nil || len(resp.Messages) == 0 {
 		// Missing / null / non-array / empty messages -> fail-open.
-		c.logFailOpen(cfg.URL, errors.New("response contained no compressed messages"))
+		c.logFailOpen(cfg.URL, attempts, errors.New("response contained no compressed messages"))
 		return &Stats{}
 	}
 
@@ -111,11 +150,24 @@ func (c *Compressor) Compress(ctx context.Context, req *core.ChatRequest, cfg Co
 	return &clamped
 }
 
+// maxCompressAttempts bounds how many times callCompress will hit the proxy for
+// a single request: one initial attempt plus retries. Headroom returns 503 (and
+// occasionally 429/502/504) while its compression model is warming up or its
+// async queue is saturated, expecting the client to retry shortly. A small
+// bounded retry converts those transient failures into successful compressions
+// instead of falling open and losing the savings.
+const maxCompressAttempts = 3
+
+// retryBackoff is the base delay between attempts when the proxy reports a
+// transient status without a usable Retry-After header.
+const retryBackoff = 250 * time.Millisecond
+
 // callCompress performs the POST to Compress_Endpoint with a context deadline
-// of cfg.Timeout. It returns an error for any non-success condition (transport
-// error, non-2xx status, decode failure, timeout/late response via context
-// cancellation) so the caller can fail open.
-func (c *Compressor) callCompress(ctx context.Context, req *core.ChatRequest, cfg Config) (*compressResponse, error) {
+// of cfg.Timeout. It returns the decoded response on success, plus the number
+// of attempts made. It returns an error for any non-success condition so the
+// caller can fail open; transient statuses (and transport errors) are retried
+// within the same deadline before giving up.
+func (c *Compressor) callCompress(ctx context.Context, req *core.ChatRequest, cfg Config) (*compressResponse, int, error) {
 	body := compressRequest{
 		Messages: toOpenAIMessages(req),
 		Model:    req.Model,
@@ -126,46 +178,143 @@ func (c *Compressor) callCompress(ctx context.Context, req *core.ChatRequest, cf
 
 	payload, err := json.Marshal(body)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	// The per-call deadline; a response arriving after it is abandoned because
-	// client.Do returns a context error.
+	// The per-call deadline spans all attempts; a response arriving after it is
+	// abandoned because client.Do returns a context error.
 	callCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 
 	endpoint := buildCompressEndpoint(cfg.URL)
-	httpReq, err := http.NewRequestWithContext(callCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+
+	var lastErr error
+	var retryAfter time.Duration
+	attempts := 0
+	for attempt := 0; attempt < maxCompressAttempts; attempt++ {
+		if attempt > 0 {
+			// Wait before retrying, honoring Retry-After when present, but never
+			// past the per-call deadline.
+			if err := sleepCtx(callCtx, retryDelay(retryAfter)); err != nil {
+				return nil, attempts, err
+			}
+		}
+		attempts++
+
+		decoded, after, retryable, err := c.doCompress(callCtx, endpoint, payload)
+		if err == nil {
+			return decoded, attempts, nil
+		}
+		lastErr = err
+		retryAfter = after
+		if !retryable {
+			return nil, attempts, err
+		}
+	}
+	return nil, attempts, lastErr
+}
+
+// doCompress performs a single POST attempt. It returns the decoded response on
+// success, or an error plus whether the failure is transient (worth retrying)
+// and any Retry-After hint parsed from the response.
+func (c *Compressor) doCompress(ctx context.Context, endpoint string, payload []byte) (*compressResponse, time.Duration, bool, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
 	if err != nil {
-		return nil, err
+		return nil, 0, false, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	httpResp, err := c.client.Do(httpReq)
 	if err != nil {
-		return nil, err
+		// Transport errors (connection refused, reset, transient DNS) are worth
+		// one more try within the deadline; a permanent failure simply exhausts
+		// the attempts and then fails open.
+		return nil, 0, true, err
 	}
 	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
-		return nil, fmt.Errorf("unexpected status %d", httpResp.StatusCode)
+		retryable := isRetryableStatus(httpResp.StatusCode)
+		var after time.Duration
+		if retryable {
+			after = parseRetryAfter(httpResp.Header.Get("Retry-After"))
+			// Drain so the connection can be reused for the retry.
+			_, _ = io.Copy(io.Discard, httpResp.Body)
+		}
+		return nil, after, retryable, fmt.Errorf("unexpected status %d", httpResp.StatusCode)
 	}
 
 	var decoded compressResponse
 	if err := json.NewDecoder(httpResp.Body).Decode(&decoded); err != nil {
-		return nil, err
+		return nil, 0, false, err
 	}
-	return &decoded, nil
+	return &decoded, 0, false, nil
+}
+
+// isRetryableStatus reports whether an HTTP status is a transient, retry-worthy
+// signal from the proxy (busy / warming up / gateway hiccup).
+func isRetryableStatus(code int) bool {
+	switch code {
+	case http.StatusTooManyRequests, // 429
+		http.StatusBadGateway,         // 502
+		http.StatusServiceUnavailable, // 503
+		http.StatusGatewayTimeout:     // 504
+		return true
+	default:
+		return false
+	}
+}
+
+// retryDelay returns the delay to wait before the next attempt: the proxy's
+// Retry-After hint when present and sane, otherwise the base backoff.
+func retryDelay(retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		return retryAfter
+	}
+	return retryBackoff
+}
+
+// parseRetryAfter parses a Retry-After header expressed in whole seconds. It
+// ignores HTTP-date forms and caps the value at 2s so a misbehaving proxy can't
+// stall the request near its deadline.
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs <= 0 {
+		return 0
+	}
+	d := time.Duration(secs) * time.Second
+	if d > 2*time.Second {
+		d = 2 * time.Second
+	}
+	return d
+}
+
+// sleepCtx waits for d or until ctx is done, returning ctx.Err() if the
+// deadline is reached first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // logFailOpen records a fail-open warning with a masked endpoint (never the raw
 // URL, so embedded credentials and query strings stay out of logs). The work is
 // wrapped in a recover so that a logging failure is itself suppressed and never
 // escapes the pipeline.
-func (c *Compressor) logFailOpen(rawURL string, cause error) {
+func (c *Compressor) logFailOpen(rawURL string, attempts int, cause error) {
 	defer func() { _ = recover() }()
 	c.log.Warn("headroom compression failed; leaving request unchanged (fail-open)",
 		"endpoint", maskURL(rawURL),
+		"attempts", attempts,
 		"error", cause,
 	)
 }

--- a/backend/internal/headroom/compressor.go
+++ b/backend/internal/headroom/compressor.go
@@ -1,0 +1,171 @@
+package headroom
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+// Compressor wraps a fail-open HTTP client and a logger. It compresses a
+// request's messages by calling an external Headroom proxy and replacing the
+// messages with the compressed version. Every failure path is fail-open: the
+// request is left untouched and no error is propagated to the caller.
+type Compressor struct {
+	client *http.Client
+	log    *slog.Logger
+}
+
+// New constructs a Compressor. The HTTP client deliberately has NO client-level
+// Timeout: the per-call deadline is enforced via context so a late response is
+// abandoned through context cancellation rather than a transport-level timeout.
+// A nil logger falls back to slog.Default().
+func New(log *slog.Logger) *Compressor {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Compressor{
+		client: &http.Client{},
+		log:    log,
+	}
+}
+
+// compressRequest is the JSON body POSTed to Compress_Endpoint.
+type compressRequest struct {
+	Messages []openAIMessage `json:"messages"`
+	Model    string          `json:"model"`
+	Config   *compressConfig `json:"config,omitempty"`
+}
+
+// compressConfig carries the optional per-call proxy configuration.
+type compressConfig struct {
+	CompressUserMessages bool `json:"compress_user_messages"`
+}
+
+// compressResponse is the decoded proxy response. A nil/absent/empty Messages
+// slice is treated as a failure (fail-open); only a non-empty array counts as a
+// successful compression.
+type compressResponse struct {
+	Messages []openAIMessage `json:"messages"`
+	Stats    *compressStats  `json:"stats"`
+}
+
+// compressStats mirrors the proxy-reported token statistics. Absent stats leave
+// every token field at zero.
+type compressStats struct {
+	TokensBefore int `json:"tokens_before"`
+	TokensAfter  int `json:"tokens_after"`
+	TokensSaved  int `json:"tokens_saved"`
+}
+
+// Compress mutates req.Messages in place when compression succeeds and returns
+// a Stats snapshot. It NEVER returns an error and NEVER panics out: every
+// failure path is fail-open (req left unchanged) and logged at warning level
+// with a masked URL.
+func (c *Compressor) Compress(ctx context.Context, req *core.ChatRequest, cfg Config) *Stats {
+	// Skip entirely when disabled or no URL is configured.
+	if req == nil || !cfg.Enabled || strings.TrimSpace(cfg.URL) == "" {
+		return &Stats{}
+	}
+
+	// Capture the outbound JSON size before the call so phantom-savings can be
+	// judged against the real payload, not the proxy's token claim.
+	bytesBefore := jsonBytes(toOpenAIMessages(req))
+
+	resp, err := c.callCompress(ctx, req, cfg)
+	if err != nil {
+		c.logFailOpen(cfg.URL, err)
+		return &Stats{}
+	}
+	if resp == nil || len(resp.Messages) == 0 {
+		// Missing / null / non-array / empty messages -> fail-open.
+		c.logFailOpen(cfg.URL, errors.New("response contained no compressed messages"))
+		return &Stats{}
+	}
+
+	// Success: replace the request messages with the compressed mapping and
+	// measure the resulting payload size.
+	req.Messages = fromOpenAIMessages(resp.Messages)
+	bytesAfter := jsonBytes(toOpenAIMessages(req))
+
+	stats := Stats{
+		BytesBefore: bytesBefore,
+		BytesAfter:  bytesAfter,
+		Compressed:  true,
+	}
+	if resp.Stats != nil {
+		stats.TokensBefore = resp.Stats.TokensBefore
+		stats.TokensAfter = resp.Stats.TokensAfter
+		stats.TokensSaved = resp.Stats.TokensSaved
+	}
+	// Phantom detection: tokens claimed saved but the body did not shrink.
+	stats.Phantom = isPhantom(bytesBefore, bytesAfter, defaultMinShrinkRatio)
+
+	clamped := stats.clamp()
+	return &clamped
+}
+
+// callCompress performs the POST to Compress_Endpoint with a context deadline
+// of cfg.Timeout. It returns an error for any non-success condition (transport
+// error, non-2xx status, decode failure, timeout/late response via context
+// cancellation) so the caller can fail open.
+func (c *Compressor) callCompress(ctx context.Context, req *core.ChatRequest, cfg Config) (*compressResponse, error) {
+	body := compressRequest{
+		Messages: toOpenAIMessages(req),
+		Model:    req.Model,
+	}
+	if cfg.CompressUserMessages {
+		body.Config = &compressConfig{CompressUserMessages: true}
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// The per-call deadline; a response arriving after it is abandoned because
+	// client.Do returns a context error.
+	callCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	endpoint := buildCompressEndpoint(cfg.URL)
+	httpReq, err := http.NewRequestWithContext(callCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
+		return nil, fmt.Errorf("unexpected status %d", httpResp.StatusCode)
+	}
+
+	var decoded compressResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&decoded); err != nil {
+		return nil, err
+	}
+	return &decoded, nil
+}
+
+// logFailOpen records a fail-open warning with a masked endpoint (never the raw
+// URL, so embedded credentials and query strings stay out of logs). The work is
+// wrapped in a recover so that a logging failure is itself suppressed and never
+// escapes the pipeline.
+func (c *Compressor) logFailOpen(rawURL string, cause error) {
+	defer func() { _ = recover() }()
+	c.log.Warn("headroom compression failed; leaving request unchanged (fail-open)",
+		"endpoint", maskURL(rawURL),
+		"error", cause,
+	)
+}

--- a/backend/internal/headroom/compressor_test.go
+++ b/backend/internal/headroom/compressor_test.go
@@ -1,0 +1,104 @@
+package headroom
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+func testRequest() *core.ChatRequest {
+	return &core.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hello world"}}},
+		},
+	}
+}
+
+// TestCompress_RetriesTransientThenSucceeds verifies that a transient 503 is
+// retried and a subsequent 200 yields a successful compression.
+func TestCompress_RetriesTransientThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"messages":[{"role":"user","content":"hi"}],"stats":{"tokens_before":10,"tokens_after":2,"tokens_saved":8}}`))
+	}))
+	defer srv.Close()
+
+	req := testRequest()
+	stats := New(nil).Compress(context.Background(), req, Config{Enabled: true, URL: srv.URL, Timeout: 2 * time.Second})
+
+	require.True(t, stats.Compressed, "should succeed on retry")
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls), "should retry once after 503")
+	require.Len(t, req.Messages, 1)
+	require.Equal(t, "hi", req.Messages[0].Content[0].Text)
+}
+
+// TestCompress_PersistentTransientFailsOpen verifies that when every attempt
+// returns 503, Compress exhausts its retries and fails open (request unchanged,
+// no panic, empty stats).
+func TestCompress_PersistentTransientFailsOpen(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	req := testRequest()
+	before := req.Messages[0].Content[0].Text
+	stats := New(nil).Compress(context.Background(), req, Config{Enabled: true, URL: srv.URL, Timeout: 2 * time.Second})
+
+	require.False(t, stats.Compressed, "should fail open")
+	require.Equal(t, before, req.Messages[0].Content[0].Text, "messages must be unchanged")
+	require.Equal(t, int32(maxCompressAttempts), atomic.LoadInt32(&calls), "should try maxCompressAttempts times")
+}
+
+// TestCompress_ConcurrencyCapSkips verifies that when all concurrency slots are
+// busy, Compress skips the proxy entirely (fail-open) instead of piling on.
+func TestCompress_ConcurrencyCapSkips(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"messages":[{"role":"user","content":"hi"}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(nil)
+	c.sem = make(chan struct{}, 1)
+	c.sem <- struct{}{} // occupy the only slot
+
+	req := testRequest()
+	stats := c.Compress(context.Background(), req, Config{Enabled: true, URL: srv.URL, Timeout: 2 * time.Second})
+
+	require.False(t, stats.Compressed, "should skip when concurrency cap is reached")
+	require.Equal(t, int32(0), atomic.LoadInt32(&calls), "proxy must not be called when capped")
+}
+
+// (e.g. 400) fails open immediately without consuming retries.
+func TestCompress_NonRetryableStatusNoRetry(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	req := testRequest()
+	stats := New(nil).Compress(context.Background(), req, Config{Enabled: true, URL: srv.URL, Timeout: 2 * time.Second})
+
+	require.False(t, stats.Compressed)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "non-retryable status must not be retried")
+}

--- a/backend/internal/headroom/headroom.go
+++ b/backend/internal/headroom/headroom.go
@@ -1,0 +1,69 @@
+// Package headroom is an input-side token saver that compresses a request's
+// messages by calling an external Headroom proxy (POST {url}/v1/compress) and
+// replacing the messages with the compressed version.
+//
+// Like the slimmer package it operates on the canonical core.ChatRequest before
+// any format translation, so a single implementation benefits every provider
+// dialect. It is fail-open by design: any failure (network error, non-2xx
+// status, invalid body, timeout, late response) leaves the request untouched
+// and never propagates an error to the caller.
+//
+// It also detects "phantom savings": the proxy may report tokens_saved > 0
+// while the outbound JSON payload does not actually shrink, so the provider
+// still bills nearly the full amount. Such results are flagged and excluded
+// from the accumulated savings.
+//
+// This file defines the pure, I/O-free types (Config, Stats). The HTTP client
+// (Compressor) lives in compressor.go.
+package headroom
+
+import "time"
+
+// Config controls headroom behavior for a request.
+type Config struct {
+	// Enabled turns the compressor on. When false the request is left untouched.
+	Enabled bool
+	// URL is the base proxy URL (without the /v1/compress suffix).
+	URL string
+	// CompressUserMessages, when true, asks the proxy to also compress user
+	// messages (sent as config.compress_user_messages=true).
+	CompressUserMessages bool
+	// Timeout is the per-call deadline, resolved from headroom_timeout_ms.
+	Timeout time.Duration
+}
+
+// Stats captures the per-request compression result for the meter.
+//
+// All byte/token fields are clamped to >= 0 by convention (see clamp).
+type Stats struct {
+	// TokensBefore is the proxy-reported token count before compression (>= 0).
+	TokensBefore int
+	// TokensAfter is the proxy-reported token count after compression (>= 0).
+	TokensAfter int
+	// TokensSaved is max(0, reported tokens_saved).
+	TokensSaved int
+	// BytesBefore is the JSON byte size of messages before compression (>= 0).
+	BytesBefore int
+	// BytesAfter is the JSON byte size of messages after compression (>= 0).
+	BytesAfter int
+	// BytesSaved is max(0, BytesBefore - BytesAfter).
+	BytesSaved int
+	// Phantom is true when phantom-savings were detected.
+	Phantom bool
+	// Compressed is true when the request messages were actually replaced.
+	Compressed bool
+}
+
+// clamp returns a copy of s with every byte/token field forced to a
+// non-negative value. BytesSaved is recomputed as max(0, BytesBefore-BytesAfter)
+// and TokensSaved as max(0, TokensSaved) so a body that grows or a proxy that
+// reports negative savings can never produce negative analytics.
+func (s Stats) clamp() Stats {
+	s.TokensBefore = max(0, s.TokensBefore)
+	s.TokensAfter = max(0, s.TokensAfter)
+	s.BytesBefore = max(0, s.BytesBefore)
+	s.BytesAfter = max(0, s.BytesAfter)
+	s.BytesSaved = max(0, s.BytesBefore-s.BytesAfter)
+	s.TokensSaved = max(0, s.TokensSaved)
+	return s
+}

--- a/backend/internal/headroom/mapping.go
+++ b/backend/internal/headroom/mapping.go
@@ -1,0 +1,139 @@
+package headroom
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+// openAIMessage is the minimal OpenAI chat-message shape exchanged with the
+// Headroom proxy. KeiRouter works on core.ChatRequest before any provider
+// dialect is formed, so a single mapping (core.ChatRequest <-> OpenAI messages)
+// suffices — no per-provider-dialect mapping is needed.
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+	Name    string `json:"name,omitempty"`
+	// ToolCalls carries assistant tool/function call requests.
+	ToolCalls []openAIToolCall `json:"tool_calls,omitempty"`
+	// ToolCallID links a tool-result message back to the call it answers.
+	ToolCallID string `json:"tool_call_id,omitempty"`
+}
+
+// openAIToolCall mirrors the OpenAI tool_calls entry shape.
+type openAIToolCall struct {
+	ID       string         `json:"id"`
+	Type     string         `json:"type"`
+	Function openAIFunction `json:"function"`
+}
+
+// openAIFunction is the function payload of a tool call.
+type openAIFunction struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// toOpenAIMessages maps a core.ChatRequest to the OpenAI message list sent to
+// the proxy. A non-empty System becomes a leading role:"system" message so it
+// is compressed alongside the conversation; the reverse mapping restores it as
+// a leading system message (round-trips System through the proxy).
+func toOpenAIMessages(req *core.ChatRequest) []openAIMessage {
+	if req == nil {
+		return nil
+	}
+
+	out := make([]openAIMessage, 0, len(req.Messages)+1)
+	if req.System != "" {
+		out = append(out, openAIMessage{Role: string(core.RoleSystem), Content: req.System})
+	}
+	for i := range req.Messages {
+		out = append(out, messageToOpenAI(req.Messages[i]))
+	}
+	return out
+}
+
+// messageToOpenAI converts a single canonical message. Text and thinking parts
+// are concatenated into Content, tool calls map to ToolCalls, and a tool-result
+// part maps to Content plus ToolCallID. The mapping is reversible by
+// openAIToMessage for the part kinds the proxy understands.
+func messageToOpenAI(m core.Message) openAIMessage {
+	om := openAIMessage{Role: string(m.Role), Name: m.Name}
+
+	var content strings.Builder
+	for _, p := range m.Content {
+		switch p.Type {
+		case core.PartText, core.PartThinking:
+			content.WriteString(p.Text)
+		case core.PartToolCall:
+			if p.ToolCall != nil {
+				om.ToolCalls = append(om.ToolCalls, openAIToolCall{
+					ID:   p.ToolCall.ID,
+					Type: "function",
+					Function: openAIFunction{
+						Name:      p.ToolCall.Name,
+						Arguments: p.ToolCall.Arguments,
+					},
+				})
+			}
+		case core.PartToolResult:
+			if p.ToolResult != nil {
+				om.ToolCallID = p.ToolResult.CallID
+				content.WriteString(p.ToolResult.Content)
+			}
+		}
+	}
+	om.Content = content.String()
+	return om
+}
+
+// fromOpenAIMessages maps proxy-returned OpenAI messages back to canonical
+// messages. It is the inverse of toOpenAIMessages: a leading system message is
+// preserved with RoleSystem, role/order/content are kept, tool calls become
+// PartToolCall, and a message carrying a ToolCallID becomes a PartToolResult.
+func fromOpenAIMessages(msgs []openAIMessage) []core.Message {
+	if msgs == nil {
+		return nil
+	}
+
+	out := make([]core.Message, 0, len(msgs))
+	for _, om := range msgs {
+		out = append(out, openAIToMessage(om))
+	}
+	return out
+}
+
+// openAIToMessage converts a single OpenAI message back to canonical form.
+func openAIToMessage(om openAIMessage) core.Message {
+	m := core.Message{Role: core.Role(om.Role), Name: om.Name}
+
+	switch {
+	case om.ToolCallID != "":
+		// Tool-result message: content is the result payload.
+		m.Content = append(m.Content, core.ContentPart{
+			Type: core.PartToolResult,
+			ToolResult: &core.ToolResult{
+				CallID:  om.ToolCallID,
+				Content: om.Content,
+			},
+		})
+	case om.Content != "":
+		m.Content = append(m.Content, core.ContentPart{
+			Type: core.PartText,
+			Text: om.Content,
+		})
+	}
+
+	for _, tc := range om.ToolCalls {
+		m.Content = append(m.Content, core.ContentPart{
+			Type: core.PartToolCall,
+			ToolCall: &core.ToolCall{
+				ID:        tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			},
+		})
+	}
+
+	return m
+}

--- a/backend/internal/headroom/probe.go
+++ b/backend/internal/headroom/probe.go
@@ -1,0 +1,95 @@
+package headroom
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ProbeResult reports whether a Headroom proxy is reachable and behaving like a
+// working /v1/compress endpoint. It is returned by Probe and surfaced to the
+// dashboard "Test connection" control. Endpoint is always masked so embedded
+// credentials and query strings never reach the UI or logs.
+type ProbeResult struct {
+	OK        bool   `json:"ok"`        // proxy answered like a working compressor
+	Reachable bool   `json:"reachable"` // an HTTP response was received at all
+	Status    int    `json:"status"`    // HTTP status code (0 when unreachable)
+	LatencyMs int64  `json:"latency_ms"`
+	Endpoint  string `json:"endpoint"` // masked /v1/compress URL that was probed
+	Message   string `json:"message"`  // human-readable result
+}
+
+// Probe sends a minimal compression request to the configured proxy and reports
+// whether it is up. It never returns an error: every failure is captured in the
+// result so the caller can render a status without special-casing.
+func (c *Compressor) Probe(ctx context.Context, cfg Config) ProbeResult {
+	endpoint := buildCompressEndpoint(cfg.URL)
+	res := ProbeResult{Endpoint: maskURL(endpoint)}
+
+	if strings.TrimSpace(cfg.URL) == "" {
+		res.Message = "proxy URL is empty"
+		return res
+	}
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// A tiny, valid OpenAI-shaped payload so a working proxy returns messages[].
+	payload, _ := json.Marshal(compressRequest{
+		Messages: []openAIMessage{{Role: "user", Content: "ping"}},
+		Model:    "headroom-probe",
+	})
+
+	httpReq, err := http.NewRequestWithContext(callCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		res.Message = "could not build request: " + err.Error()
+		return res
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	httpResp, err := c.client.Do(httpReq)
+	res.LatencyMs = time.Since(start).Milliseconds()
+	if err != nil {
+		res.Message = "not reachable: " + maskErr(err)
+		return res
+	}
+	defer httpResp.Body.Close()
+
+	res.Reachable = true
+	res.Status = httpResp.StatusCode
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
+		res.Message = fmt.Sprintf("reachable, but returned HTTP %d", httpResp.StatusCode)
+		return res
+	}
+
+	var decoded compressResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&decoded); err != nil {
+		res.Message = "reachable, but response was not valid JSON"
+		return res
+	}
+	if len(decoded.Messages) == 0 {
+		res.OK = true
+		res.Message = "reachable; proxy responded but returned no compressed messages"
+		return res
+	}
+
+	res.OK = true
+	res.Message = "Headroom proxy is running"
+	return res
+}
+
+// maskErr renders an error message with any embedded URL stripped of
+// credentials and query string, so probe failures never leak secrets.
+func maskErr(err error) string {
+	return scrubURLText(err.Error())
+}

--- a/backend/internal/headroom/util.go
+++ b/backend/internal/headroom/util.go
@@ -1,0 +1,84 @@
+package headroom
+
+import (
+	"encoding/json"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// credsRE matches "//user:pass@" (or "//user@") userinfo in a URL; urlQueryRE
+// matches an http(s) URL up to (but excluding) its query string or fragment.
+var (
+	credsRE    = regexp.MustCompile(`//[^/@\s]+@`)
+	urlQueryRE = regexp.MustCompile(`(https?://[^\s?#]+)[?#][^\s]*`)
+)
+
+// defaultMinShrinkRatio is the minimum fraction by which the outbound JSON body
+// must shrink for reported savings to be considered real. When the body shrinks
+// less than 5% the savings are treated as phantom.
+const defaultMinShrinkRatio = 0.05
+
+// compressPath is appended to the normalized base URL to form Compress_Endpoint.
+const compressPath = "/v1/compress"
+
+// buildCompressEndpoint normalizes base by dropping any fragment and one or more
+// trailing slashes, then appends /v1/compress. The result ends in exactly one
+// /v1/compress with no duplicate slashes.
+func buildCompressEndpoint(base string) string {
+	if i := strings.IndexByte(base, '#'); i >= 0 {
+		base = base[:i]
+	}
+	base = strings.TrimRight(base, "/")
+	return base + compressPath
+}
+
+// maskURL strips credentials (userinfo) and the query string from raw, keeping
+// only scheme, host, and path. It is used before logging an endpoint so secrets
+// embedded in the configured URL never reach diagnostic logs.
+// On a parse error it returns an empty string rather than risk leaking the raw
+// value.
+func maskURL(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	masked := url.URL{
+		Scheme: u.Scheme,
+		Opaque: u.Opaque,
+		Host:   u.Host, // host:port only; userinfo lives in u.User and is dropped
+		Path:   u.Path,
+	}
+	return masked.String()
+}
+
+// scrubURLText removes userinfo (credentials) and any query string/fragment
+// from URLs embedded inside an arbitrary string (such as an error message), so
+// secrets never leak through diagnostics surfaced to the UI or logs.
+func scrubURLText(text string) string {
+	text = credsRE.ReplaceAllString(text, "//")
+	text = urlQueryRE.ReplaceAllString(text, "$1")
+	return text
+}
+
+// jsonBytes returns the JSON-encoded byte size of v. On a marshal error it
+// returns 0 so callers can treat it as a non-negative measurement.
+func jsonBytes(v any) int {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0
+	}
+	return len(b)
+}
+
+// isPhantom reports whether reported token savings are phantom: the body did not
+// shrink by at least minShrinkRatio. With minShrinkRatio == 0.05 the result is
+// phantom when bytesAfter >= 0.95 * bytesBefore. It requires bytesBefore > 0;
+// without a measurable "before" size no phantom judgment is made.
+func isPhantom(bytesBefore, bytesAfter int, minShrinkRatio float64) bool {
+	if bytesBefore <= 0 {
+		return false
+	}
+	threshold := (1 - minShrinkRatio) * float64(bytesBefore)
+	return float64(bytesAfter) >= threshold
+}

--- a/backend/internal/meter/meter.go
+++ b/backend/internal/meter/meter.go
@@ -110,9 +110,11 @@ type Event struct {
 	TTFT      time.Duration // time-to-first-token (0 if not measured)
 
 	// Token-saving analytics.
-	SlimStats     *SlimSnapshot // nil when RTK did not fire
-	CavemanActive bool          // caveman output compression was active
-	TerseActive   bool          // terse output compression was active
+	SlimStats      *SlimSnapshot     // nil when RTK did not fire
+	CavemanActive  bool              // caveman output compression was active
+	TerseActive    bool              // terse output compression was active
+	HeadroomStats  *HeadroomSnapshot // nil when Headroom did not yield non-phantom savings
+	PonytailActive bool              // ponytail output injection was active
 }
 
 // SlimSnapshot captures the RTK slimmer's per-request compression results.
@@ -120,6 +122,15 @@ type SlimSnapshot struct {
 	BytesSaved  int
 	TokensSaved int
 	Rules       string // comma-separated rule names that fired
+}
+
+// HeadroomSnapshot captures the Headroom compressor's per-request input-side
+// savings. It is only populated when Headroom achieved real (non-phantom)
+// savings; nil indicates no savings should be recorded for this request.
+type HeadroomSnapshot struct {
+	TokensSaved int
+	BytesSaved  int
+	Active      bool
 }
 
 // resolvePrice looks up the price for a provider/model pair. It tries
@@ -192,12 +203,18 @@ func (m *Meter) Record(ctx context.Context, ev Event) (int64, error) {
 		TTFTMS:           int(ev.TTFT.Milliseconds()),
 		CavemanActive:    ev.CavemanActive,
 		TerseActive:      ev.TerseActive,
+		PonytailActive:   ev.PonytailActive,
 		CreatedAt:        time.Now(),
 	}
 	if ev.SlimStats != nil {
 		rec.SlimBytesSaved = ev.SlimStats.BytesSaved
 		rec.SlimTokensSaved = ev.SlimStats.TokensSaved
 		rec.SlimRules = ev.SlimStats.Rules
+	}
+	if ev.HeadroomStats != nil {
+		rec.HeadroomTokensSaved = ev.HeadroomStats.TokensSaved
+		rec.HeadroomBytesSaved = ev.HeadroomStats.BytesSaved
+		rec.HeadroomActive = ev.HeadroomStats.Active
 	}
 	if err := m.recordUsage(ctx, rec); err != nil {
 		return cost, err

--- a/backend/internal/pipeline/headroom_e2e_test.go
+++ b/backend/internal/pipeline/headroom_e2e_test.go
@@ -1,0 +1,217 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mydisha/keirouter/backend/internal/config"
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/mydisha/keirouter/backend/internal/dispatch"
+	"github.com/mydisha/keirouter/backend/internal/headroom"
+	"github.com/mydisha/keirouter/backend/internal/meter"
+	"github.com/mydisha/keirouter/backend/internal/ponytail"
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+// TestHeadroomEndToEnd_PipelineMeterStore exercises the full Headroom flow end
+// to end: the pipeline's token-saving stage calls an external proxy (an
+// httptest.Server) to compress messages, the result flows through saveState
+// into the meter, and the meter persists a store.UsageRecord. We then read the
+// record back and assert the Headroom token/byte/active fields and the Ponytail
+// active flag were recorded correctly.
+//
+// This wires together the real pipeline (applyTokenSaving -> buildSaveState ->
+// record), the real meter mapping, and a real migrated SQLite store, so it
+// covers the pipeline -> meter -> store path.
+func TestHeadroomEndToEnd_PipelineMeterStore(t *testing.T) {
+	// A long user message so the JSON body before compression is comfortably
+	// large; the "real savings" scenario shrinks it dramatically.
+	longText := strings.Repeat("the quick brown fox jumps over the lazy dog. ", 80)
+
+	newRequest := func() *core.ChatRequest {
+		return &core.ChatRequest{
+			Model:  "gpt-4o",
+			System: "You are a helpful assistant.",
+			Messages: []core.Message{
+				{
+					Role:    core.RoleUser,
+					Content: []core.ContentPart{{Type: core.PartText, Text: longText}},
+				},
+			},
+			Metadata: core.RequestMetadata{
+				TenantID:   store.DefaultTenantID,
+				ClientKind: "claude-code",
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		// proxyHandler is the /v1/compress responder; nil means Headroom is
+		// disabled (no proxy is configured and the server is never consulted).
+		proxyHandler    http.HandlerFunc
+		headroomEnabled bool
+		ponytailEnabled bool
+
+		wantHeadroomActive bool
+		wantHeadroomTokens int
+		wantHeadroomBytesP func(t *testing.T, got int)
+		wantPonytailActive bool
+	}{
+		{
+			name:            "real non-phantom savings record Headroom active",
+			headroomEnabled: true,
+			ponytailEnabled: true,
+			proxyHandler: func(w http.ResponseWriter, r *http.Request) {
+				// Return a much shorter compressed message plus token stats so
+				// the JSON body really shrinks (non-phantom) and tokens_saved>0.
+				writeJSON(w, map[string]any{
+					"messages": []map[string]any{
+						{"role": "system", "content": "Helpful assistant."},
+						{"role": "user", "content": "Summarize the fox text."},
+					},
+					"stats": map[string]any{
+						"tokens_before": 1200,
+						"tokens_after":  200,
+						"tokens_saved":  1000,
+					},
+				})
+			},
+			wantHeadroomActive: true,
+			wantHeadroomTokens: 1000,
+			wantHeadroomBytesP: func(t *testing.T, got int) {
+				require.Greater(t, got, 0, "real compression should record positive bytes saved")
+			},
+			wantPonytailActive: true,
+		},
+		{
+			name:            "phantom savings record Headroom inactive with zero savings",
+			headroomEnabled: true,
+			ponytailEnabled: true,
+			proxyHandler: func(w http.ResponseWriter, r *http.Request) {
+				// Echo the request messages back unchanged (no real byte shrink)
+				// while claiming tokens were saved. This is the phantom case:
+				// the provider would still bill nearly the full amount.
+				var body struct {
+					Messages []json.RawMessage `json:"messages"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				writeJSON(w, map[string]any{
+					"messages": body.Messages,
+					"stats": map[string]any{
+						"tokens_before": 1200,
+						"tokens_after":  700,
+						"tokens_saved":  500,
+					},
+				})
+			},
+			wantHeadroomActive: false,
+			wantHeadroomTokens: 0,
+			wantHeadroomBytesP: func(t *testing.T, got int) {
+				require.Equal(t, 0, got, "phantom savings must record zero bytes saved")
+			},
+			wantPonytailActive: true,
+		},
+		{
+			name:               "headroom disabled record inactive but Ponytail still flagged",
+			headroomEnabled:    false,
+			ponytailEnabled:    true,
+			proxyHandler:       nil,
+			wantHeadroomActive: false,
+			wantHeadroomTokens: 0,
+			wantHeadroomBytesP: func(t *testing.T, got int) {
+				require.Equal(t, 0, got)
+			},
+			wantPonytailActive: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Real migrated in-memory store + meter backed by its usage repo.
+			db := newPipelineTestDB(t)
+			m := meter.New(db.Usage(), nil, nil)
+			p := New(Deps{Meter: m})
+
+			var proxyURL string
+			if tc.proxyHandler != nil {
+				srv := httptest.NewServer(tc.proxyHandler)
+				t.Cleanup(srv.Close)
+				proxyURL = srv.URL
+			}
+
+			opts := Options{
+				Headroom: headroom.Config{
+					Enabled: tc.headroomEnabled,
+					URL:     proxyURL,
+					Timeout: 2 * time.Second,
+				},
+				Ponytail: ponytail.Config{
+					Enabled: tc.ponytailEnabled,
+					Level:   ponytail.LevelFull,
+				},
+			}
+
+			req := newRequest()
+
+			// Drive the real pipeline token-saving stage: this calls the proxy
+			// over HTTP (Headroom) and injects the Ponytail block.
+			slim, hr := p.applyTokenSaving(ctx, req, opts)
+			save := buildSaveState(slim, hr, opts)
+
+			// When Ponytail is enabled it must have injected its sentinel block.
+			if tc.ponytailEnabled {
+				require.Contains(t, req.System, "keirouter:ponytail",
+					"ponytail block should be appended to the system prompt")
+			}
+
+			// Meter + persist the record (pipeline -> meter -> store).
+			attempt := dispatch.Attempt{
+				Target:  dispatch.Target{Provider: "openai", Model: "gpt-4o"},
+				Account: store.Account{ID: "acc-1"},
+			}
+			usage := core.Usage{PromptTokens: 100, CompletionTokens: 50}
+			p.record(ctx, req.Metadata, attempt, usage, false, 5*time.Millisecond, save)
+
+			// Read the persisted record back from the store.
+			recent, err := db.Usage().Recent(ctx, store.DefaultTenantID, 10)
+			require.NoError(t, err)
+			require.Len(t, recent, 1, "exactly one usage record should be persisted")
+			rec := recent[0]
+
+			require.Equal(t, tc.wantHeadroomActive, rec.HeadroomActive, "HeadroomActive")
+			require.Equal(t, tc.wantHeadroomTokens, rec.HeadroomTokensSaved, "HeadroomTokensSaved")
+			require.GreaterOrEqual(t, rec.HeadroomBytesSaved, 0, "HeadroomBytesSaved must be non-negative")
+			tc.wantHeadroomBytesP(t, rec.HeadroomBytesSaved)
+			require.Equal(t, tc.wantPonytailActive, rec.PonytailActive, "PonytailActive")
+		})
+	}
+}
+
+// newPipelineTestDB opens a migrated in-memory SQLite database for a single
+// test, with the default tenant ensured so usage records can be attributed.
+func newPipelineTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	ctx := context.Background()
+	db, err := store.Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: ":memory:"}, t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, db.Migrate(ctx))
+	require.NoError(t, db.Tenants().EnsureDefault(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// writeJSON is a tiny helper for the fake proxy handlers.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -25,10 +25,12 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/core"
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
 	"github.com/mydisha/keirouter/backend/internal/guardrails"
+	"github.com/mydisha/keirouter/backend/internal/headroom"
 	"github.com/mydisha/keirouter/backend/internal/limits"
 	"github.com/mydisha/keirouter/backend/internal/meter"
 	"github.com/mydisha/keirouter/backend/internal/normalizer"
 	"github.com/mydisha/keirouter/backend/internal/observ"
+	"github.com/mydisha/keirouter/backend/internal/ponytail"
 	"github.com/mydisha/keirouter/backend/internal/slimmer"
 	"github.com/mydisha/keirouter/backend/internal/terse"
 )
@@ -51,6 +53,7 @@ type Pipeline struct {
 	meter      *meter.Meter
 	budget     *budget.Engine
 	slimmer    *slimmer.Engine
+	headroom   *headroom.Compressor
 	metrics    *observ.Metrics
 	cache      *cache.Cache
 	embedder   cache.Embedder
@@ -97,6 +100,7 @@ func New(d Deps) *Pipeline {
 		meter:      d.Meter,
 		budget:     d.Budget,
 		slimmer:    d.Slimmer,
+		headroom:   headroom.New(log),
 		metrics:    d.Metrics,
 		cache:      d.Cache,
 		embedder:   d.Embedder,
@@ -145,6 +149,11 @@ type Options struct {
 	Slimmer slimmer.Config
 	Terse   terse.Config
 	Caveman caveman.Config
+	// Headroom (input side) calls an external proxy to compress messages;
+	// Ponytail (output side) injects a system-prompt block biasing toward
+	// minimal output. Both run inside applyTokenSaving before format translation.
+	Headroom headroom.Config
+	Ponytail ponytail.Config
 	// Limits carries already-resolved per-key rate limits. Zero values mean unlimited.
 	Limits limits.EffectiveLimits
 }
@@ -215,11 +224,11 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 		p.metrics.RecordCache(false)
 	}
 
-	slimStats := p.applyTokenSaving(req, opts)
+	slimStats, hrStats := p.applyTokenSaving(ctx, req, opts)
 	if slimStats != nil {
 		p.log.Debug("slimmer stats", "saved", slimStats.Saved(), "hits", len(slimStats.Hits))
 	}
-	save := buildSaveState(slimStats, opts)
+	save := buildSaveState(slimStats, hrStats, opts)
 
 	required := capability.Required(req)
 	attempts, err := p.planWithCooldownRetry(ctx, req.Metadata.TenantID, opts.Targets, required, opts.PlanOpts)
@@ -365,8 +374,8 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 		return nil, &core.ProviderError{Kind: core.ErrPolicyBlocked, Message: gres.Reason}
 	}
 
-	slimStats := p.applyTokenSaving(req, opts)
-	save := buildSaveState(slimStats, opts)
+	slimStats, hrStats := p.applyTokenSaving(ctx, req, opts)
+	save := buildSaveState(slimStats, hrStats, opts)
 
 	required := capability.Required(req)
 	scope := budget.Scope{TenantID: req.Metadata.TenantID, ProjectID: req.Metadata.ProjectID, APIKeyID: req.Metadata.APIKeyID}
@@ -898,11 +907,17 @@ func (p *Pipeline) planWithCooldownRetry(ctx context.Context, tenantID string, t
 	return attempts, err
 }
 
-// applyTokenSaving runs the input-side (slimmer/RTK) and output-side
-// (terse, caveman) token-saving transforms in place. Terse and caveman both
-// inject system-prompt directives; if both are enabled, terse runs first and
-// caveman appends after, but in practice only one output-saver is used.
-func (p *Pipeline) applyTokenSaving(req *core.ChatRequest, opts Options) *slimmer.Stats {
+// applyTokenSaving runs the input-side (slimmer/RTK, headroom) and output-side
+// (terse, caveman, ponytail) token-saving transforms in place, in a fixed
+// deterministic order before format translation:
+//
+//	normalizer -> slimmer -> headroom (input) -> terse -> caveman -> ponytail (output)
+//
+// Terse and caveman both inject system-prompt directives; if both are enabled,
+// terse runs first and caveman appends after, but in practice only one
+// output-saver is used. Ponytail appends its block last, preserving any
+// existing directives. Headroom is fail-open and never returns an error.
+func (p *Pipeline) applyTokenSaving(ctx context.Context, req *core.ChatRequest, opts Options) (*slimmer.Stats, *headroom.Stats) {
 	// Normalize tool call IDs and fix missing tool results before any
 	// downstream processing. This ensures Anthropic-compatible IDs and
 	// complete tool_use/tool_result pairs.
@@ -915,17 +930,27 @@ func (p *Pipeline) applyTokenSaving(req *core.ChatRequest, opts Options) *slimme
 			p.log.Debug("slimmer compressed request", "saved_bytes", stats.Saved(), "hits", len(stats.Hits))
 		}
 	}
+
+	var hrStats *headroom.Stats
+	if p.headroom != nil && opts.Headroom.Enabled {
+		// Fail-open: never returns an error; leaves req untouched on failure.
+		hrStats = p.headroom.Compress(ctx, req, opts.Headroom)
+	}
+
 	terse.Apply(req, opts.Terse)
 	caveman.Apply(req, opts.Caveman)
-	return stats
+	ponytail.Apply(req, opts.Ponytail)
+	return stats, hrStats
 }
 
 // saveState captures which token-saving features were active and their results
 // for a single request, so the meter can persist them.
 type saveState struct {
-	slimSnap *meter.SlimSnapshot
-	caveman  bool
-	terse    bool
+	slimSnap     *meter.SlimSnapshot
+	headroomSnap *meter.HeadroomSnapshot
+	caveman      bool
+	terse        bool
+	ponytail     bool
 }
 
 // splitRuleNames splits a comma-separated rule string into individual names.
@@ -948,10 +973,16 @@ func splitRuleNames(s string) []string {
 
 // buildSaveState converts pipeline-level token-saving results into a snapshot
 // suitable for the meter. Returns nil when no features were active.
-func buildSaveState(stats *slimmer.Stats, opts Options) *saveState {
+//
+// The Headroom snapshot is populated only when the compressor achieved real
+// (non-phantom) token savings; in every other case headroomSnap stays nil so
+// the meter records zero tokens/bytes and HeadroomActive=false. The Ponytail
+// flag mirrors opts.Ponytail.Enabled.
+func buildSaveState(stats *slimmer.Stats, hr *headroom.Stats, opts Options) *saveState {
 	save := &saveState{
-		caveman: opts.Caveman.Enabled,
-		terse:   opts.Terse.Enabled,
+		caveman:  opts.Caveman.Enabled,
+		terse:    opts.Terse.Enabled,
+		ponytail: opts.Ponytail.Enabled,
 	}
 	if stats != nil && stats.Saved() > 0 {
 		// Build comma-separated rule names from hits.
@@ -972,7 +1003,16 @@ func buildSaveState(stats *slimmer.Stats, opts Options) *saveState {
 			Rules:       ruleNames,
 		}
 	}
-	if save.slimSnap == nil && !save.caveman && !save.terse {
+	// Populate the Headroom snapshot only for real, non-phantom savings
+	// (values already clamped >= 0 by headroom.Stats).
+	if hr != nil && hr.Compressed && hr.TokensSaved > 0 && !hr.Phantom {
+		save.headroomSnap = &meter.HeadroomSnapshot{
+			TokensSaved: hr.TokensSaved,
+			BytesSaved:  hr.BytesSaved,
+			Active:      true,
+		}
+	}
+	if save.slimSnap == nil && save.headroomSnap == nil && !save.caveman && !save.terse && !save.ponytail {
 		return nil
 	}
 	return save
@@ -1007,6 +1047,8 @@ func (p *Pipeline) recordWithTTFT(ctx context.Context, meta core.RequestMetadata
 		ev.SlimStats = save.slimSnap
 		ev.CavemanActive = save.caveman
 		ev.TerseActive = save.terse
+		ev.HeadroomStats = save.headroomSnap
+		ev.PonytailActive = save.ponytail
 	}
 	cost, err := p.meter.Record(ctx, ev)
 	if err != nil {

--- a/backend/internal/ponytail/ponytail.go
+++ b/backend/internal/ponytail/ponytail.go
@@ -1,0 +1,81 @@
+// Package ponytail implements KeiRouter's output-token saving mode by injecting
+// a leveled "lazy senior developer" system-prompt block that biases the model
+// toward minimal code.
+//
+// It mirrors the terse package's structure (an HTML-comment sentinel for
+// idempotency across retries and chained fallbacks) but APPENDS its block after
+// any existing system text rather than prepending. This keeps Terse/Caveman
+// directives intact while still steering output style.
+//
+// This is a request-side transform: it only modifies the system prompt and runs
+// before format translation so it applies uniformly across every provider
+// dialect.
+package ponytail
+
+import (
+	"strings"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+// sentinel marks instruction text KeiRouter injected, so Apply is idempotent
+// across retries and chained fallbacks. It is an HTML-style comment that models
+// ignore in their output.
+const sentinel = "<!-- keirouter:ponytail -->"
+
+// Level selects the intensity of the injected Ponytail prompt.
+type Level string
+
+const (
+	// LevelLite builds what's asked but names the lazier alternative.
+	LevelLite Level = "lite"
+	// LevelFull (default) enforces the laziness ladder.
+	LevelFull Level = "full"
+	// LevelUltra is the YAGNI-extremist intensity.
+	LevelUltra Level = "ultra"
+)
+
+// Config controls Ponytail behavior for a request.
+type Config struct {
+	Enabled bool
+	Level   Level
+}
+
+// ValidLevel reports whether s is one of lite/full/ultra (case-sensitive).
+func ValidLevel(s Level) bool {
+	switch s {
+	case LevelLite, LevelFull, LevelUltra:
+		return true
+	default:
+		return false
+	}
+}
+
+// Apply appends the leveled "lazy senior developer" prompt block (carrying the
+// sentinel) after any existing system text in req.System when cfg.Enabled.
+//
+// It is a no-op when disabled or when the sentinel is already present, so it is
+// safe to call repeatedly across retries and fallback attempts. An invalid
+// level falls back to LevelFull. When the system text is empty or whitespace,
+// req.System is set to the block; otherwise the block is appended after the
+// existing text so Terse/Caveman directives are preserved.
+func Apply(req *core.ChatRequest, cfg Config) {
+	if req == nil || !cfg.Enabled {
+		return
+	}
+	if strings.Contains(req.System, sentinel) {
+		return
+	}
+
+	level := cfg.Level
+	if !ValidLevel(level) {
+		level = LevelFull
+	}
+
+	block := sentinel + "\n" + prompts[level]
+	if strings.TrimSpace(req.System) == "" {
+		req.System = block
+		return
+	}
+	req.System = req.System + "\n\n" + block
+}

--- a/backend/internal/ponytail/prompt.go
+++ b/backend/internal/ponytail/prompt.go
@@ -1,0 +1,47 @@
+package ponytail
+
+import "strings"
+
+// Shared prompt fragments adapted from the ponytail skill
+// (https://github.com/DietrichGebert/ponytail). They are combined with a
+// level-specific line to form the per-level prompt blocks.
+const (
+	sharedPersona = "You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written."
+
+	sharedLadder = "Before writing code, stop at the first rung that holds: 1) Does this need to exist at all? (YAGNI) 2) Stdlib does it? Use it. 3) Native platform feature covers it? Use it (CSS over JS, DB constraint over app code). 4) Already-installed dependency solves it? Use it; never add a new one for what a few lines can do. 5) Can it be one line? One line. 6) Only then: the minimum code that works."
+
+	sharedRules = "No unrequested abstractions (no interface with one implementation, no factory for one product, no config for a value that never changes). No boilerplate or scaffolding \"for later\". Deletion over addition. Boring over clever. Fewest files possible; shortest working diff wins. Two stdlib options the same size: take the edge-case-correct one. Mark deliberate simplifications with a `ponytail:` comment naming the ceiling and upgrade path."
+
+	sharedOutput = "Code first. Then at most three short lines: what was skipped, when to add it. No essays or design notes. Pattern: `[code] → skipped: [X], add when [Y].`"
+
+	sharedNotLazy = "Never simplify away: input validation at trust boundaries, error handling that prevents data loss, security, accessibility, anything explicitly requested. Non-trivial logic leaves ONE runnable check behind (an assert-based self-check or one small test file; no frameworks). Trivial one-liners need no test."
+
+	sharedPersistence = "ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if unsure."
+)
+
+// levelLines holds the single level-specific line that distinguishes each
+// prompt block. It is combined with the shared fragments to build prompts.
+var levelLines = map[Level]string{
+	LevelLite:  "Lite: build what's asked, but name the lazier alternative in one line. User picks.",
+	LevelFull:  "Full: the ladder enforced. Stdlib and native first. Shortest diff, shortest explanation.",
+	LevelUltra: "Ultra: YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same response.",
+}
+
+// prompts maps each level to its fully assembled "lazy senior developer" prompt
+// block. The persona and level line lead, followed by the shared ladder, rules,
+// output contract, non-laziness guardrails, and persistence reminder.
+var prompts = func() map[Level]string {
+	out := make(map[Level]string, len(levelLines))
+	for level, line := range levelLines {
+		out[level] = strings.Join([]string{
+			sharedPersona,
+			line,
+			sharedLadder,
+			sharedRules,
+			sharedOutput,
+			sharedNotLazy,
+			sharedPersistence,
+		}, " ")
+	}
+	return out
+}()

--- a/backend/internal/store/migrate.go
+++ b/backend/internal/store/migrate.go
@@ -66,6 +66,16 @@ func (db *DB) runMigration(ctx context.Context, version, body string) error {
 			continue
 		}
 		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			// Tolerate an "ADD COLUMN" whose column already exists. This makes
+			// migrations idempotent against the case where a migration file was
+			// renamed/renumbered after being applied to a database: the new
+			// version is not yet recorded in schema_migrations, so it re-runs,
+			// but the column it adds is already present. The desired end state
+			// (the column exists) is already satisfied, so we skip the
+			// statement instead of aborting. Any other failure still rolls back.
+			if isAddColumnAlreadyExists(stmt, err) {
+				continue
+			}
 			return fmt.Errorf("statement failed: %w\n%s", err, stmt)
 		}
 	}
@@ -75,6 +85,24 @@ func (db *DB) runMigration(ctx context.Context, version, body string) error {
 		return err
 	}
 	return tx.Commit()
+}
+
+// isAddColumnAlreadyExists reports whether err is the "column already exists"
+// error produced by attempting an "ALTER TABLE ... ADD COLUMN ..." for a column
+// that is already present. It is scoped to ADD COLUMN statements so genuine
+// errors on other statements are never swallowed. The message substrings cover
+// both engines: modernc SQLite emits "duplicate column name: <col>" and
+// Postgres emits "column \"<col>\" of relation \"<table>\" already exists".
+func isAddColumnAlreadyExists(stmt string, err error) bool {
+	if err == nil {
+		return false
+	}
+	if !strings.Contains(strings.ToUpper(stmt), "ADD COLUMN") {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "duplicate column name") ||
+		strings.Contains(msg, "already exists")
 }
 
 func (db *DB) appliedVersions(ctx context.Context) (map[string]struct{}, error) {

--- a/backend/internal/store/migrations/0022_headroom_ponytail_savings.sql
+++ b/backend/internal/store/migrations/0022_headroom_ponytail_savings.sql
@@ -1,0 +1,9 @@
+-- Add Headroom (input-side proxy compression) and Ponytail (output-side
+-- system-prompt injection) savings columns to usage_records.
+-- Tracks Headroom non-phantom token/byte savings plus Headroom/Ponytail
+-- activation flags for detailed savings reporting. DEFAULT 0 keeps old records
+-- backward compatible (they read as zero/false).
+ALTER TABLE usage_records ADD COLUMN headroom_tokens_saved INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN headroom_bytes_saved INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN headroom_active INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN ponytail_active INTEGER NOT NULL DEFAULT 0;

--- a/backend/internal/store/models.go
+++ b/backend/internal/store/models.go
@@ -143,7 +143,13 @@ type UsageRecord struct {
 	SlimRules        string // comma-separated rule names that fired (e.g. "git-diff,grep")
 	CavemanActive    bool   // caveman output compression was active
 	TerseActive      bool   // terse output compression was active
-	CreatedAt        time.Time
+
+	HeadroomTokensSaved int  // estimated tokens saved by Headroom (input-side compression)
+	HeadroomBytesSaved  int  // bytes removed by Headroom (input-side compression)
+	HeadroomActive      bool // Headroom achieved real (non-phantom) savings
+	PonytailActive      bool // ponytail output injection was active
+
+	CreatedAt time.Time
 }
 
 // BudgetScope identifies what a budget applies to.

--- a/backend/internal/store/repo_usage.go
+++ b/backend/internal/store/repo_usage.go
@@ -35,20 +35,21 @@ func (r *UsageRepo) RecordBatch(ctx context.Context, records []UsageRecord) erro
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	const cols = 22
+	const cols = 26
 	var b strings.Builder
 	b.WriteString(`INSERT INTO usage_records
 		(id, tenant_id, project_id, api_key_id, provider, model, account_id, client,
 		 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
 		 cost_micros, cache_hit, latency_ms, ttft_ms,
 		 slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+		 headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active,
 		 created_at) VALUES `)
 	args := make([]any, 0, len(records)*cols)
 	for i, u := range records {
 		if i > 0 {
 			b.WriteString(",")
 		}
-		b.WriteString("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+		b.WriteString("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 		args = append(args, usageArgs(u)...)
 	}
 	q := r.db.rebind(b.String())
@@ -70,8 +71,9 @@ func insertUsage(ctx context.Context, exec interface {
 			 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
 			 cost_micros, cache_hit, latency_ms, ttft_ms,
 			 slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+			 headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active,
 			 created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	_, err := exec.ExecContext(ctx, q, usageArgs(u)...)
 	return err
 }
@@ -83,6 +85,7 @@ func usageArgs(u UsageRecord) []any {
 		u.PromptTokens, u.CompletionTokens, u.CachedTokens, u.CacheWriteTokens,
 		u.CostMicros, boolToInt(u.CacheHit), u.LatencyMS, u.TTFTMS,
 		u.SlimBytesSaved, u.SlimTokensSaved, u.SlimRules, boolToInt(u.CavemanActive), boolToInt(u.TerseActive),
+		u.HeadroomTokensSaved, u.HeadroomBytesSaved, boolToInt(u.HeadroomActive), boolToInt(u.PonytailActive),
 		formatTime(u.CreatedAt),
 	}
 }
@@ -210,6 +213,10 @@ type Summary struct {
 	SlimTokensSaved  int64 // total estimated tokens saved by RTK
 	CavemanRequests  int64 // requests where caveman was active
 	TerseRequests    int64 // requests where terse was active
+
+	HeadroomTokensSaved int64 // SUM(headroom_tokens_saved)
+	HeadroomRequests    int64 // SUM(headroom_active)
+	PonytailRequests    int64 // SUM(ponytail_active)
 }
 
 // Summarize returns aggregate usage for a tenant since the given time.
@@ -229,7 +236,10 @@ func (r *UsageRepo) Summarize(ctx context.Context, tenantID string, since time.T
 			COALESCE(SUM(slim_bytes_saved), 0),
 			COALESCE(SUM(slim_tokens_saved), 0),
 			COALESCE(SUM(caveman_active), 0),
-			COALESCE(SUM(terse_active), 0)
+			COALESCE(SUM(terse_active), 0),
+			COALESCE(SUM(headroom_tokens_saved), 0),
+			COALESCE(SUM(headroom_active), 0),
+			COALESCE(SUM(ponytail_active), 0)
 		FROM usage_records
 		WHERE tenant_id = ? AND created_at >= ?`)
 	var s Summary
@@ -237,7 +247,8 @@ func (r *UsageRepo) Summarize(ctx context.Context, tenantID string, since time.T
 		&s.TotalRequests, &s.PromptTokens, &s.CompletionTokens,
 		&s.CachedTokens, &s.CacheWriteTokens, &s.CostMicros, &s.CacheHits, &s.AvgTTFTMS,
 		&s.AvgLatencyMS, &s.SuccessCount,
-		&s.SlimBytesSaved, &s.SlimTokensSaved, &s.CavemanRequests, &s.TerseRequests)
+		&s.SlimBytesSaved, &s.SlimTokensSaved, &s.CavemanRequests, &s.TerseRequests,
+		&s.HeadroomTokensSaved, &s.HeadroomRequests, &s.PonytailRequests)
 	if err != nil {
 		return Summary{}, fmt.Errorf("store: summarize usage: %w", err)
 	}
@@ -262,7 +273,10 @@ func (r *UsageRepo) SummarizeByKey(ctx context.Context, keyID string, since time
 			COALESCE(SUM(slim_bytes_saved), 0),
 			COALESCE(SUM(slim_tokens_saved), 0),
 			COALESCE(SUM(caveman_active), 0),
-			COALESCE(SUM(terse_active), 0)
+			COALESCE(SUM(terse_active), 0),
+			COALESCE(SUM(headroom_tokens_saved), 0),
+			COALESCE(SUM(headroom_active), 0),
+			COALESCE(SUM(ponytail_active), 0)
 		FROM usage_records
 		WHERE api_key_id = ? AND created_at >= ?`)
 	var s Summary
@@ -270,7 +284,8 @@ func (r *UsageRepo) SummarizeByKey(ctx context.Context, keyID string, since time
 		&s.TotalRequests, &s.PromptTokens, &s.CompletionTokens,
 		&s.CachedTokens, &s.CacheWriteTokens, &s.CostMicros, &s.CacheHits, &s.AvgTTFTMS,
 		&s.AvgLatencyMS, &s.SuccessCount,
-		&s.SlimBytesSaved, &s.SlimTokensSaved, &s.CavemanRequests, &s.TerseRequests)
+		&s.SlimBytesSaved, &s.SlimTokensSaved, &s.CavemanRequests, &s.TerseRequests,
+		&s.HeadroomTokensSaved, &s.HeadroomRequests, &s.PonytailRequests)
 	if err != nil {
 		return Summary{}, fmt.Errorf("store: summarize usage by key: %w", err)
 	}
@@ -336,7 +351,13 @@ type RecentRecord struct {
 	SlimRules        string // comma-separated rule names that fired
 	CavemanActive    bool
 	TerseActive      bool
-	CreatedAt        time.Time
+
+	HeadroomTokensSaved int  // tokens saved by Headroom (non-phantom)
+	HeadroomBytesSaved  int  // bytes saved by Headroom
+	HeadroomActive      bool // Headroom produced non-phantom savings
+	PonytailActive      bool // Ponytail injection was active
+
+	CreatedAt time.Time
 }
 
 // Recent returns the most recent usage records for a tenant, newest first.
@@ -348,6 +369,7 @@ func (r *UsageRepo) Recent(ctx context.Context, tenantID string, limit int) ([]R
 		SELECT id, provider, model, prompt_tokens, completion_tokens, cached_tokens,
 		       cache_write_tokens, cost_micros, cache_hit, latency_ms, ttft_ms,
 		       slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+		       headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active,
 		       created_at
 		FROM usage_records
 		WHERE tenant_id = ?
@@ -362,20 +384,24 @@ func (r *UsageRepo) Recent(ctx context.Context, tenantID string, limit int) ([]R
 	var out []RecentRecord
 	for rows.Next() {
 		var (
-			rec                      RecentRecord
-			cacheHit, caveman, terse int
-			createdAt                string
+			rec                            RecentRecord
+			cacheHit, caveman, terse       int
+			headroomActive, ponytailActive int
+			createdAt                      string
 		)
 		if err := rows.Scan(&rec.ID, &rec.Provider, &rec.Model, &rec.PromptTokens,
 			&rec.CompletionTokens, &rec.CachedTokens, &rec.CacheWriteTokens,
 			&rec.CostMicros, &cacheHit, &rec.LatencyMS, &rec.TTFTMS,
 			&rec.SlimBytesSaved, &rec.SlimTokensSaved, &rec.SlimRules, &caveman, &terse,
+			&rec.HeadroomTokensSaved, &rec.HeadroomBytesSaved, &headroomActive, &ponytailActive,
 			&createdAt); err != nil {
 			return nil, err
 		}
 		rec.CacheHit = cacheHit != 0
 		rec.CavemanActive = caveman != 0
 		rec.TerseActive = terse != 0
+		rec.HeadroomActive = headroomActive != 0
+		rec.PonytailActive = ponytailActive != 0
 		rec.CreatedAt = parseTime(createdAt)
 		out = append(out, rec)
 	}
@@ -666,6 +692,9 @@ type ClientSavings struct {
 	SlimTokensSaved int64 // estimated tokens saved by RTK (bytes/4)
 	CavemanRequests int64 // requests where caveman was active
 	TerseRequests   int64 // requests where terse was active
+
+	HeadroomTokensSaved int64 // tokens saved by Headroom
+	PonytailRequests    int64 // requests where Ponytail was active
 }
 
 // SavingsByClient returns per-client optimization savings for a tenant since
@@ -679,7 +708,9 @@ func (r *UsageRepo) SavingsByClient(ctx context.Context, tenantID string, since 
 			COALESCE(SUM(slim_bytes_saved), 0),
 			COALESCE(SUM(slim_tokens_saved), 0),
 			COALESCE(SUM(caveman_active), 0),
-			COALESCE(SUM(terse_active), 0)
+			COALESCE(SUM(terse_active), 0),
+			COALESCE(SUM(headroom_tokens_saved), 0),
+			COALESCE(SUM(ponytail_active), 0)
 		FROM usage_records
 		WHERE tenant_id = ? AND created_at >= ?
 		GROUP BY client
@@ -694,7 +725,8 @@ func (r *UsageRepo) SavingsByClient(ctx context.Context, tenantID string, since 
 	for rows.Next() {
 		var c ClientSavings
 		if err := rows.Scan(&c.Client, &c.Requests, &c.SlimBytesSaved,
-			&c.SlimTokensSaved, &c.CavemanRequests, &c.TerseRequests); err != nil {
+			&c.SlimTokensSaved, &c.CavemanRequests, &c.TerseRequests,
+			&c.HeadroomTokensSaved, &c.PonytailRequests); err != nil {
 			return nil, err
 		}
 		out = append(out, c)

--- a/backend/internal/store/store_test.go
+++ b/backend/internal/store/store_test.go
@@ -27,6 +27,52 @@ func TestMigrate_Idempotent(t *testing.T) {
 	require.NoError(t, db.Migrate(context.Background()))
 }
 
+// TestMigrate_ToleratesPreexistingAddColumn reproduces the renamed-migration
+// hazard: a migration file was renumbered after being applied to a database, so
+// its new version is not recorded in schema_migrations and re-runs, but the
+// column it adds is already present. runMigration must treat the duplicate
+// "ADD COLUMN" as already-satisfied instead of aborting startup.
+func TestMigrate_ToleratesPreexistingAddColumn(t *testing.T) {
+	ctx := context.Background()
+	db, err := Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: ":memory:"}, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Run the real migrations to get a fully-migrated schema.
+	require.NoError(t, db.Migrate(ctx))
+
+	// Simulate the orphaned state: forget that a column-adding migration ran
+	// while leaving its column in place. Re-running the migration would then
+	// attempt to ADD an already-existing column.
+	_, err = db.sql.ExecContext(ctx,
+		"DELETE FROM schema_migrations WHERE version = '0022_headroom_ponytail_savings'")
+	require.NoError(t, err)
+
+	// Migrate again: the duplicate ADD COLUMN must be tolerated, not fatal.
+	require.NoError(t, db.Migrate(ctx))
+
+	// And the migration is recorded again so future runs skip it.
+	applied, err := db.appliedVersions(ctx)
+	require.NoError(t, err)
+	_, ok := applied["0022_headroom_ponytail_savings"]
+	require.True(t, ok, "migration should be recorded after the tolerated re-run")
+}
+
+// TestMigrate_RealErrorsStillFail ensures the duplicate-column tolerance is
+// tightly scoped: a genuinely broken statement still aborts the migration.
+func TestMigrate_RealErrorsStillFail(t *testing.T) {
+	ctx := context.Background()
+	db, err := Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: ":memory:"}, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.sql.ExecContext(ctx, migrationsTable)
+	require.NoError(t, err)
+
+	err = db.runMigration(ctx, "9999_bad", "SELECT * FROM table_that_does_not_exist;")
+	require.Error(t, err)
+}
+
 func TestAPIKeyRepo_CRUD(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()

--- a/frontend/src/components/SavingsBreakdown.tsx
+++ b/frontend/src/components/SavingsBreakdown.tsx
@@ -49,7 +49,11 @@ export function TokenSavingsBreakdown({ savings, totalRequests, insights, period
   const maxBytes = Math.max(...rules.map((r) => r.bytes_saved), 1);
   const totalCavemanPct = totalRequests > 0 ? ((savings.caveman_requests / totalRequests) * 100).toFixed(1) : "0";
   const totalTersePct = totalRequests > 0 ? ((savings.terse_requests / totalRequests) * 100).toFixed(0) : "0";
-  const hasSavings = savings.slim_bytes_saved > 0 || savings.caveman_requests > 0 || savings.terse_requests > 0 || rules.length > 0;
+  // New savers. Old payloads predate these fields, so coalesce missing to 0.
+  const headroomTokensSaved = savings.headroom_tokens_saved ?? 0;
+  const ponytailRequests = savings.ponytail_requests ?? 0;
+  const totalPonytailPct = totalRequests > 0 ? ((ponytailRequests / totalRequests) * 100).toFixed(0) : "0";
+  const hasSavings = savings.slim_bytes_saved > 0 || savings.caveman_requests > 0 || savings.terse_requests > 0 || headroomTokensSaved > 0 || ponytailRequests > 0 || rules.length > 0;
   // Prefer the backend's blended USD estimate; fall back to a rough $3/M rate
   // for older payloads that predate the usd_saved field.
   const usdSaved = savings.usd_saved ?? (savings.slim_tokens_saved / 1_000_000) * 3;
@@ -73,6 +77,12 @@ export function TokenSavingsBreakdown({ savings, totalRequests, insights, period
             <span className="flex items-center gap-1.5">
               <span className="h-1.5 w-1.5 rounded-full bg-indigo-500" />
               TRSE {totalTersePct}%
+            </span>
+          )}
+          {ponytailRequests > 0 && (
+            <span className="flex items-center gap-1.5">
+              <span className="h-1.5 w-1.5 rounded-full bg-teal-500" />
+              PONY {totalPonytailPct}%
             </span>
           )}
           </div>
@@ -112,6 +122,22 @@ export function TokenSavingsBreakdown({ savings, totalRequests, insights, period
             ))
           )}
         </div>
+        {(headroomTokensSaved > 0 || ponytailRequests > 0) && (
+          <div className="mt-6 grid grid-cols-2 gap-4 border-t border-[var(--border)] pt-4">
+            <div className="flex flex-col">
+              <span className="mb-1 text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">Headroom Tokens Saved</span>
+              <span className="text-lg font-light tabular-nums text-[var(--text)]">
+                {fmtNum(headroomTokensSaved)} <span className="ml-1 text-xs font-medium text-[var(--text-muted)]">tokens</span>
+              </span>
+            </div>
+            <div className="flex flex-col text-right">
+              <span className="mb-1 text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">Ponytail Requests</span>
+              <span className="text-lg font-light tabular-nums text-[var(--text)]">
+                {fmtNum(ponytailRequests)} <span className="ml-1 text-xs font-medium text-[var(--text-muted)]">requests</span>
+              </span>
+            </div>
+          </div>
+        )}
         <ClientBreakdown clients={savings.by_client || []} />
         <div className="mt-6 flex items-center justify-between border-t border-[var(--border)] pt-4">
           <div className="flex flex-col">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -96,6 +96,12 @@ export interface EndpointSettings {
   caveman_level: string;
   terse_enabled: boolean;
   terse_level: string;
+  headroom_enabled: boolean;
+  headroom_url: string;
+  headroom_compress_user_messages: boolean;
+  headroom_timeout_ms: number;
+  ponytail_enabled: boolean;
+  ponytail_level: "lite" | "full" | "ultra";
   routing_strategy: string;
   sticky_limit: number;
   combo_strategy: string;
@@ -114,6 +120,18 @@ export interface ProviderRoutingSettings {
   routing_strategy: "inherit" | "fill-first" | "round-robin" | "smart-round-robin" | string;
   sticky_limit: number;
   affinity_ttl_minutes: number;
+}
+
+// HeadroomTestResult is returned by POST /settings/headroom-test and reports
+// whether the configured Headroom proxy is reachable and behaving correctly.
+// endpoint is always masked (no credentials/query string).
+export interface HeadroomTestResult {
+  ok: boolean;
+  reachable: boolean;
+  status: number;
+  latency_ms: number;
+  endpoint: string;
+  message: string;
 }
 
 export interface OAuthProvider {
@@ -326,6 +344,10 @@ export interface ClientSaving {
   usd_saved: number;
   caveman_requests: number;
   terse_requests: number;
+  // Headroom/Ponytail per-client savings. Optional for backward-compat with
+  // payloads recorded before these savers existed; treat missing as 0.
+  headroom_tokens_saved?: number;
+  ponytail_requests?: number;
 }
 
 export interface TokenSavings {
@@ -335,6 +357,11 @@ export interface TokenSavings {
   terse_requests: number;
   usd_saved?: number;
   usd_saved_estimate?: boolean;
+  // Headroom/Ponytail summary savings. Optional for backward-compat with
+  // payloads recorded before these savers existed; treat missing as 0.
+  headroom_tokens_saved?: number;
+  ponytail_requests?: number;
+  headroom_requests?: number;
   rules: RuleSaving[];
   by_client?: ClientSaving[];
 }
@@ -408,8 +435,15 @@ export interface QuotaAccount {
   updated_at: string;
 }
 
-// Console log now uses raw text lines (like 9router).
-// The /api/console endpoint returns { logs: string[] }.
+// Console log uses structured entries streamed via SSE (/api/console/stream)
+// and fetched as history from /api/console, which returns { logs: ConsoleLogEntry[] }.
+export interface ConsoleLogEntry {
+  seq: number;
+  time: string; // HH:MM:SS.mmm
+  level: string; // DEBUG | INFO | WARN | ERROR | LOG
+  msg: string; // human-readable summary
+  detail?: string; // optional technical detail, revealed on expand
+}
 
 export interface ProxyPool {
   id: string;
@@ -1018,7 +1052,7 @@ export const api = {
   quota: (period: string) =>
     request<{ accounts: QuotaAccount[]; since: string }>("GET", `/quota?period=${period}&tz=${browserTZ()}`),
 
-  consoleLog: () => request<{ logs: string[] }>("GET", "/console"),
+  consoleLog: () => request<{ logs: ConsoleLogEntry[] }>("GET", "/console"),
 
   cliTools: (model?: string) =>
     request<CLIToolsResponse>("GET", model ? `/cli-tools?model=${encodeURIComponent(model)}` : "/cli-tools"),
@@ -1044,6 +1078,8 @@ export const api = {
   endpointSettings: () => request<EndpointSettings>("GET", "/settings/endpoint"),
   updateEndpointSettings: (patch: Partial<EndpointSettings>) =>
     request<EndpointSettings>("POST", "/settings/endpoint", patch),
+  testHeadroom: (body?: { url?: string; timeout_ms?: number }) =>
+    request<HeadroomTestResult>("POST", "/settings/headroom-test", body ?? {}),
 
   accessSettings: () => request<AccessSettings>("GET", "/settings/access"),
   updateAccessSettings: (patch: Partial<Omit<AccessSettings, "endpoint_url">>) =>

--- a/frontend/src/pages/ConsoleLog.tsx
+++ b/frontend/src/pages/ConsoleLog.tsx
@@ -10,20 +10,16 @@ import {
   Copy,
   Check,
   ChevronDown,
+  ChevronRight,
 } from "lucide-react";
 import { PageHeader } from "../components/Layout";
 import { Card, Button, EmptyState } from "../components/ui";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR" | "LOG";
+import type { ConsoleLogEntry } from "../lib/api";
 
-interface ParsedLine {
-  raw: string;
-  time: string;
-  level: LogLevel;
-  message: string;
-}
+type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR" | "LOG";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -58,58 +54,86 @@ const LEVELS: LogLevel[] = ["DEBUG", "INFO", "WARN", "ERROR"];
 
 const MAX_LINES = 500;
 
-const ROW_HEIGHT = 24; // approximate px per row (leading-[1.6] ~ 20.8px + 3px*2 padding)
+const ROW_HEIGHT = 24; // approximate px per collapsed row
 
-// ── Parsing ──────────────────────────────────────────────────────────────────
-
-// Matches [HH:MM:SS.mmm] [LEVEL] message
-const LINE_RE = /^\[(\d{2}:\d{2}:\d{2}\.\d{3})\]\s*\[(\w+)\]\s*(.*)/;
-
-function parseLine(raw: string): ParsedLine {
-  const m = raw.match(LINE_RE);
-  if (m) {
-    return { raw, time: m[1], level: m[2] as LogLevel, message: m[3] };
+// Normalize an arbitrary server level string into a known LogLevel.
+function normalizeLevel(level: string): LogLevel {
+  const up = (level || "").toUpperCase();
+  if (up === "DEBUG" || up === "INFO" || up === "WARN" || up === "ERROR") {
+    return up;
   }
-  // Continuation line (e.g. "  └─ error details") or unstructured
-  return { raw, time: "", level: "LOG", message: raw };
+  return "LOG";
 }
 
 // ── Memoized log row ─────────────────────────────────────────────────────────
 
 const LogRow = memo(function LogRow({
-  line,
+  entry,
   index,
+  expanded,
+  onToggle,
 }: {
-  line: ParsedLine;
+  entry: ConsoleLogEntry;
   index: number;
+  expanded: boolean;
+  onToggle: (seq: number) => void;
 }) {
+  const level = normalizeLevel(entry.level);
+  const hasDetail = !!entry.detail && entry.detail.trim().length > 0;
+
   return (
     <div
-      className={`flex border-b border-l-2 border-[var(--border)]/40 transition-colors hover:bg-[var(--bg-subtle)] ${LEVEL_BORDER[line.level]}`}
-      style={{ minHeight: ROW_HEIGHT }}
+      className={`border-b border-l-2 border-[var(--border)]/40 transition-colors ${LEVEL_BORDER[level]}`}
     >
-      {/* Line number */}
-      <div className="w-[3.5rem] shrink-0 select-none px-3 py-[3px] text-right text-[11px] text-[var(--text-muted)]/50">
-        {index + 1}
+      {/* Summary line */}
+      <div
+        className={`flex ${hasDetail ? "cursor-pointer" : ""} hover:bg-[var(--bg-subtle)]`}
+        style={{ minHeight: ROW_HEIGHT }}
+        onClick={hasDetail ? () => onToggle(entry.seq) : undefined}
+      >
+        {/* Line number */}
+        <div className="w-[3.5rem] shrink-0 select-none px-3 py-[3px] text-right text-[11px] text-[var(--text-muted)]/50">
+          {index + 1}
+        </div>
+        {/* Timestamp */}
+        <div className="w-[6.5rem] shrink-0 px-2 py-[3px] whitespace-nowrap text-[var(--text-muted)]">
+          {entry.time || "\u00A0"}
+        </div>
+        {/* Level badge */}
+        <div className="w-[3.5rem] shrink-0 px-1 py-[3px]">
+          {level !== "LOG" && (
+            <span
+              className={`inline-block rounded px-1.5 text-[11px] font-bold leading-normal ${LEVEL_TEXT[level]} ${LEVEL_BG[level]}`}
+            >
+              {level}
+            </span>
+          )}
+        </div>
+        {/* Message */}
+        <div className="min-w-0 flex-1 px-2 py-[3px] break-words text-[var(--text)]">
+          <HighlightMessage message={entry.msg} />
+        </div>
+        {/* Detail toggle */}
+        <div className="w-[5rem] shrink-0 px-2 py-[3px] text-right">
+          {hasDetail && (
+            <span className="inline-flex items-center gap-0.5 text-[11px] text-[var(--text-muted)] hover:text-[var(--text)]">
+              <ChevronRight
+                className={`h-3 w-3 transition-transform ${expanded ? "rotate-90" : ""}`}
+              />
+              detail
+            </span>
+          )}
+        </div>
       </div>
-      {/* Timestamp */}
-      <div className="w-[6.5rem] shrink-0 px-2 py-[3px] whitespace-nowrap text-[var(--text-muted)]">
-        {line.time || "\u00A0"}
-      </div>
-      {/* Level badge */}
-      <div className="w-[3.5rem] shrink-0 px-1 py-[3px]">
-        {line.level !== "LOG" && (
-          <span
-            className={`inline-block rounded px-1.5 text-[11px] font-bold leading-normal ${LEVEL_TEXT[line.level]} ${LEVEL_BG[line.level]}`}
-          >
-            {line.level}
-          </span>
-        )}
-      </div>
-      {/* Message */}
-      <div className="min-w-0 flex-1 px-2 py-[3px] break-all text-[var(--text)]">
-        <HighlightMessage message={line.message} />
-      </div>
+
+      {/* Expanded detail block */}
+      {hasDetail && expanded && (
+        <div className="border-t border-[var(--border)]/30 bg-[var(--bg-subtle)]/60 py-2 pr-4 pl-[13.5rem]">
+          <pre className="whitespace-pre-wrap break-words text-[12px] leading-[1.5] text-[var(--text-muted)]">
+            {entry.detail}
+          </pre>
+        </div>
+      )}
     </div>
   );
 });
@@ -139,14 +163,6 @@ const HighlightMessage = memo(function HighlightMessage({
             </span>
           );
         }
-        // Dim arrows and decorative symbols
-        if (/^[→✔✖▶└─\s]+$/.test(part)) {
-          return (
-            <span key={i} className="text-[var(--text-muted)]/60">
-              {part}
-            </span>
-          );
-        }
         return <span key={i}>{part}</span>;
       })}
     </>
@@ -156,13 +172,14 @@ const HighlightMessage = memo(function HighlightMessage({
 // ── Component ────────────────────────────────────────────────────────────────
 
 export function ConsoleLogPage() {
-  const [logs, setLogs] = useState<string[]>([]);
+  const [entries, setEntries] = useState<ConsoleLogEntry[]>([]);
   const [connected, setConnected] = useState(false);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [activeLevels, setActiveLevels] = useState<Set<LogLevel>>(
     new Set(LEVELS),
   );
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const [autoScroll, setAutoScroll] = useState(true);
   const [copied, setCopied] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -178,15 +195,16 @@ export function ConsoleLogPage() {
     es.onmessage = (e) => {
       const msg = JSON.parse(e.data);
       if (msg.type === "init") {
-        setLogs(msg.logs || []);
+        setEntries(msg.logs || []);
         setLoading(false);
       } else if (msg.type === "line") {
-        setLogs((prev) => {
-          const next = [...prev, msg.line];
+        setEntries((prev) => {
+          const next = [...prev, msg.log as ConsoleLogEntry];
           return next.length > MAX_LINES ? next.slice(-MAX_LINES) : next;
         });
       } else if (msg.type === "clear") {
-        setLogs([]);
+        setEntries([]);
+        setExpanded(new Set());
       }
     };
 
@@ -197,21 +215,24 @@ export function ConsoleLogPage() {
 
   // ── Filtering ────────────────────────────────────────────────────────────
 
-  const parsed = useMemo(() => logs.map(parseLine), [logs]);
-
   const filtered = useMemo(() => {
-    let list = parsed;
+    let list = entries;
     if (activeLevels.size < LEVELS.length) {
-      list = list.filter(
-        (l) => activeLevels.has(l.level) || l.level === "LOG",
-      );
+      list = list.filter((l) => {
+        const lvl = normalizeLevel(l.level);
+        return activeLevels.has(lvl) || lvl === "LOG";
+      });
     }
     if (search) {
       const q = search.toLowerCase();
-      list = list.filter((l) => l.raw.toLowerCase().includes(q));
+      list = list.filter(
+        (l) =>
+          l.msg.toLowerCase().includes(q) ||
+          (l.detail || "").toLowerCase().includes(q),
+      );
     }
     return list;
-  }, [parsed, activeLevels, search]);
+  }, [entries, activeLevels, search]);
 
   // ── Stats ────────────────────────────────────────────────────────────────
 
@@ -223,9 +244,9 @@ export function ConsoleLogPage() {
       ERROR: 0,
       LOG: 0,
     };
-    for (const l of parsed) counts[l.level]++;
+    for (const l of entries) counts[normalizeLevel(l.level)]++;
     return counts;
-  }, [parsed]);
+  }, [entries]);
 
   // ── Virtualizer ──────────────────────────────────────────────────────────
 
@@ -270,7 +291,19 @@ export function ConsoleLogPage() {
   };
 
   const handleCopy = async () => {
-    const text = filtered.map((l) => l.raw).join("\n");
+    const text = filtered
+      .map((l) => {
+        const head = `${l.time} ${normalizeLevel(l.level)} ${l.msg}`;
+        if (l.detail && l.detail.trim()) {
+          const indented = l.detail
+            .split("\n")
+            .map((line) => "    " + line)
+            .join("\n");
+          return `${head}\n${indented}`;
+        }
+        return head;
+      })
+      .join("\n");
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
@@ -279,6 +312,18 @@ export function ConsoleLogPage() {
       /* ignore */
     }
   };
+
+  const toggleExpand = useCallback((seq: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(seq)) {
+        next.delete(seq);
+      } else {
+        next.add(seq);
+      }
+      return next;
+    });
+  }, []);
 
   const toggleLevel = (level: LogLevel) => {
     setActiveLevels((prev) => {
@@ -308,7 +353,7 @@ export function ConsoleLogPage() {
         icon={ScrollText}
         description={
           connected
-            ? `${logs.length} lines · live`
+            ? `${entries.length} lines · live`
             : "Connecting…"
         }
         action={
@@ -328,7 +373,7 @@ export function ConsoleLogPage() {
               )}
               {copied ? "Copied" : "Copy"}
             </Button>
-            <Button variant="ghost" onClick={handleClear} disabled={logs.length === 0}>
+            <Button variant="ghost" onClick={handleClear} disabled={entries.length === 0}>
               <Trash2 className="h-4 w-4" />
               Clear
             </Button>
@@ -389,7 +434,7 @@ export function ConsoleLogPage() {
           <div className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
             {search && (
               <span>
-                {filtered.length}/{logs.length} matched
+                {filtered.length}/{entries.length} matched
               </span>
             )}
             <button
@@ -418,7 +463,7 @@ export function ConsoleLogPage() {
           <div className="flex items-center justify-center py-12">
             <div className="h-5 w-5 animate-spin rounded-full border-2 border-[var(--border)] border-t-accent-500" />
           </div>
-        ) : filtered.length === 0 && logs.length === 0 ? (
+        ) : filtered.length === 0 && entries.length === 0 ? (
           <EmptyState
             title="No console logs yet"
             hint="Requests will appear here once traffic flows through KeiRouter."
@@ -443,10 +488,10 @@ export function ConsoleLogPage() {
               }}
             >
               {virtualizer.getVirtualItems().map((virtualRow) => {
-                const line = filtered[virtualRow.index];
+                const entry = filtered[virtualRow.index];
                 return (
                   <div
-                    key={virtualRow.key}
+                    key={entry.seq}
                     data-index={virtualRow.index}
                     ref={virtualizer.measureElement}
                     style={{
@@ -457,7 +502,12 @@ export function ConsoleLogPage() {
                       transform: `translateY(${virtualRow.start}px)`,
                     }}
                   >
-                    <LogRow line={line} index={virtualRow.index} />
+                    <LogRow
+                      entry={entry}
+                      index={virtualRow.index}
+                      expanded={expanded.has(entry.seq)}
+                      onToggle={toggleExpand}
+                    />
                   </div>
                 );
               })}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,11 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Sparkles, Zap, MessageSquare, Layers, Route, Wifi, Monitor, Database, Clock,
-  ArrowUpCircle, CheckCircle2, ExternalLink,
+  ArrowUpCircle, CheckCircle2, ExternalLink, XCircle, Terminal,
   Gauge, Eye, EyeOff, KeyRound, Download, Upload, ShieldCheck, Info,
   Palette, Shield,
 } from "lucide-react";
-import { api, type EndpointSettings, type BrandingSettings } from "../lib/api";
+import { api, type EndpointSettings, type BrandingSettings, type HeadroomTestResult } from "../lib/api";
 import { ChangelogMarkdown } from "../components/ChangelogMarkdown";
 import { PALETTES, getPaletteScales } from "../lib/palettes";
 import { applyShadeScale, generateShades } from "../lib/color-utils";
@@ -82,6 +82,17 @@ const terseHints: Record<string, string> = {
   aggressive: "Bare technical minimum.",
 };
 
+const ponytailOptions = [
+  { value: "lite", label: "Lite" },
+  { value: "full", label: "Full" },
+  { value: "ultra", label: "Ultra" },
+];
+const ponytailHints: Record<string, string> = {
+  lite: "Light nudge toward minimal code.",
+  full: "Balanced lazy-senior-dev bias.",
+  ultra: "Maximum bias toward the smallest change.",
+};
+
 const rtkFilterOptions = [
   { value: "none", label: "Off" },
   { value: "minimal", label: "Minimal" },
@@ -137,7 +148,7 @@ export function SettingsPage() {
           <TabBar tabs={settingsTabs} active={tab} onChange={setTab} />
 
           <div className="mt-6">
-            {tab === "saving" && <SavingTab local={local} update={update} />}
+            {tab === "saving" && <SavingTab local={local} update={update} setLocal={setLocal} />}
             {tab === "routing" && <RoutingTab local={local} update={update} />}
             {tab === "network" && <NetworkTab local={local} update={update} />}
             {tab === "branding" && <BrandingTab />}
@@ -156,13 +167,155 @@ export function SettingsPage() {
 }
 
 // ── Token Saving Tab ────────────────────────────────────────────────
+const HEADROOM_TIMEOUT_MIN = 1000;
+const HEADROOM_TIMEOUT_MAX = 60000;
+const PONYTAIL_LEVELS = ["lite", "full", "ultra"] as const;
+
+const SAVER_VALIDATION_MESSAGES = {
+  headroomUrl: "Proxy URL is required when Headroom is enabled.",
+  headroomTimeout: `Timeout must be a whole number between ${HEADROOM_TIMEOUT_MIN} and ${HEADROOM_TIMEOUT_MAX} ms.`,
+  ponytailLevel: `Ponytail level must be one of: ${PONYTAIL_LEVELS.join(", ")}.`,
+} as const;
+
+type SaverErrors = {
+  headroom_url?: string;
+  headroom_timeout_ms?: string;
+  ponytail_level?: string;
+};
+
+// validateSaverSettings derives client-side validation errors for the
+// Headroom/Ponytail controls. Checks only apply
+// while the relevant saver is enabled, mirroring the visible controls.
+function validateSaverSettings(s: EndpointSettings): SaverErrors {
+  const errors: SaverErrors = {};
+  if (s.headroom_enabled && !(s.headroom_url ?? "").trim()) {
+    errors.headroom_url = SAVER_VALIDATION_MESSAGES.headroomUrl;
+  }
+  if (s.headroom_enabled) {
+    const t = s.headroom_timeout_ms;
+    if (!Number.isInteger(t) || t < HEADROOM_TIMEOUT_MIN || t > HEADROOM_TIMEOUT_MAX) {
+      errors.headroom_timeout_ms = SAVER_VALIDATION_MESSAGES.headroomTimeout;
+    }
+  }
+  if (s.ponytail_enabled && !PONYTAIL_LEVELS.includes(s.ponytail_level as (typeof PONYTAIL_LEVELS)[number])) {
+    errors.ponytail_level = SAVER_VALIDATION_MESSAGES.ponytailLevel;
+  }
+  return errors;
+}
+
+function saverPatch(s: EndpointSettings): Partial<EndpointSettings> {
+  return {
+    headroom_enabled: s.headroom_enabled,
+    headroom_url: s.headroom_url,
+    headroom_compress_user_messages: s.headroom_compress_user_messages,
+    headroom_timeout_ms: s.headroom_timeout_ms,
+    ponytail_enabled: s.ponytail_enabled,
+    ponytail_level: s.ponytail_level,
+  };
+}
+
+// HeadroomInstallHelp explains how to install and run a local Headroom proxy.
+// Headroom is the open-source headroom-ai proxy; KeiRouter calls its
+// /v1/compress endpoint. Shown inside the Headroom card so operators can get a
+// proxy running before pointing KeiRouter at it.
+function HeadroomInstallHelp() {
+  return (
+    <div className="border-t border-[var(--border)] px-6 py-4">
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--bg)] p-4">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Terminal className="h-4 w-4 text-[var(--text-muted)]" />
+          Don&apos;t have a Headroom proxy yet?
+        </div>
+        <p className="mt-1 text-xs text-[var(--text-muted)]">
+          Headroom is a local, open-source compression proxy. The{" "}
+          <code className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">headroom</code> CLI ships with the
+          Python package (the npm package is a library only). Install it with pipx, then start it:
+        </p>
+        <pre className="mt-2 overflow-x-auto rounded-lg bg-[var(--bg-elevated)] px-3 py-2 text-xs leading-relaxed text-[var(--text)]">
+          <code>{`pipx install "headroom-ai[all]"   # needs Python 3.10+ (or: pip install --user)
+pipx ensurepath                   # add headroom to PATH, then restart your shell
+headroom proxy --port 8787
+headroom doctor                   # verify it's working`}</code>
+        </pre>
+        <p className="mt-2 text-xs text-[var(--text-muted)]">
+          Then set <span className="font-medium text-[var(--text)]">Proxy URL</span> to{" "}
+          <code className="rounded bg-[var(--bg-elevated)] px-1 py-0.5">http://localhost:8787</code>.
+        </p>
+        <a
+          href="https://github.com/headroomlabs-ai/headroom"
+          target="_blank"
+          rel="noreferrer"
+          className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-secondary-600 hover:underline dark:text-secondary-400"
+        >
+          Installation guide <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    </div>
+  );
+}
+
+// HeadroomTestConnection validates that the configured proxy is actually
+// running by probing its /v1/compress endpoint via the backend. The backend
+// returns a masked endpoint and never leaks credentials.
+function HeadroomTestConnection({ url, timeoutMs }: { url: string; timeoutMs: number }) {
+  const [result, setResult] = useState<HeadroomTestResult | null>(null);
+  const test = useMutation({
+    mutationFn: () => api.testHeadroom({ url, timeout_ms: timeoutMs }),
+    onSuccess: setResult,
+    onError: (e) =>
+      setResult({ ok: false, reachable: false, status: 0, latency_ms: 0, endpoint: "", message: (e as Error).message }),
+  });
+  const disabled = !url.trim() || test.isPending;
+  return (
+    <div className="border-t border-[var(--border)] px-6 py-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <Button variant="ghost" disabled={disabled} onClick={() => test.mutate()}>
+          {test.isPending ? "Testing…" : "Test connection"}
+        </Button>
+        {result && (
+          <span
+            className={`inline-flex items-center gap-1.5 text-xs ${
+              result.ok ? "text-[color:var(--color-success)]" : "text-[color:var(--color-danger)]"
+            }`}
+          >
+            {result.ok ? <CheckCircle2 className="h-4 w-4" /> : <XCircle className="h-4 w-4" />}
+            {result.message}
+            {result.latency_ms > 0 && <span className="text-[var(--text-muted)]">({result.latency_ms} ms)</span>}
+          </span>
+        )}
+      </div>
+      <p className="mt-2 text-xs text-[var(--text-muted)]">
+        Checks that the proxy at the Proxy URL above responds on <code>/v1/compress</code>.
+      </p>
+    </div>
+  );
+}
+
 function SavingTab({
   local,
   update,
+  setLocal,
 }: {
   local: EndpointSettings;
   update: (patch: Partial<EndpointSettings>) => void;
+  setLocal: React.Dispatch<React.SetStateAction<EndpointSettings | null>>;
 }) {
+  const [saverErrors, setSaverErrors] = useState<SaverErrors>({});
+
+  // saverUpdate validates the merged Headroom/Ponytail state before persisting.
+  // Invalid values are reflected locally (so the operator sees what they typed)
+  // and surfaced as inline errors, but they are NOT persisted.
+  const saverUpdate = (patch: Partial<EndpointSettings>) => {
+    const next = { ...local, ...patch };
+    const errors = validateSaverSettings(next);
+    setSaverErrors(errors);
+    if (Object.keys(errors).length === 0) {
+      update(saverPatch(next));
+    } else {
+      setLocal(next);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <Card>
@@ -236,6 +389,93 @@ function SavingTab({
               value={local.terse_level}
               onChange={(v) => update({ terse_level: v })}
               options={terseOptions}
+            />
+          </div>
+        )}
+      </Card>
+
+      <Card>
+        <SectionHeader
+          title="Headroom input compression"
+          description="Compresses request messages through an external Headroom proxy before they reach the model. Fail-open — any proxy error leaves the request untouched."
+          icon={Zap}
+          iconTone="neutral"
+        />
+        <div className="flex items-center justify-between border-t border-[var(--border)] px-6 py-4">
+          <span className="text-sm font-medium">Enable Headroom</span>
+          <Toggle checked={local.headroom_enabled} onChange={(v) => saverUpdate({ headroom_enabled: v })} />
+        </div>
+        {local.headroom_enabled && (
+          <>
+            <div className="border-t border-[var(--border)] px-6 py-4">
+              <Field label="Proxy URL">
+                <Input
+                  type="text"
+                  placeholder="https://headroom.example.com"
+                  value={local.headroom_url}
+                  onChange={(e) => saverUpdate({ headroom_url: e.target.value })}
+                  aria-invalid={!!saverErrors.headroom_url}
+                />
+                {saverErrors.headroom_url && (
+                  <p className="text-xs text-[color:var(--color-danger)]">{saverErrors.headroom_url}</p>
+                )}
+              </Field>
+            </div>
+            <div className="flex items-center justify-between border-t border-[var(--border)] px-6 py-4">
+              <div>
+                <p className="text-sm font-medium">Compress user messages</p>
+                <p className="mt-0.5 text-xs text-[var(--text-muted)]">Also send user messages to the proxy for compression.</p>
+              </div>
+              <Toggle
+                checked={local.headroom_compress_user_messages}
+                onChange={(v) => saverUpdate({ headroom_compress_user_messages: v })}
+              />
+            </div>
+            <div className="border-t border-[var(--border)] px-6 py-4">
+              <Field label="Timeout (ms)">
+                <Input
+                  type="number"
+                  min={1000}
+                  max={60000}
+                  value={Number.isFinite(local.headroom_timeout_ms) ? local.headroom_timeout_ms : ""}
+                  onChange={(e) => saverUpdate({ headroom_timeout_ms: e.target.valueAsNumber })}
+                  aria-invalid={!!saverErrors.headroom_timeout_ms}
+                />
+                {saverErrors.headroom_timeout_ms && (
+                  <p className="text-xs text-[color:var(--color-danger)]">{saverErrors.headroom_timeout_ms}</p>
+                )}
+              </Field>
+            </div>
+            <HeadroomTestConnection url={local.headroom_url} timeoutMs={local.headroom_timeout_ms} />
+          </>
+        )}
+        <HeadroomInstallHelp />
+      </Card>
+
+      <Card>
+        <SectionHeader
+          title="Ponytail output compression"
+          description="Injects a lazy-senior-developer system prompt that biases the model toward minimal code. Layers on top of Terse or Caveman."
+          icon={MessageSquare}
+          iconTone="neutral"
+        />
+        <div className="flex items-center justify-between border-t border-[var(--border)] px-6 py-4">
+          <span className="text-sm font-medium">Enable Ponytail</span>
+          <Toggle checked={local.ponytail_enabled} onChange={(v) => saverUpdate({ ponytail_enabled: v })} />
+        </div>
+        {local.ponytail_enabled && (
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--border)] px-6 py-4">
+            <div>
+              <p className="text-sm font-medium">Ponytail level</p>
+              <p className="mt-0.5 text-xs text-[var(--text-muted)]">{ponytailHints[local.ponytail_level]}</p>
+              {saverErrors.ponytail_level && (
+                <p className="mt-0.5 text-xs text-[color:var(--color-danger)]">{saverErrors.ponytail_level}</p>
+              )}
+            </div>
+            <SegmentedControl
+              value={local.ponytail_level}
+              onChange={(v) => saverUpdate({ ponytail_level: v as "lite" | "full" | "ultra" })}
+              options={ponytailOptions}
             />
           </div>
         )}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -214,6 +214,34 @@ function saverPatch(s: EndpointSettings): Partial<EndpointSettings> {
   };
 }
 
+// HeadroomAdvisory sets expectations for the Headroom saver: it works best
+// against a fast, local proxy. Large or first-seen ("cold") contexts can take
+// many seconds for the proxy to compress, in which case Headroom fails open
+// (request passes through uncompressed, so it records 0 savings). The instant
+// local savers don't have this caveat.
+function HeadroomAdvisory() {
+  return (
+    <div className="border-t border-[var(--border)] px-6 py-4">
+      <div className="flex gap-2.5 rounded-xl border border-[var(--border)] bg-[var(--bg)] p-3">
+        <Info className="mt-0.5 h-4 w-4 shrink-0 text-[var(--text-muted)]" />
+        <div className="text-xs leading-relaxed text-[var(--text-muted)]">
+          <span className="font-medium text-[var(--text)]">Best for a fast, local proxy.</span>{" "}
+          Headroom is called synchronously before each request. Large or first-seen
+          contexts can take the proxy several seconds (sometimes much longer on CPU-only
+          machines) to compress — when that exceeds the timeout below, Headroom{" "}
+          <span className="font-medium text-[var(--text)]">fails open</span> (the request
+          goes through uncompressed and records 0 savings). For consistent savings without
+          an external dependency, rely on{" "}
+          <span className="font-medium text-[var(--text)]">RTK</span> +{" "}
+          <span className="font-medium text-[var(--text)]">Caveman/Terse</span> +{" "}
+          <span className="font-medium text-[var(--text)]">Ponytail</span>, which run
+          instantly in-process.
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // HeadroomInstallHelp explains how to install and run a local Headroom proxy.
 // Headroom is the open-source headroom-ai proxy; KeiRouter calls its
 // /v1/compress endpoint. Shown inside the Headroom card so operators can get a
@@ -401,6 +429,7 @@ function SavingTab({
           icon={Zap}
           iconTone="neutral"
         />
+        <HeadroomAdvisory />
         <div className="flex items-center justify-between border-t border-[var(--border)] px-6 py-4">
           <span className="text-sm font-medium">Enable Headroom</span>
           <Toggle checked={local.headroom_enabled} onChange={(v) => saverUpdate({ headroom_enabled: v })} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,40 @@
   "name": "keirouter",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "dependencies": {
+        "headroom-ai": "^0.22.4"
+      }
+    },
+    "node_modules/headroom-ai": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/headroom-ai/-/headroom-ai-0.22.4.tgz",
+      "integrity": "sha512-9a0rgB/jsWe8gs/ggyUwe6E8DYwKAuBvlUml2ApwlUjb5EfJ611X6X+WG0SiXw3nO6sdyV1/+Ah5uw9P7ecnjw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@ai-sdk/provider": ">=1.0.0",
+        "@anthropic-ai/sdk": ">=0.30.0",
+        "ai": ">=6.0.0",
+        "openai": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/provider": {
+          "optional": true
+        },
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "headroom-ai": "^0.22.4"
+  }
+}


### PR DESCRIPTION
## Summary

Adds two new token savers and the analytics/UI plumbing around them, plus a few robustness fixes uncovered along the way.

### Token savers
- **Headroom** (input-side): compresses request messages via an external [Headroom](https://github.com/headroomlabs-ai/headroom) proxy (`/v1/compress`). Fully **fail-open** — any network error, non-2xx, timeout, or empty/invalid response leaves the request untouched. Includes **phantom-savings detection** (ignores reported token savings when the JSON body doesn't actually shrink ≥5%).
- **Ponytail** (output-side): injects a leveled "lazy senior developer" system prompt (`lite`/`full`/`ultra`) that biases the model toward minimal code. Idempotent via a sentinel marker; appends after Terse/Caveman without overwriting them.
- Pipeline order: `normalizer → RTK → Headroom → Terse/Caveman → Ponytail → provider translation`.

### Savings tracking
- `meter` records a Headroom snapshot (tokens/bytes saved, active flag) and a Ponytail-active flag.
- New migration `0022_headroom_ponytail_savings.sql` adds the columns; `store`/`insights` aggregate them with `COALESCE` so old records read as zero (backward compatible).
- Dashboard: Headroom/Ponytail controls in Settings, client-side validation, a **Test connection** probe for the proxy, and savings surfaced in analytics.

### Resilience hardening (found during testing)
- **Headroom is best-effort under load.** Bounded retry on transient statuses (503/429/502/504), a concurrency cap (default 4, `KEIROUTER_HEADROOM_MAX_CONCURRENCY`) so a burst can't stampede/crash a small single-worker proxy, and an advisory note in the UI explaining the cold-start tradeoff (large/cold contexts fail open).
- **Migration runner** tolerates an already-existing column on `ADD COLUMN`, fixing startup crashes when a migration was renamed after being applied.
- **Graceful shutdown** now waits for DB-touching background workers (oauth keepalive, health checker, cooldown sweeper) before `db.Close()`, removing a use-after-close race.
- **Makefile `dev`**: clear the trap before `kill 0` to stop dash from segfaulting via recursive signal handling on Ctrl-C.

### Docs
- README restructured (TOC, clearer install flow) and updated with the five token savers and the correct pipx-based Headroom setup.

## Testing
- `go build ./...` clean; `go test ./...` green (incl. new `headroom` retry/concurrency/fail-open tests, `pipeline` end-to-end pipeline→meter→store test, and `store` migration backward-compat tests).
- `tsc -b --noEmit` (frontend typecheck) clean.
- Manually exercised the Headroom proxy to characterize its 503/cold-start behavior; KeiRouter fails open correctly in every case.

## Notes
- Headroom integration is best-effort by design: when the external proxy is slow/unavailable, requests pass through uncompressed (0 savings) rather than failing. The instant in-process savers (RTK + Caveman/Terse + Ponytail) remain the primary path.