### PR TITLE
Easy install & easy run: Windows installer + keirouter start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,14 +211,14 @@ jobs:
               <<~EOS
                 Quick start:
                   keirouter -bootstrap    # create your first API key
-                  keirouter               # start server on :20180
+                  keirouter start         # start server on :20180
 
                 Dashboard: http://localhost:20180  (default password: keirouter)
               EOS
             end
 
             test do
-              assert_match "KeiRouter", shell_output("\#{bin}/keirouter --help 2>&1", 2)
+              assert_match "KeiRouter", shell_output("\#{bin}/keirouter --help 2>&1")
             end
           end
           EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
             goarch: amd64
           - goos: linux
             goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
     steps:
       - uses: actions/checkout@v5
 
@@ -51,19 +55,28 @@ jobs:
           CGO_ENABLED: "0"
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          MATRIX_GOOS: ${{ matrix.goos }}
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
+          BIN=keirouter
+          if [ "${MATRIX_GOOS}" = "windows" ]; then BIN=keirouter.exe; fi
           cd backend
-          go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" -o ../keirouter ./cmd/keirouter
+          go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" -o "../${BIN}" ./cmd/keirouter
 
       - name: Package
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
-          ARCHIVE="keirouter_${VERSION}_${MATRIX_GOOS}_${MATRIX_GOARCH}.tar.gz"
           mkdir -p dist/keirouter/frontend
-          cp keirouter dist/keirouter/
           cp -R frontend/dist dist/keirouter/frontend/
-          cd dist && tar -czf "../${ARCHIVE}" keirouter
+          if [ "${MATRIX_GOOS}" = "windows" ]; then
+            ARCHIVE="keirouter_${VERSION}_${MATRIX_GOOS}_${MATRIX_GOARCH}.zip"
+            cp keirouter.exe dist/keirouter/
+            ( cd dist && zip -qr "../${ARCHIVE}" keirouter )
+          else
+            ARCHIVE="keirouter_${VERSION}_${MATRIX_GOOS}_${MATRIX_GOARCH}.tar.gz"
+            cp keirouter dist/keirouter/
+            ( cd dist && tar -czf "../${ARCHIVE}" keirouter )
+          fi
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
         env:
           MATRIX_GOOS: ${{ matrix.goos }}
@@ -94,7 +107,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum *.tar.gz > checksums.txt
+          sha256sum *.tar.gz *.zip > checksums.txt
           cat checksums.txt
 
       - name: Generate changelog
@@ -149,6 +162,7 @@ jobs:
           body_path: CHANGES.md
           files: |
             artifacts/*.tar.gz
+            artifacts/*.zip
             artifacts/checksums.txt
 
       - name: Update Homebrew formula

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ backend/dist/
 coverage.txt
 /keirouter
 /keirouter.exe
+/backend/keirouter
 
 # Go build cache / vendor
 vendor/

--- a/Formula/keirouter.rb
+++ b/Formula/keirouter.rb
@@ -34,13 +34,13 @@ class Keirouter < Formula
     <<~EOS
       Quick start:
         keirouter -bootstrap    # create your first API key
-        keirouter               # start server on :20180
+        keirouter start         # start server on :20180
 
       Dashboard: http://localhost:20180  (default password: keirouter)
     EOS
   end
 
   test do
-    assert_match "KeiRouter", shell_output("\#{bin}/keirouter --help 2>&1", 2)
+    assert_match "KeiRouter", shell_output("#{bin}/keirouter --help 2>&1")
   end
 end

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ brew tap mydisha/keirouter https://github.com/mydisha/keirouter
 brew install keirouter
 
 keirouter -bootstrap   # mint your first API key (printed once — don't blink)
-keirouter              # fire up the server on :20180
+keirouter start        # fire up the server on :20180
 ```
 </details>
 
@@ -169,7 +169,7 @@ It downloads the latest prebuilt binary, drops it (plus the dashboard) into `%LO
 
 ```powershell
 keirouter -bootstrap   # mint your first API key (printed once)
-keirouter              # start the server on :20180
+keirouter start        # start the server on :20180
 ```
 
 > Pin a version or change the location with `$env:KEIROUTER_VERSION` / `$env:KEIROUTER_DIR` before running the one-liner.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Grab whichever path matches what's already on your machine — no need to instal
 | Method | You'll need | Great for |
 |---|---|---|
 | **Homebrew** | macOS or Linux with Homebrew | The fastest way to a prebuilt binary |
+| **Windows** | Windows 10/11 with PowerShell | Prebuilt binary, no Go/Node |
 | **From source** | Go 1.24+ and Node.js 20+ | Local hacking / latest `main` |
 | **Docker** | Just Docker | Clean, isolated runs |
 | **Docker Compose** | Docker + Docker Compose | VPS / production / Coolify |
@@ -153,6 +154,25 @@ docker compose up -d --build
 ```
 
 VPS, PostgreSQL, and Coolify notes live in [deploy/README.md](deploy/README.md).
+</details>
+
+<details>
+<summary><strong>Option E — Windows</strong> · prebuilt, no Go/Node needed</summary>
+
+Open **PowerShell** and run:
+
+```powershell
+irm https://raw.githubusercontent.com/mydisha/keirouter/main/scripts/install.ps1 | iex
+```
+
+It downloads the latest prebuilt binary, drops it (plus the dashboard) into `%LOCALAPPDATA%\KeiRouter`, and adds it to your PATH. Open a **new** terminal afterwards, then:
+
+```powershell
+keirouter -bootstrap   # mint your first API key (printed once)
+keirouter              # start the server on :20180
+```
+
+> Pin a version or change the location with `$env:KEIROUTER_VERSION` / `$env:KEIROUTER_DIR` before running the one-liner.
 </details>
 
 ### First login

--- a/backend/cmd/keirouter/main.go
+++ b/backend/cmd/keirouter/main.go
@@ -1,15 +1,35 @@
 // Command keirouter is the KeiRouter server entrypoint. It loads configuration,
 // builds the application, and serves until interrupted.
+//
+// Usage:
+//
+//	keirouter [command] [flags]
+//
+// Commands:
+//
+//	start        start the server (default when no command is given)
+//	status       check whether a local server is running and print its URL
+//	bootstrap    create an initial API key and exit
+//	version      print version and exit
+//	help         show usage
+//
+// For backward compatibility the legacy flag form is still accepted, so
+// `keirouter`, `keirouter -bootstrap`, `keirouter -healthcheck`, and
+// `keirouter -version` keep working exactly as before.
 package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
+	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -26,38 +46,184 @@ import (
 var Version = "dev"
 
 func main() {
-	if err := run(); err != nil {
-		fmt.Fprintln(os.Stderr, "keirouter:", err)
+	if err := run(os.Args[1:]); err != nil {
+		if !errors.Is(err, errSilent) {
+			fmt.Fprintln(os.Stderr, "keirouter:", err)
+		}
 		os.Exit(1)
 	}
 }
 
-func run() error {
-	showVersion := flag.Bool("version", false, "print version and exit")
-	configPath := flag.String("config", "", "path to a YAML config file (optional)")
-	bootstrap := flag.Bool("bootstrap", false, "create an initial API key and exit")
-	healthcheck := flag.Bool("healthcheck", false, "check the local HTTP health endpoint and exit")
-	keyName := flag.String("key-name", "default", "name for the bootstrapped API key")
-	flag.Parse()
+// errSilent signals a non-zero exit without printing the default error prefix.
+// Used by commands that already printed a user-friendly message.
+var errSilent = errors.New("silent")
 
-	resolvedVersion := version.Resolve(Version)
+// run dispatches to a subcommand when the first argument is a known verb.
+// Otherwise it falls back to the legacy flag form, which also serves the
+// server — so `keirouter`, `keirouter -bootstrap`, etc. keep working.
+func run(args []string) error {
+	if len(args) > 0 {
+		switch args[0] {
+		case "help", "-h", "--help":
+			printUsage(os.Stdout)
+			return nil
+		}
+	}
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		cmd := args[0]
+		rest := args[1:]
+		switch cmd {
+		case "start":
+			return cmdStart(rest)
+		case "status":
+			return cmdStatus(rest)
+		case "bootstrap":
+			return cmdBootstrap(rest)
+		case "version":
+			fmt.Println("keirouter", version.Resolve(Version))
+			return nil
+		default:
+			printUsage(os.Stderr)
+			return fmt.Errorf("unknown command %q", cmd)
+		}
+	}
+	// Legacy flag form (no subcommand). Equivalent to `start`, but also honors
+	// -bootstrap, -healthcheck, and -version for backward compatibility.
+	return runLegacy(args)
+}
 
-	if *showVersion {
-		fmt.Println("keirouter", resolvedVersion)
-		return nil
+func printUsage(w *os.File) {
+	fmt.Fprint(w, `KeiRouter — self-hostable AI gateway
+
+Usage:
+  keirouter [command] [flags]
+
+Commands:
+  start        Start the server (default when no command is given)
+  status       Check whether a local server is running and print its URL
+  bootstrap    Create an initial API key and print it once
+  version      Print version and exit
+  help         Show this help
+
+Common flags:
+  -config <path>     Path to a YAML config file (optional)
+  --no-browser       (start) Do not open the dashboard in a browser
+  -key-name <name>   (bootstrap) Name for the created API key
+
+Examples:
+  keirouter start                 # start the server, open the dashboard
+  keirouter start --no-browser    # start without opening a browser
+  keirouter bootstrap             # mint your first API key
+  keirouter status                # is it running?
+`)
+}
+
+// cmdStart parses start-specific flags and serves.
+func cmdStart(args []string) error {
+	fs := flag.NewFlagSet("start", flag.ContinueOnError)
+	configPath := fs.String("config", "", "path to a YAML config file (optional)")
+	noBrowser := fs.Bool("no-browser", false, "do not open the dashboard in a browser")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfg, log, isPretty, err := setup(*configPath)
+	if err != nil {
+		return err
+	}
+	// Open the dashboard by default, but only on an interactive terminal so
+	// headless/Docker runs stay quiet. --no-browser always wins.
+	openBrowser := isPretty && !*noBrowser
+	return serve(cfg, log, isPretty, openBrowser)
+}
+
+// cmdBootstrap creates an initial API key and exits.
+func cmdBootstrap(args []string) error {
+	fs := flag.NewFlagSet("bootstrap", flag.ContinueOnError)
+	configPath := fs.String("config", "", "path to a YAML config file (optional)")
+	keyName := fs.String("key-name", "default", "name for the bootstrapped API key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfg, _, _, err := setup(*configPath)
+	if err != nil {
+		return err
+	}
+	return doBootstrap(cfg, *keyName)
+}
+
+// cmdStatus reports whether a local server is reachable.
+func cmdStatus(args []string) error {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	configPath := fs.String("config", "", "path to a YAML config file (optional)")
+	if err := fs.Parse(args); err != nil {
+		return err
 	}
 
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+	url := dashboardURL(cfg)
+	if err := runHealthcheck(cfg); err != nil {
+		fmt.Printf("KeiRouter is not running (no response at %s)\n", url)
+		return errSilent
+	}
+	fmt.Printf("KeiRouter is running → %s\n", url)
+	return nil
+}
 
-	log, isPretty := newLogger(cfg.Log)
-	slog.SetDefault(log)
+// runLegacy preserves the original flag-based entrypoint so existing usage
+// (`keirouter`, `keirouter -bootstrap`, `keirouter -healthcheck`,
+// `keirouter -version`) keeps working unchanged.
+func runLegacy(args []string) error {
+	fs := flag.NewFlagSet("keirouter", flag.ContinueOnError)
+	showVersion := fs.Bool("version", false, "print version and exit")
+	configPath := fs.String("config", "", "path to a YAML config file (optional)")
+	bootstrap := fs.Bool("bootstrap", false, "create an initial API key and exit")
+	healthcheck := fs.Bool("healthcheck", false, "check the local HTTP health endpoint and exit")
+	keyName := fs.String("key-name", "default", "name for the bootstrapped API key")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *showVersion {
+		fmt.Println("keirouter", version.Resolve(Version))
+		return nil
+	}
+
+	cfg, log, isPretty, err := setup(*configPath)
+	if err != nil {
+		return err
+	}
 
 	if *healthcheck {
 		return runHealthcheck(cfg)
 	}
+	if *bootstrap {
+		return doBootstrap(cfg, *keyName)
+	}
+	// Legacy plain `keirouter` keeps the original behavior: serve without
+	// auto-opening a browser.
+	return serve(cfg, log, isPretty, false)
+}
+
+// setup loads configuration and initializes the default logger.
+func setup(configPath string) (config.Config, *slog.Logger, bool, error) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return config.Config{}, nil, false, fmt.Errorf("load config: %w", err)
+	}
+	log, isPretty := newLogger(cfg.Log)
+	slog.SetDefault(log)
+	return cfg, log, isPretty, nil
+}
+
+// serve builds the application and runs it until interrupted. When openBrowser
+// is true it launches the dashboard once the server reports healthy.
+func serve(cfg config.Config, log *slog.Logger, isPretty, openBrowser bool) error {
+	resolvedVersion := version.Resolve(Version)
 
 	// Print the startup banner in pretty mode (TTY only).
 	if isPretty {
@@ -83,14 +249,8 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if *bootstrap {
-		plaintext, berr := app.Bootstrap(ctx, cfg, *keyName)
-		if berr != nil {
-			return berr
-		}
-		fmt.Println("Created API key (copy it now, it will not be shown again):")
-		fmt.Println(plaintext)
-		return nil
+	if openBrowser {
+		go openDashboardWhenReady(ctx, cfg)
 	}
 
 	application, err := app.Build(ctx, cfg, log, resolvedVersion)
@@ -101,22 +261,97 @@ func run() error {
 	return application.Run(ctx)
 }
 
-func runHealthcheck(cfg config.Config) error {
-	host := cfg.Server.Host
-	if host == "" || host == "0.0.0.0" || host == "::" {
-		host = "127.0.0.1"
-	}
-	url := fmt.Sprintf("http://%s:%d/healthz", host, cfg.Server.Port)
-	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get(url)
+// doBootstrap creates an initial API key and prints it once.
+func doBootstrap(cfg config.Config, keyName string) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	plaintext, err := app.Bootstrap(ctx, cfg, keyName)
 	if err != nil {
-		return fmt.Errorf("healthcheck %s: %w", url, err)
+		return err
+	}
+	fmt.Println("Created API key (copy it now, it will not be shown again):")
+	fmt.Println(plaintext)
+	return nil
+}
+
+func runHealthcheck(cfg config.Config) error {
+	resp, err := http.Get(healthURL(cfg))
+	if err != nil {
+		return fmt.Errorf("healthcheck %s: %w", healthURL(cfg), err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("healthcheck %s: %s", url, resp.Status)
+		return fmt.Errorf("healthcheck %s: %s", healthURL(cfg), resp.Status)
 	}
 	return nil
+}
+
+// loopbackHost normalizes a wildcard/empty bind address to a reachable
+// loopback host for local client connections.
+func loopbackHost(cfg config.Config) string {
+	host := cfg.Server.Host
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		return "127.0.0.1"
+	}
+	return host
+}
+
+func healthURL(cfg config.Config) string {
+	return fmt.Sprintf("http://%s:%d/healthz", loopbackHost(cfg), cfg.Server.Port)
+}
+
+// dashboardURL is the friendly URL to show users and open in a browser.
+func dashboardURL(cfg config.Config) string {
+	host := loopbackHost(cfg)
+	if host == "127.0.0.1" {
+		host = "localhost"
+	}
+	return fmt.Sprintf("http://%s:%d", host, cfg.Server.Port)
+}
+
+// openDashboardWhenReady polls the health endpoint until the server is up (or
+// ctx is cancelled), then opens the dashboard in the default browser. Failures
+// are best-effort: the user can always open the URL printed in the banner.
+func openDashboardWhenReady(ctx context.Context, cfg config.Config) {
+	client := &http.Client{Timeout: 1 * time.Second}
+	ticker := time.NewTicker(300 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(30 * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline:
+			return
+		case <-ticker.C:
+			resp, err := client.Get(healthURL(cfg))
+			if err != nil {
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				openBrowser(dashboardURL(cfg))
+				return
+			}
+		}
+	}
+}
+
+// openBrowser opens url in the system default browser. Best-effort; errors are
+// ignored because the URL is also printed to the console.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	_ = cmd.Start()
 }
 
 // newLogger builds a structured logger per config. Returns the logger and

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -153,7 +153,7 @@ Write-Ok "KeiRouter $Version installed."
 Write-Host ""
 Write-Host "Quick start:" -ForegroundColor Cyan
 Write-Host "  keirouter -bootstrap     # create your first API key (shown once)"
-Write-Host "  keirouter                # start the server on :20180"
+Write-Host "  keirouter start          # start the server on :20180"
 Write-Host ""
 Write-Host "Dashboard: http://localhost:20180  (default password: keirouter)"
 Write-Host ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,160 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    KeiRouter installer for Windows.
+
+.DESCRIPTION
+    Downloads the latest prebuilt KeiRouter release, extracts the binary and
+    dashboard assets into a per-user directory, and adds it to your PATH so you
+    can run `keirouter` from any new terminal.
+
+    No Go or Node.js required — this installs a prebuilt binary.
+
+.PARAMETER Version
+    Release version to install (e.g. "v0.1.18"). Defaults to the latest release.
+
+.PARAMETER InstallDir
+    Where to install. Defaults to %LOCALAPPDATA%\KeiRouter.
+
+.EXAMPLE
+    irm https://raw.githubusercontent.com/mydisha/keirouter/main/scripts/install.ps1 | iex
+
+.EXAMPLE
+    # Pin a version and a custom directory:
+    $env:KEIROUTER_VERSION = "v0.1.18"; $env:KEIROUTER_DIR = "D:\Tools\KeiRouter"
+    irm https://raw.githubusercontent.com/mydisha/keirouter/main/scripts/install.ps1 | iex
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = $env:KEIROUTER_VERSION,
+    [string]$InstallDir = $env:KEIROUTER_DIR
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"  # speeds up Invoke-WebRequest downloads
+
+$Repo = "mydisha/keirouter"
+
+function Write-Info($msg)  { Write-Host "> $msg" -ForegroundColor Cyan }
+function Write-Ok($msg)    { Write-Host "OK $msg" -ForegroundColor Green }
+function Write-Warn($msg)  { Write-Host "! $msg"  -ForegroundColor Yellow }
+function Die($msg)         { Write-Host "ERROR $msg" -ForegroundColor Red; exit 1 }
+
+# ── Banner ───────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "  KeiRouter - Windows installer" -ForegroundColor Green
+Write-Host ""
+
+# ── Detect architecture ───────────────────────────────────────────────────────
+# Under a 32-bit (WOW64) process on a 64-bit OS, PROCESSOR_ARCHITECTURE reports
+# "x86" while PROCESSOR_ARCHITEW6432 holds the real architecture.
+$rawArch = $env:PROCESSOR_ARCHITECTURE
+if ($env:PROCESSOR_ARCHITEW6432) { $rawArch = $env:PROCESSOR_ARCHITEW6432 }
+switch ($rawArch) {
+    "AMD64" { $arch = "amd64" }
+    "ARM64" { $arch = "arm64" }
+    "x86"   { Die "32-bit Windows is not supported. KeiRouter ships amd64 and arm64 builds only." }
+    default { Die "Unsupported architecture: $rawArch" }
+}
+Write-Info "Architecture: $arch"
+
+# ── Resolve version ────────────────────────────────────────────────────────────
+if (-not $Version) {
+    Write-Info "Resolving latest release..."
+    try {
+        $headers = @{ "User-Agent" = "keirouter-installer" }
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers $headers
+        $Version = $release.tag_name
+    } catch {
+        Die "Could not resolve the latest release. Set `$env:KEIROUTER_VERSION (e.g. v0.1.18) and retry. ($($_.Exception.Message))"
+    }
+}
+if ($Version -notmatch '^v') { $Version = "v$Version" }
+Write-Ok "Version: $Version"
+
+# ── Resolve install dir ────────────────────────────────────────────────────────
+if (-not $InstallDir) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "KeiRouter"
+}
+Write-Info "Install directory: $InstallDir"
+
+# ── Download archive ───────────────────────────────────────────────────────────
+$asset = "keirouter_${Version}_windows_${arch}.zip"
+$url = "https://github.com/$Repo/releases/download/$Version/$asset"
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("keirouter_" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+$zipPath = Join-Path $tmp $asset
+
+Write-Info "Downloading $asset..."
+try {
+    Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+} catch {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+    Die "Download failed from $url`n  ($($_.Exception.Message))"
+}
+Write-Ok "Downloaded"
+
+# ── Extract ────────────────────────────────────────────────────────────────────
+Write-Info "Extracting..."
+$extractDir = Join-Path $tmp "extract"
+try {
+    Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+} catch {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+    Die "Failed to extract archive: $($_.Exception.Message)"
+}
+
+# The archive contains a top-level "keirouter/" folder holding keirouter.exe and frontend/.
+$payload = Join-Path $extractDir "keirouter"
+if (-not (Test-Path (Join-Path $payload "keirouter.exe"))) {
+    # Fallback: some archives may not nest under keirouter/.
+    if (Test-Path (Join-Path $extractDir "keirouter.exe")) {
+        $payload = $extractDir
+    } else {
+        Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+        Die "keirouter.exe not found in the downloaded archive."
+    }
+}
+
+# ── Install (stop a running instance first so the .exe isn't locked) ───────────
+Get-Process -Name "keirouter" -ErrorAction SilentlyContinue | ForEach-Object {
+    Write-Warn "Stopping running keirouter process (PID $($_.Id))"
+    try { $_.Kill() } catch {}
+}
+
+Write-Info "Installing to $InstallDir..."
+New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+# Clear previous binary + assets, keep any user data that might live alongside.
+Remove-Item (Join-Path $InstallDir "keirouter.exe") -Force -ErrorAction SilentlyContinue
+Remove-Item (Join-Path $InstallDir "frontend") -Recurse -Force -ErrorAction SilentlyContinue
+Copy-Item -Path (Join-Path $payload "*") -Destination $InstallDir -Recurse -Force
+
+Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+Write-Ok "Installed keirouter.exe and dashboard assets"
+
+# ── Add to PATH (user scope) ───────────────────────────────────────────────────
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$paths = @()
+if ($userPath) { $paths = $userPath.Split(';') | Where-Object { $_ -ne "" } }
+if ($paths -notcontains $InstallDir) {
+    Write-Info "Adding $InstallDir to your user PATH"
+    $newPath = (($paths + $InstallDir) -join ';')
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    # Make it available in the current session too.
+    $env:Path = "$env:Path;$InstallDir"
+    Write-Ok "PATH updated (open a new terminal for it to take effect everywhere)"
+} else {
+    Write-Ok "PATH already contains the install directory"
+}
+
+# ── Done ───────────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Ok "KeiRouter $Version installed."
+Write-Host ""
+Write-Host "Quick start:" -ForegroundColor Cyan
+Write-Host "  keirouter -bootstrap     # create your first API key (shown once)"
+Write-Host "  keirouter                # start the server on :20180"
+Write-Host ""
+Write-Host "Dashboard: http://localhost:20180  (default password: keirouter)"
+Write-Host ""
+Write-Warn "Open a NEW terminal window before running 'keirouter' so the PATH change applies."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -208,7 +208,7 @@ run_source_install() {
   ok "Dashboard assets installed to $SHARE_DIR/frontend/dist"
   echo ""
   echo "Quick start:"
-  echo "  keirouter                  # start the server on :20180"
+  echo "  keirouter start            # start the server on :20180"
   echo "  keirouter -bootstrap       # create your first API key"
   echo ""
   echo "Dashboard: http://localhost:20180  (default password: keirouter)"


### PR DESCRIPTION
## Summary

Closes #23 — makes KeiRouter easy to install and easy to re-run, especially for Windows users.

The reporter installed via the `quickstart.sh` one-liner (a dev-runner that rebuilds from source every time) and had no persistent command to start the server again. There was also no prebuilt Windows binary at all — the release pipeline only built macOS and Linux.

This PR ships the two highest-impact pieces:

### Windows release + installer (no Go/Node required)
- Add `windows/amd64` and `windows/arm64` targets to the release matrix.
- Package Windows builds as `.zip` (binary + dashboard assets); macOS/Linux stay `.tar.gz`.
- Include `.zip` files in checksums and GitHub release uploads.
- New `scripts/install.ps1` PowerShell one-liner: detects architecture, resolves the latest release (pinnable via `$env:KEIROUTER_VERSION`), downloads + extracts into `%LOCALAPPDATA%\KeiRouter`, and adds it to the user PATH. Assets land next to the binary so `resolveFrontendDir()` finds the dashboard automatically.

```powershell
irm https://raw.githubusercontent.com/mydisha/keirouter/main/scripts/install.ps1 | iex
```

### `keirouter start` subcommand (9router-style UX)
Restructured the CLI to support explicit verbs while staying 100% backward compatible:

- `keirouter start` — start the server; opens the dashboard in a browser on an interactive terminal (`--no-browser` to disable).
- `keirouter status` — check whether a local server is running and print its URL (exit 0/1 for scripting).
- `keirouter bootstrap` — mint an API key.
- `keirouter version` / `keirouter help`.
- Legacy forms preserved exactly: bare `keirouter`, `keirouter -bootstrap`, `keirouter -healthcheck` (used by Docker HEALTHCHECK), `keirouter -version`.

Docs and installer hints (README, `install.ps1`, `install.sh`, Homebrew caveats) updated to surface `keirouter start`.

## Testing
- `go build ./...` and `go vet ./cmd/keirouter` pass.
- Verified CLI manually: `version`, `help`/`-h`/`--help`, unknown-command error, `status` (running and not-running), and `start` boots the server and reports healthy via `status`.
- `release.yml` validated as well-formed YAML.

## Notes
- The PowerShell installer downloads from GitHub releases, so it only works fully once a tag is cut that includes the new Windows artifacts from this updated workflow.
- `stop`/`restart` and background/tray mode were intentionally left out — they require cross-platform process management (no Unix signals on Windows) and are a larger effort. For a foreground server, Ctrl+C is sufficient.
