### PR TITLE
feat: mature bulk key/proxy upload, multi-select bulk actions, stricter validation, faster update checks

### DIFF
--- a/backend/internal/connectors/anthropic.go
+++ b/backend/internal/connectors/anthropic.go
@@ -92,6 +92,16 @@ func (c *Anthropic) Validate(ctx context.Context, creds core.Credentials) error 
 	modelsURL := base + "/models"
 	_, err := doJSONMethod(ctx, http.MethodGet, c.id, "validate", modelsURL, nil, c.headers(creds))
 	if err == nil {
+		// The official Anthropic API auth-protects GET /models, so a 200 proves
+		// the key. Anthropic-compatible third-party gateways may list models
+		// without auth, so confirm those with a minimal messages probe.
+		hasKey := strings.TrimSpace(creds.APIKey) != "" || strings.TrimSpace(creds.AccessToken) != ""
+		if c.id == "anthropic" || !hasKey {
+			return nil
+		}
+		if perr := c.messagesAuthProbe(ctx, creds); perr != nil {
+			return fmt.Errorf("validation failed for %s: %w", c.id, perr)
+		}
 		return nil
 	}
 	// If it's an auth error, the key is bad.
@@ -100,11 +110,26 @@ func (c *Anthropic) Validate(ctx context.Context, creds core.Credentials) error 
 		return fmt.Errorf("validation failed for %s: %w", c.id, err)
 	}
 	// Otherwise /models may not exist (404 etc); fall back to a minimal chat probe.
+	if perr := c.messagesAuthProbe(ctx, creds); perr != nil {
+		return fmt.Errorf("validation failed for %s: %w", c.id, perr)
+	}
+	return nil
+}
+
+// messagesAuthProbe issues a minimal POST /messages request (max_tokens=1) to
+// confirm the credential is accepted. Only an auth failure (401/403) or a
+// transport error that never reached the provider counts as a failure; a
+// non-auth HTTP response (e.g. an unknown probe model) still proves the key was
+// accepted.
+func (c *Anthropic) messagesAuthProbe(ctx context.Context, creds core.Credentials) error {
 	chatURL := joinURL(c.baseURL(creds), "messages")
 	probeBody := []byte(`{"model":"claude-sonnet-4-20250514","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}`)
-	_, err = doJSON(ctx, c.id, "validate", chatURL, probeBody, c.headers(creds))
-	if err != nil {
-		return fmt.Errorf("validation failed for %s: %w", c.id, err)
+	_, err := doJSON(ctx, c.id, "validate", chatURL, probeBody, c.headers(creds))
+	if err == nil {
+		return nil
+	}
+	if validationAuthError(err) || !validationReachedUpstream(err) {
+		return err
 	}
 	return nil
 }

--- a/backend/internal/connectors/connectors_test.go
+++ b/backend/internal/connectors/connectors_test.go
@@ -242,3 +242,67 @@ func TestRegistry_DefaultProviders(t *testing.T) {
 	_, err = reg.Get("nonexistent")
 	require.Error(t, err)
 }
+
+// publicModelsServer simulates a non-strict OpenAI-compatible gateway whose
+// GET /models endpoint lists models WITHOUT checking auth, while the chat
+// endpoint properly rejects a bad key with 401. This is the case that made
+// invalid keys pass validation before the authenticated chat probe was added.
+func publicModelsServer(t *testing.T, goodKey string) (*httptest.Server, *bool) {
+	t.Helper()
+	chatProbed := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models":
+			// No auth check — returns 200 for anyone.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m1"}]}`))
+		case "/chat/completions":
+			chatProbed = true
+			if r.Header.Get("Authorization") != "Bearer "+goodKey {
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprint(w, `{"error":"invalid api key"}`)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &chatProbed
+}
+
+func TestOpenAICompatible_ValidateConfirmsKeyWhenModelsIsPublic(t *testing.T) {
+	t.Run("bad key is rejected via chat probe", func(t *testing.T) {
+		srv, chatProbed := publicModelsServer(t, "good-key")
+		c := NewOpenAICompatible("sumopod", srv.URL)
+		err := c.Validate(context.Background(), core.Credentials{APIKey: "bad-key"})
+		require.Error(t, err, "a bad key must fail even when /models returns 200 without auth")
+		require.True(t, *chatProbed, "validation should confirm the key with a chat probe")
+	})
+
+	t.Run("good key passes", func(t *testing.T) {
+		srv, chatProbed := publicModelsServer(t, "good-key")
+		c := NewOpenAICompatible("sumopod", srv.URL)
+		require.NoError(t, c.Validate(context.Background(), core.Credentials{APIKey: "good-key"}))
+		require.True(t, *chatProbed)
+	})
+}
+
+func TestOpenAICompatible_ValidateStrictTrustsModels200(t *testing.T) {
+	// Strict providers (e.g. openai) auth-protect /models, so a 200 is conclusive
+	// and the chat probe must NOT be issued (avoids consuming quota).
+	srv, chatProbed := publicModelsServer(t, "good-key")
+	c := NewOpenAICompatible("openai", srv.URL)
+	require.NoError(t, c.Validate(context.Background(), core.Credentials{APIKey: "any-key"}))
+	require.False(t, *chatProbed, "strict providers should trust a /models 200 without a chat probe")
+}
+
+func TestOpenAICompatible_ValidateNoAuthTrustsModels200(t *testing.T) {
+	// No-auth accounts (no key/token) only get a reachability check.
+	srv, chatProbed := publicModelsServer(t, "good-key")
+	c := NewOpenAICompatible("local-gw", srv.URL)
+	require.NoError(t, c.Validate(context.Background(), core.Credentials{}))
+	require.False(t, *chatProbed, "no-auth accounts should not issue a chat probe")
+}

--- a/backend/internal/connectors/openai_compatible.go
+++ b/backend/internal/connectors/openai_compatible.go
@@ -162,6 +162,19 @@ func (c *OpenAICompatible) Validate(ctx context.Context, creds core.Credentials)
 	url := joinURL(c.baseURL(creds), "models")
 	_, err := doJSONMethod(ctx, http.MethodGet, c.id, "validate", url, nil, c.headers(creds))
 	if err == nil {
+		// GET /models reached the upstream. For no-auth accounts (e.g. a local
+		// gateway) reachability is all we can verify. For strict providers the
+		// /models endpoint itself requires the key, so a 200 proves it is valid.
+		// For any other keyed account a 200 is NOT proof — many OpenAI-compatible
+		// providers list models without checking auth — so confirm the key with
+		// an authenticated chat probe before reporting success.
+		hasKey := strings.TrimSpace(creds.APIKey) != "" || strings.TrimSpace(creds.AccessToken) != ""
+		if !hasKey || strictModelsValidation(c.id) {
+			return nil
+		}
+		if perr := c.chatAuthProbe(ctx, creds); perr != nil {
+			return fmt.Errorf("validation failed for %s: %w", c.id, perr)
+		}
 		return nil
 	}
 	if c.id == "xai" {
@@ -182,6 +195,18 @@ func (c *OpenAICompatible) Validate(ctx context.Context, creds core.Credentials)
 	// probe models with 400/404 while still accepting the credential. Fall back
 	// to a minimal chat request and treat any non-auth HTTP response as proof
 	// that the connection reached the provider.
+	if err := c.chatAuthProbe(ctx, creds); err != nil {
+		return fmt.Errorf("validation failed for %s: %w", c.id, err)
+	}
+	return nil
+}
+
+// chatAuthProbe issues a minimal, near-zero-cost chat request (max_tokens=1) to
+// confirm the credential is actually accepted by the upstream. It relies on
+// validateProbe semantics: only an auth failure (401/403) or a transport error
+// that never reached the provider counts as a failure. A non-auth HTTP response
+// (e.g. a 400/404 for an unknown probe model) still proves the key was accepted.
+func (c *OpenAICompatible) chatAuthProbe(ctx context.Context, creds core.Credentials) error {
 	probeModel := firstCatalogModel(c.id)
 	body, _ := json.Marshal(map[string]any{
 		"model": probeModel,
@@ -191,10 +216,7 @@ func (c *OpenAICompatible) Validate(ctx context.Context, creds core.Credentials)
 		"max_tokens": 1,
 		"stream":     false,
 	})
-	if err := validateProbe(ctx, c.id, c.chatCompletionsURL(creds, probeModel), body, c.headers(creds)); err != nil {
-		return fmt.Errorf("validation failed for %s: %w", c.id, err)
-	}
-	return nil
+	return validateProbe(ctx, c.id, c.chatCompletionsURL(creds, probeModel), body, c.headers(creds))
 }
 
 func validateProbe(ctx context.Context, provider, endpoint string, body []byte, headers map[string]string) error {

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -39,6 +41,7 @@ func (s *Server) mountAdmin(r chi.Router) {
 
 	r.Get("/accounts", s.adminListAccounts)
 	r.Post("/accounts", s.adminCreateAccount)
+	r.Post("/accounts/bulk", s.adminBulkCreateAccounts)
 	r.Post("/validate-key", s.adminValidateKey)
 	r.Patch("/accounts/{id}", s.adminUpdateAccount)
 	r.Delete("/accounts/{id}", s.adminDeleteAccount)
@@ -703,6 +706,232 @@ func (s *Server) adminCreateAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{"id": acc.ID, "provider": acc.Provider, "label": acc.Label})
+}
+
+// bulkMaxItems caps the number of credentials accepted in a single bulk import
+// to bound memory, upstream validation fan-out, and DB write time.
+const bulkMaxItems = 1000
+
+// bulkValidateConcurrency bounds how many upstream credential probes run at
+// once during a bulk import with validation enabled.
+const bulkValidateConcurrency = 6
+
+type bulkAccountItem struct {
+	Label   string `json:"label"`
+	APIKey  string `json:"api_key"`
+	BaseURL string `json:"base_url"`
+}
+
+type bulkAccountsRequest struct {
+	Provider string `json:"provider"`
+	// Shared settings applied to every item unless an item overrides them.
+	BaseURL           string `json:"base_url"`
+	Region            string `json:"region"`
+	AccountID         string `json:"account_id"`
+	AzureEndpoint     string `json:"azure_endpoint"`
+	AzureDeployment   string `json:"azure_deployment"`
+	AzureAPIVersion   string `json:"azure_api_version"`
+	AzureOrganization string `json:"azure_organization"`
+	Priority          int    `json:"priority"`
+	ProxyPoolID       string `json:"proxy_pool_id"`
+	// Validate probes each credential against the upstream before persisting.
+	// Off by default for bulk to avoid slow imports and upstream rate limits.
+	Validate bool              `json:"validate"`
+	Items    []bulkAccountItem `json:"items"`
+}
+
+type bulkAccountResult struct {
+	Index  int    `json:"index"`
+	Label  string `json:"label"`
+	Status string `json:"status"` // created | error | skipped
+	ID     string `json:"id,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// adminBulkCreateAccounts imports many provider credentials in one request. It
+// reuses the same sealing, metadata, validation, and persistence path as the
+// single-create handler, but reports a per-item outcome so partial failures
+// don't abort the whole batch. Upstream validation (when enabled) runs with a
+// bounded worker pool; DB writes are serialized to stay friendly to SQLite.
+func (s *Server) adminBulkCreateAccounts(w http.ResponseWriter, r *http.Request) {
+	var body bulkAccountsRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if body.Provider == "" {
+		writeError(w, http.StatusBadRequest, "provider is required")
+		return
+	}
+	spec, ok := connectors.SpecByID(body.Provider)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "unknown provider: "+body.Provider)
+		return
+	}
+	if s.vault == nil {
+		writeError(w, http.StatusInternalServerError, "vault not configured")
+		return
+	}
+	if len(body.Items) == 0 {
+		writeError(w, http.StatusBadRequest, "items is required")
+		return
+	}
+	if len(body.Items) > bulkMaxItems {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("too many items: %d (max %d)", len(body.Items), bulkMaxItems))
+		return
+	}
+
+	// SSRF Protection: validate the shared base/endpoint URLs once up front.
+	if body.BaseURL != "" {
+		if err := httputil.ValidateBaseURL(body.BaseURL); err != nil {
+			s.log.Warn("blocked suspicious base_url", "url", body.BaseURL, "error", err)
+			writeError(w, http.StatusBadRequest, "invalid base_url: URL blocked by security policy")
+			return
+		}
+	}
+	if body.AzureEndpoint != "" {
+		if err := httputil.ValidateBaseURL(body.AzureEndpoint); err != nil {
+			s.log.Warn("blocked suspicious azure_endpoint", "url", body.AzureEndpoint, "error", err)
+			writeError(w, http.StatusBadRequest, "invalid azure_endpoint: URL blocked by security policy")
+			return
+		}
+	}
+
+	results := make([]bulkAccountResult, len(body.Items))
+	var (
+		seen    = map[string]struct{}{} // de-dup api keys within the batch
+		seenMu  sync.Mutex
+		writeMu sync.Mutex // serialize DB writes (SQLite-friendly)
+		sem     = make(chan struct{}, bulkValidateConcurrency)
+		wg      sync.WaitGroup
+	)
+
+	for i, item := range body.Items {
+		label := strings.TrimSpace(item.Label)
+		key := strings.TrimSpace(item.APIKey)
+		results[i] = bulkAccountResult{Index: i, Label: label}
+
+		authKind := accountAuthKind(spec, key)
+		if authKind != store.AuthNone && key == "" {
+			results[i].Status = "error"
+			results[i].Error = "api_key is required"
+			continue
+		}
+
+		// De-duplicate identical keys within the same batch.
+		if key != "" {
+			seenMu.Lock()
+			if _, dup := seen[key]; dup {
+				seenMu.Unlock()
+				results[i].Status = "skipped"
+				results[i].Error = "duplicate api key in batch"
+				continue
+			}
+			seen[key] = struct{}{}
+			seenMu.Unlock()
+		}
+
+		// Per-item base URL overrides the shared one when present.
+		baseURL := strings.TrimSpace(item.BaseURL)
+		if baseURL == "" {
+			baseURL = body.BaseURL
+		}
+		if baseURL != "" {
+			if err := httputil.ValidateBaseURL(baseURL); err != nil {
+				results[i].Status = "error"
+				results[i].Error = "invalid base_url: URL blocked by security policy"
+				continue
+			}
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, label, key, baseURL string, authKind store.AuthKind) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			meta, err := providerAccountMetadata(spec, providerMetadataInput{
+				BaseURL:           baseURL,
+				Region:            body.Region,
+				AccountID:         body.AccountID,
+				AzureEndpoint:     body.AzureEndpoint,
+				AzureDeployment:   body.AzureDeployment,
+				AzureAPIVersion:   body.AzureAPIVersion,
+				AzureOrganization: body.AzureOrganization,
+			})
+			if err != nil {
+				results[i].Status = "error"
+				results[i].Error = err.Error()
+				return
+			}
+
+			now := time.Now()
+			displayLabel := label
+			if displayLabel == "" {
+				displayLabel = fmt.Sprintf("%s-%d", spec.DisplayName, i+1)
+			}
+			acc := store.Account{
+				ID:        uuid.NewString(),
+				TenantID:  adminTenant,
+				Provider:  body.Provider,
+				Label:     displayLabel,
+				AuthKind:  authKind,
+				Priority:  defaultInt(body.Priority, 100),
+				CreatedAt: now,
+				UpdatedAt: now,
+			}
+			if body.ProxyPoolID != "" {
+				acc.ProxyPoolID = body.ProxyPoolID
+			}
+			if err := s.vault.Seal(&acc, vault.NewSecret{APIKey: key, Metadata: meta}); err != nil {
+				results[i].Status = "error"
+				results[i].Error = "vault seal failed"
+				return
+			}
+
+			if body.Validate {
+				if verr := s.validateAccountCredentials(r.Context(), acc); verr != nil {
+					results[i].Status = "error"
+					results[i].Error = sanitizeError(s.log, verr, "credential validation failed")
+					return
+				}
+			}
+
+			writeMu.Lock()
+			err = s.accounts.Create(r.Context(), acc)
+			writeMu.Unlock()
+			if err != nil {
+				results[i].Status = "error"
+				results[i].Error = sanitizeError(s.log, err, "account creation failed")
+				return
+			}
+			results[i].Status = "created"
+			results[i].ID = acc.ID
+			results[i].Label = displayLabel
+		}(i, label, key, baseURL, authKind)
+	}
+
+	wg.Wait()
+
+	sort.Slice(results, func(a, b int) bool { return results[a].Index < results[b].Index })
+	var created, failed, skipped int
+	for _, res := range results {
+		switch res.Status {
+		case "created":
+			created++
+		case "skipped":
+			skipped++
+		default:
+			failed++
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"total":   len(results),
+		"created": created,
+		"failed":  failed,
+		"skipped": skipped,
+		"results": results,
+	})
 }
 
 func (s *Server) adminDeleteAccount(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/gateway/admin_bulk_test.go
+++ b/backend/internal/gateway/admin_bulk_test.go
@@ -1,0 +1,108 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mydisha/keirouter/backend/internal/config"
+	"github.com/mydisha/keirouter/backend/internal/crypto"
+	"github.com/mydisha/keirouter/backend/internal/store"
+	"github.com/mydisha/keirouter/backend/internal/vault"
+)
+
+// newBulkTestServer builds a minimal Server wired with just the store and vault
+// needed by adminBulkCreateAccounts. Validation is exercised with validate=false
+// so no upstream connector/refresher is required.
+func newBulkTestServer(t *testing.T) (*Server, *store.DB) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := store.Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: ":memory:"}, t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, db.Migrate(ctx))
+	require.NoError(t, db.Tenants().EnsureDefault(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	mk, err := crypto.GenerateMasterKey()
+	require.NoError(t, err)
+	sealer, err := crypto.NewSealer(mk)
+	require.NoError(t, err)
+
+	s := &Server{
+		accounts: db.Accounts(),
+		vault:    vault.New(sealer),
+		log:      slog.Default(),
+	}
+	return s, db
+}
+
+func bulkResponse(t *testing.T, s *Server, body string) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/accounts/bulk", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.adminBulkCreateAccounts(rec, req)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	return rec.Code, out
+}
+
+func TestBulkCreateAccounts_PartialOutcomes(t *testing.T) {
+	s, db := newBulkTestServer(t)
+
+	// sk-1 appears twice (the second is a duplicate), one item has an empty key.
+	body := `{
+		"provider": "openai",
+		"validate": false,
+		"items": [
+			{"label": "alpha", "api_key": "sk-1"},
+			{"api_key": "sk-2"},
+			{"label": "dup", "api_key": "sk-1"},
+			{"label": "empty", "api_key": ""}
+		]
+	}`
+	code, out := bulkResponse(t, s, body)
+	require.Equal(t, http.StatusOK, code)
+	require.EqualValues(t, 4, out["total"])
+	require.EqualValues(t, 2, out["created"])
+	require.EqualValues(t, 1, out["skipped"])
+	require.EqualValues(t, 1, out["failed"])
+
+	// Two accounts persisted.
+	accs, err := db.Accounts().ListByTenant(context.Background(), adminTenant)
+	require.NoError(t, err)
+	require.Len(t, accs, 2)
+
+	// Results preserve input order.
+	results, ok := out["results"].([]any)
+	require.True(t, ok)
+	require.Len(t, results, 4)
+	statuses := make([]string, len(results))
+	for i, r := range results {
+		statuses[i] = r.(map[string]any)["status"].(string)
+	}
+	require.Equal(t, []string{"created", "created", "skipped", "error"}, statuses)
+}
+
+func TestBulkCreateAccounts_Validation(t *testing.T) {
+	s, _ := newBulkTestServer(t)
+
+	// Unknown provider.
+	code, _ := bulkResponse(t, s, `{"provider":"does-not-exist","items":[{"api_key":"x"}]}`)
+	require.Equal(t, http.StatusBadRequest, code)
+
+	// Missing provider.
+	code, _ = bulkResponse(t, s, `{"items":[{"api_key":"x"}]}`)
+	require.Equal(t, http.StatusBadRequest, code)
+
+	// Empty items.
+	code, _ = bulkResponse(t, s, `{"provider":"openai","items":[]}`)
+	require.Equal(t, http.StatusBadRequest, code)
+}

--- a/backend/internal/gateway/update.go
+++ b/backend/internal/gateway/update.go
@@ -24,6 +24,14 @@ func (s *Server) adminUpdateCheck(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, &update.Info{Current: s.versionString(), Checked: false})
 		return
 	}
-	info := s.updates.Check(r.Context())
+	// ?refresh=1 forces a live re-check, bypassing the in-memory cache. This
+	// backs the dashboard "Check now" button so a just-published release is
+	// detected immediately instead of waiting for the cache TTL.
+	var info *update.Info
+	if q := r.URL.Query().Get("refresh"); q == "1" || q == "true" {
+		info = s.updates.Refresh(r.Context())
+	} else {
+		info = s.updates.Check(r.Context())
+	}
 	writeJSON(w, http.StatusOK, info)
 }

--- a/backend/internal/update/update.go
+++ b/backend/internal/update/update.go
@@ -20,7 +20,7 @@ import (
 const defaultRepo = "mydisha/keirouter"
 
 // defaultTTL is how long a successful check is cached before refreshing.
-const defaultTTL = 6 * time.Hour
+const defaultTTL = 15 * time.Minute
 
 // Info is the update status reported to the dashboard.
 type Info struct {
@@ -99,6 +99,32 @@ func (c *Checker) Check(ctx context.Context) *Info {
 			return &cached
 		}
 		c.mu.Unlock()
+		return &Info{Current: c.current, Checked: false}
+	}
+
+	c.mu.Lock()
+	c.cached = info
+	c.cachedAt = time.Now()
+	c.mu.Unlock()
+
+	out := *info
+	return &out
+}
+
+// Refresh forces a live GitHub check, bypassing the cache, and stores the
+// result. It backs the dashboard's "Check now" action so a freshly-published
+// release shows up immediately instead of waiting for the cache TTL to expire.
+// On a network/API error it serves a stale cache when available, otherwise it
+// reports the current version with Checked=false.
+func (c *Checker) Refresh(ctx context.Context) *Info {
+	info, err := c.fetch(ctx)
+	if err != nil {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.cached != nil {
+			cached := *c.cached
+			return &cached
+		}
 		return &Info{Current: c.current, Checked: false}
 	}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -247,6 +247,46 @@ export interface AccountInput {
   priority?: number;
 }
 
+// BulkAccountItem is one credential in a bulk import. Only api_key (and an
+// optional per-item base_url / label) varies per row; shared provider config
+// lives on BulkAccountInput.
+export interface BulkAccountItem {
+  label?: string;
+  api_key?: string;
+  base_url?: string;
+}
+
+export interface BulkAccountInput {
+  provider: string;
+  base_url?: string;
+  region?: string;
+  account_id?: string;
+  azure_endpoint?: string;
+  azure_deployment?: string;
+  azure_api_version?: string;
+  azure_organization?: string;
+  priority?: number;
+  proxy_pool_id?: string;
+  validate?: boolean;
+  items: BulkAccountItem[];
+}
+
+export interface BulkAccountResult {
+  index: number;
+  label: string;
+  status: "created" | "error" | "skipped";
+  id?: string;
+  error?: string;
+}
+
+export interface BulkAccountResponse {
+  total: number;
+  created: number;
+  failed: number;
+  skipped: number;
+  results: BulkAccountResult[];
+}
+
 export interface ChainStep {
   provider: string;
   model: string;
@@ -1016,6 +1056,8 @@ export const api = {
   listAccounts: () => request<{ accounts: Account[] }>("GET", "/accounts"),
   createAccount: (input: AccountInput) =>
     request<{ id: string }>("POST", "/accounts", input),
+  bulkCreateAccounts: (input: BulkAccountInput) =>
+    request<BulkAccountResponse>("POST", "/accounts/bulk", input),
   updateAccount: (id: string, patch: { label?: string; priority?: number; disabled?: boolean; proxy_pool_id?: string }) =>
     request<{ id: string }>("PATCH", `/accounts/${id}`, patch),
   deleteAccount: (id: string) => request<void>("DELETE", `/accounts/${id}`),
@@ -1108,7 +1150,9 @@ export const api = {
     request<{ ids: string[] }>("DELETE", "/models/disabled", { providerAlias, ids }),
 
   // Update check (queries GitHub for the latest release + changelog).
-  updateCheck: () => request<UpdateInfo>("GET", "/update/check"),
+  // Pass force=true to bypass the backend's 6-hour cache (the "Check now" button).
+  updateCheck: (force?: boolean) =>
+    request<UpdateInfo>("GET", `/update/check${force ? "?refresh=1" : ""}`),
 
   // Database export/import. An optional passphrase produces a portable backup
   // whose credentials are re-keyed to the passphrase (movable across machines

--- a/frontend/src/lib/bulk.ts
+++ b/frontend/src/lib/bulk.ts
@@ -1,0 +1,204 @@
+// Standardized bulk-import parsing shared across the dashboard (API keys,
+// proxy pools, and any future batch importer). The goal is one predictable,
+// forgiving text format so users learn it once.
+//
+// Format rules (applied uniformly):
+//   - One entry per line.
+//   - Blank lines are ignored.
+//   - Lines beginning with "#" (after trimming) are comments and ignored.
+//   - Fields within a line are comma-separated. Surrounding whitespace on each
+//     field is trimmed.
+//   - A leading header row (e.g. "label,api_key") is detected and skipped.
+//
+// Each importer layers its own field mapping on top of stripComments().
+
+/** A single parsed line with its 1-based source line number (for diagnostics). */
+export interface RawLine {
+  /** 1-based line number in the original text. */
+  line: number;
+  /** Trimmed, non-empty, non-comment content. */
+  text: string;
+}
+
+/** stripComments returns the meaningful lines of a bulk-import blob. */
+export function stripComments(input: string): RawLine[] {
+  const out: RawLine[] = [];
+  const lines = input.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const text = lines[i].trim();
+    if (!text || text.startsWith("#")) continue;
+    out.push({ line: i + 1, text });
+  }
+  return out;
+}
+
+/** splitFields splits a line on commas and trims each field. */
+export function splitFields(text: string): string[] {
+  return text.split(",").map((f) => f.trim());
+}
+
+// ─── API keys ────────────────────────────────────────────────────────────────
+
+export interface ParsedKey {
+  line: number;
+  label: string;
+  apiKey: string;
+  baseURL?: string;
+}
+
+export interface ParsedKeyResult {
+  entries: ParsedKey[];
+  /** Lines skipped as exact duplicates of an earlier key. */
+  duplicates: number;
+  /** Per-line problems that prevented parsing (e.g. empty key). */
+  errors: { line: number; message: string }[];
+}
+
+const KEY_HEADER = /^label\s*,\s*(api[_ ]?key|key|secret)/i;
+
+/**
+ * parseKeys reads the standardized key format. Each line is one of:
+ *   - `apiKey`
+ *   - `label,apiKey`
+ *   - `label,apiKey,baseURL`
+ * When only one field is present it is treated as the key (label auto-filled
+ * downstream). Duplicate keys are dropped and counted.
+ */
+export function parseKeys(input: string): ParsedKeyResult {
+  const entries: ParsedKey[] = [];
+  const errors: { line: number; message: string }[] = [];
+  const seen = new Set<string>();
+  let duplicates = 0;
+
+  const rows = stripComments(input);
+  rows.forEach((row, idx) => {
+    // Skip an optional CSV-style header on the first meaningful row.
+    if (idx === 0 && KEY_HEADER.test(row.text)) return;
+
+    const fields = splitFields(row.text);
+    let label = "";
+    let apiKey = "";
+    let baseURL: string | undefined;
+
+    if (fields.length === 1) {
+      apiKey = fields[0];
+    } else {
+      label = fields[0];
+      apiKey = fields[1];
+      if (fields.length >= 3 && fields[2]) baseURL = fields[2];
+    }
+
+    if (!apiKey) {
+      errors.push({ line: row.line, message: "missing API key" });
+      return;
+    }
+    if (seen.has(apiKey)) {
+      duplicates++;
+      return;
+    }
+    seen.add(apiKey);
+    entries.push({ line: row.line, label, apiKey, baseURL });
+  });
+
+  return { entries, duplicates, errors };
+}
+
+// ─── Proxies ─────────────────────────────────────────────────────────────────
+
+export interface ParsedProxy {
+  line: number;
+  name?: string;
+  url: string;
+}
+
+export interface ParsedProxyResult {
+  entries: ParsedProxy[];
+  duplicates: number;
+  errors: { line: number; message: string }[];
+}
+
+const PROXY_HEADER = /^name\s*,\s*(proxy[_ ]?url|url)/i;
+
+/**
+ * normalizeProxyURL accepts the two supported proxy spellings and returns a
+ * canonical `protocol://[user:pass@]host:port` URL:
+ *   - `protocol://user:pass@host:port` (passed through)
+ *   - `host:port:user:pass` (rewritten to http://user:pass@host:port)
+ *   - `host:port` (rewritten to http://host:port)
+ */
+export function normalizeProxyURL(raw: string): string {
+  const value = raw.trim();
+  if (value.includes("://")) return value;
+  const parts = value.split(":");
+  if (parts.length === 4) {
+    return `http://${parts[2]}:${parts[3]}@${parts[0]}:${parts[1]}`;
+  }
+  return `http://${value}`;
+}
+
+/**
+ * parseProxies reads the standardized proxy format. Each line is one of:
+ *   - `url`
+ *   - `name,url`
+ * where `url` follows normalizeProxyURL(). Duplicate URLs are dropped.
+ */
+export function parseProxies(input: string): ParsedProxyResult {
+  const entries: ParsedProxy[] = [];
+  const errors: { line: number; message: string }[] = [];
+  const seen = new Set<string>();
+  let duplicates = 0;
+
+  const rows = stripComments(input);
+  rows.forEach((row, idx) => {
+    if (idx === 0 && PROXY_HEADER.test(row.text)) return;
+
+    const fields = splitFields(row.text);
+    let name: string | undefined;
+    let rawURL = "";
+    if (fields.length === 1) {
+      rawURL = fields[0];
+    } else {
+      name = fields[0] || undefined;
+      rawURL = fields[1];
+    }
+    if (!rawURL) {
+      errors.push({ line: row.line, message: "missing proxy URL" });
+      return;
+    }
+    const url = normalizeProxyURL(rawURL);
+    if (seen.has(url)) {
+      duplicates++;
+      return;
+    }
+    seen.add(url);
+    entries.push({ line: row.line, name, url });
+  });
+
+  return { entries, duplicates, errors };
+}
+
+// ─── Concurrency helper ──────────────────────────────────────────────────────
+
+/**
+ * runPool runs `task` over `items` with at most `concurrency` in flight,
+ * preserving input order in the returned results. Used to parallelize
+ * per-item network work (e.g. proxy connectivity tests) without flooding the
+ * backend.
+ */
+export async function runPool<T, R>(
+  items: T[],
+  concurrency: number,
+  task: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const workers = new Array(Math.min(concurrency, items.length)).fill(0).map(async () => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) break;
+      results[index] = await task(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}

--- a/frontend/src/pages/ProviderDetail.tsx
+++ b/frontend/src/pages/ProviderDetail.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState, useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Plus, Trash2, Plug, X, Zap, ArrowUp, ArrowDown, CheckCircle, ToggleLeft, ToggleRight, Search, Route, AlertCircle, AlertTriangle, RefreshCw, Globe, Copy, Check } from "lucide-react";
-import { api, type DeviceCode, type OAuthProvider, type Provider, type Account, type ProxyPool, type UpstreamQuota, type ProviderRoutingSettings } from "../lib/api";
+import { ArrowLeft, Plus, Trash2, Plug, X, Zap, ArrowUp, ArrowDown, CheckCircle, ToggleLeft, ToggleRight, Search, Route, AlertCircle, AlertTriangle, RefreshCw, Globe, Copy, Check, Upload, Loader2, XCircle, Layers, FileText } from "lucide-react";
+import { api, type DeviceCode, type OAuthProvider, type Provider, type Account, type ProxyPool, type UpstreamQuota, type ProviderRoutingSettings, type BulkAccountResult } from "../lib/api";
 import { KiroConnectModal } from "../components/KiroConnectModal";
 import { QoderConnectModal } from "../components/QoderConnectModal";
 import { KilocodeConnectModal } from "../components/KilocodeConnectModal";
@@ -11,6 +11,7 @@ import { CursorConnectModal } from "../components/CursorConnectModal";
 import { CommandCodeConnectModal } from "../components/CommandCodeConnectModal";
 import { CustomModelsSection } from "../components/CustomModelsSection";
 import { useToast } from "../components/Toast";
+import { parseKeys } from "../lib/bulk";
 
 import {
   Card,
@@ -22,6 +23,7 @@ import {
   Spinner,
   EmptyState,
   ErrorBanner,
+  Modal,
 } from "../components/ui";
 
 // redirectURIForProvider returns the OAuth callback the provider redirects to
@@ -93,6 +95,7 @@ export function ProviderDetailPage() {
   const [cursorOpen, setCursorOpen] = useState(false);
   const [commandcodeOpen, setCommandcodeOpen] = useState(false);
   const [addKeyOpen, setAddKeyOpen] = useState(false);
+  const [bulkOpen, setBulkOpen] = useState(false);
 
   // Model search and pagination
   const [modelSearchQuery, setModelSearchQuery] = useState("");
@@ -250,9 +253,72 @@ export function ProviderDetailPage() {
     onError: (e: Error) => toast.error("Routing update failed", e.message),
   });
 
+  // Multi-select for connected accounts: enables bulk enable / disable / delete.
+  const [selectedAccountIds, setSelectedAccountIds] = useState<Set<string>>(new Set());
+  const toggleAccountSelection = (accId: string) =>
+    setSelectedAccountIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(accId)) next.delete(accId);
+      else next.add(accId);
+      return next;
+    });
+  const clearAccountSelection = () => setSelectedAccountIds(new Set());
+
+  const bulkUpdateAccounts = useMutation({
+    mutationFn: async ({ ids, disabled }: { ids: string[]; disabled: boolean }) => {
+      await Promise.all(ids.map((accId) => api.updateAccount(accId, { disabled })));
+    },
+    onSuccess: (_, { ids, disabled }) => {
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      clearAccountSelection();
+      toast.success(
+        `${ids.length} account${ids.length > 1 ? "s" : ""} ${disabled ? "disabled" : "enabled"}`,
+        disabled ? "Selected accounts are paused and excluded from routing." : "Selected accounts are active again.",
+      );
+    },
+    onError: (e: Error) => toast.error("Bulk update failed", e.message),
+  });
+
+  const bulkDeleteAccounts = useMutation({
+    mutationFn: async (ids: string[]) => {
+      await Promise.all(ids.map((accId) => api.deleteAccount(accId)));
+    },
+    onSuccess: (_, ids) => {
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      clearAccountSelection();
+      toast.success(`${ids.length} account${ids.length > 1 ? "s" : ""} removed`, "Encrypted secrets have been purged.");
+    },
+    onError: (e: Error) => toast.error("Bulk removal failed", e.message),
+  });
+
   // Sort accounts by priority for display.
   const sortedAccounts = [...myAccounts].sort((a, b) => a.priority - b.priority);
   const disabledModelIds = new Set(disabledModels.data?.ids ?? []);
+
+  // Derived selection state (scoped to this provider's accounts).
+  const selectedList = sortedAccounts.filter((a) => selectedAccountIds.has(a.id));
+  const allAccountsSelected = sortedAccounts.length > 0 && selectedList.length === sortedAccounts.length;
+  const someAccountsSelected = selectedList.length > 0 && !allAccountsSelected;
+  const bulkBusy = bulkUpdateAccounts.isPending || bulkDeleteAccounts.isPending;
+
+  const toggleSelectAllAccounts = () => {
+    if (allAccountsSelected) clearAccountSelection();
+    else setSelectedAccountIds(new Set(sortedAccounts.map((a) => a.id)));
+  };
+  const handleBulkDisable = () => {
+    const ids = selectedList.filter((a) => !a.disabled).map((a) => a.id);
+    if (ids.length) bulkUpdateAccounts.mutate({ ids, disabled: true });
+  };
+  const handleBulkEnable = () => {
+    const ids = selectedList.filter((a) => a.disabled).map((a) => a.id);
+    if (ids.length) bulkUpdateAccounts.mutate({ ids, disabled: false });
+  };
+  const handleBulkDeleteAccounts = () => {
+    const ids = selectedList.map((a) => a.id);
+    if (!ids.length) return;
+    if (!confirm(`Delete ${ids.length} account${ids.length > 1 ? "s" : ""}? Encrypted secrets will be purged. This cannot be undone.`)) return;
+    bulkDeleteAccounts.mutate(ids);
+  };
 
   // runTestAll tests every account sequentially (one at a time), updating each
   // row's status as it goes, then summarizes the outcome. Failures don't stop
@@ -324,6 +390,11 @@ export function ProviderDetailPage() {
     provider.auth_modes.includes("none") ||
     !oauthProvider
   );
+  // Bulk key upload applies to providers authenticated by API key. It is hidden
+  // for Azure (each key needs its own endpoint + deployment, so there is no
+  // shared config to bulk against) and for no-auth providers (nothing to bulk).
+  const providerSupportsApiKey = provider.auth_modes.includes("api_key") || provider.auth_kind === "api_key";
+  const supportsBulkUpload = supportsManualConnect && providerSupportsApiKey && provider.id !== "azure";
 
   return (
     <>
@@ -438,6 +509,12 @@ export function ProviderDetailPage() {
                     {provider.auth_kind === "none" ? "Connect" : "Add API key"}
                   </Button>
                 )}
+                {supportsBulkUpload && (
+                  <Button variant="ghost" className="h-8 px-3 text-xs" onClick={() => setBulkOpen(true)}>
+                    <Layers className="h-3.5 w-3.5" />
+                    Bulk add
+                  </Button>
+                )}
               </div>
             }
           />
@@ -465,24 +542,63 @@ export function ProviderDetailPage() {
               hint="Add an account to start routing through this provider."
             />
           ) : (
-            <div className="divide-y divide-[var(--border)]">
-              {sortedAccounts.map((a, i) => (
-                <AccountRow
-                  key={a.id}
-                  account={a}
-                  index={i}
-                  total={sortedAccounts.length}
-                  pools={pools.data?.pools ?? []}
-                  onDelete={() => remove.mutate(a.id)}
-                  onMoveUp={() => moveAccount(a.id, "up")}
-                  onMoveDown={() => moveAccount(a.id, "down")}
-                  onTest={() => runTest(a.id)}
-                  onUpdateProxy={(patch) => updateAccount.mutate({ id: a.id, patch })}
-                  testResult={testResults[a.id]}
-                  disabledByBatch={testingAll}
-                />
-              ))}
-            </div>
+            <>
+              <div className="flex flex-wrap items-center gap-2 border-t border-[var(--border)] bg-[var(--bg-subtle)] px-4 py-2.5">
+                <label className="flex cursor-pointer items-center gap-2 text-xs text-[var(--text-muted)]">
+                  <input
+                    type="checkbox"
+                    className="h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--color-accent-500)]"
+                    checked={allAccountsSelected}
+                    ref={(el) => { if (el) el.indeterminate = someAccountsSelected; }}
+                    onChange={toggleSelectAllAccounts}
+                  />
+                  Select all
+                </label>
+                {selectedList.length > 0 ? (
+                  <>
+                    <span className="text-xs text-[var(--text-muted)]">{selectedList.length} selected</span>
+                    <div className="flex-1" />
+                    <Button variant="ghost" className="h-7 px-2 text-xs" onClick={handleBulkEnable} disabled={bulkBusy}>
+                      <ToggleRight className="h-3.5 w-3.5 text-emerald-500" />
+                      Enable
+                    </Button>
+                    <Button variant="ghost" className="h-7 px-2 text-xs" onClick={handleBulkDisable} disabled={bulkBusy}>
+                      <ToggleLeft className="h-3.5 w-3.5" />
+                      Disable
+                    </Button>
+                    <Button variant="ghost" className="h-7 px-2 text-xs" onClick={handleBulkDeleteAccounts} disabled={bulkBusy}>
+                      <Trash2 className="h-3.5 w-3.5 text-red-500" />
+                      Delete
+                    </Button>
+                    <Button variant="ghost" className="h-7 px-2 text-xs" onClick={clearAccountSelection} disabled={bulkBusy}>
+                      Clear
+                    </Button>
+                  </>
+                ) : (
+                  <span className="text-xs text-[var(--text-muted)]">Select accounts for bulk actions</span>
+                )}
+              </div>
+              <div className="divide-y divide-[var(--border)]">
+                {sortedAccounts.map((a, i) => (
+                  <AccountRow
+                    key={a.id}
+                    account={a}
+                    index={i}
+                    total={sortedAccounts.length}
+                    pools={pools.data?.pools ?? []}
+                    selected={selectedAccountIds.has(a.id)}
+                    onToggleSelect={() => toggleAccountSelection(a.id)}
+                    onDelete={() => remove.mutate(a.id)}
+                    onMoveUp={() => moveAccount(a.id, "up")}
+                    onMoveDown={() => moveAccount(a.id, "down")}
+                    onTest={() => runTest(a.id)}
+                    onUpdateProxy={(patch) => updateAccount.mutate({ id: a.id, patch })}
+                    testResult={testResults[a.id]}
+                    disabledByBatch={testingAll}
+                  />
+                ))}
+              </div>
+            </>
           )}
         </Card>
 
@@ -657,6 +773,9 @@ export function ProviderDetailPage() {
           onClose={() => { setAddKeyOpen(false); setError(""); }}
         />
       )}
+      {bulkOpen && (
+        <BulkAddKeysModal provider={provider} onClose={() => setBulkOpen(false)} />
+      )}
     </>
   );
 }
@@ -798,6 +917,8 @@ function AccountRow({
   index,
   total,
   pools,
+  selected,
+  onToggleSelect,
   onDelete,
   onMoveUp,
   onMoveDown,
@@ -810,6 +931,8 @@ function AccountRow({
   index: number;
   total: number;
   pools: ProxyPool[];
+  selected?: boolean;
+  onToggleSelect?: () => void;
   onDelete: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
@@ -846,9 +969,18 @@ function AccountRow({
   const boundPool = pools.find((p) => p.id === a.proxy_pool_id);
 
   return (
-    <div className={`px-4 py-3 ${a.disabled ? "opacity-60" : ""}`}>
+    <div className={`px-4 py-3 ${a.disabled ? "opacity-60" : ""} ${selected ? "bg-accent-50/50 dark:bg-accent-900/10" : ""}`}>
       {/* Header row */}
       <div className="flex items-center justify-between gap-3">
+        {onToggleSelect && (
+          <input
+            type="checkbox"
+            checked={!!selected}
+            onChange={onToggleSelect}
+            aria-label={`Select ${a.label || a.provider}`}
+            className="h-3.5 w-3.5 shrink-0 rounded border-[var(--border)] accent-[var(--color-accent-500)]"
+          />
+        )}
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
             <span className="text-sm font-medium">{a.label || a.provider}</span>
@@ -1028,6 +1160,258 @@ function QuotaBarInline({ quota: q }: { quota: UpstreamQuota }) {
       </div>
       <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--bg-subtle)]">
         <div className={`h-full rounded-full ${tone}`} style={{ width: `${Math.max(2, pct)}%` }} />
+      </div>
+    </div>
+  );
+}
+
+// BulkAddKeysModal imports many API keys for a provider in one shot. Shared
+// provider config (base URL, region, Cloudflare account) is entered once and
+// applied to every key; only the key (and an optional inline label / base URL)
+// varies per line. The standardized paste format is parsed live with a preview,
+// keys can be loaded from a .txt/.csv file, and the backend returns a per-row
+// outcome that is rendered after import.
+function BulkAddKeysModal({ provider, onClose }: { provider: Provider; onClose: () => void }) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const [text, setText] = useState("");
+  const [validate, setValidate] = useState(false);
+  const [baseURL, setBaseURL] = useState(provider.base_url ?? "");
+  const [region, setRegion] = useState(provider.default_region ?? "");
+  const [accountID, setAccountID] = useState("");
+  const [results, setResults] = useState<BulkAccountResult[] | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const isCloudflare = provider.id === "cloudflare-ai";
+  const isCustom = provider.id === "custom-openai" || provider.id === "custom-anthropic" || !!provider.custom;
+  const hasRegions = (provider.regions?.length ?? 0) > 0;
+  const requiresBaseURL = isCustom;
+  // Generic providers expose an optional shared base URL; region/Cloudflare
+  // providers use their own dedicated control instead.
+  const showBaseURL = !hasRegions && !isCloudflare;
+  const keyPlaceholder = provider.id === "xai" ? "xai-..." : "sk-...";
+
+  const parsed = useMemo(() => parseKeys(text), [text]);
+  const validCount = parsed.entries.length;
+
+  const importMut = useMutation({
+    mutationFn: () =>
+      api.bulkCreateAccounts({
+        provider: provider.id,
+        base_url: showBaseURL && baseURL.trim() ? baseURL.trim() : undefined,
+        region: hasRegions ? region : undefined,
+        account_id: isCloudflare ? accountID.trim() : undefined,
+        validate,
+        items: parsed.entries.map((e) => ({
+          label: e.label || undefined,
+          api_key: e.apiKey,
+          base_url: e.baseURL,
+        })),
+      }),
+    onSuccess: (res) => {
+      setResults(res.results);
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      if (res.failed === 0) {
+        toast.success(
+          "Bulk import complete",
+          `${res.created} key${res.created === 1 ? "" : "s"} added${res.skipped ? `, ${res.skipped} duplicate skipped` : ""}.`,
+        );
+      } else {
+        toast.error(
+          "Bulk import finished with errors",
+          `${res.created} added, ${res.failed} failed${res.skipped ? `, ${res.skipped} skipped` : ""}.`,
+        );
+      }
+    },
+    onError: (e: Error) => toast.error("Bulk import failed", e.message),
+  });
+
+  const canImport =
+    validCount > 0 &&
+    !importMut.isPending &&
+    (!requiresBaseURL || !!baseURL.trim()) &&
+    (!isCloudflare || !!accountID.trim());
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const content = await file.text();
+    setText((prev) => (prev.trim() ? `${prev.replace(/\s+$/, "")}\n${content}` : content));
+    e.target.value = "";
+  };
+
+  const reset = () => {
+    setResults(null);
+    setText("");
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={`Bulk add API keys — ${provider.display_name}`}
+      subtitle="Paste one key per line, or load a .txt/.csv file."
+      maxWidth="max-w-2xl"
+    >
+      {results ? (
+        <BulkResultsView
+          results={results}
+          onClose={onClose}
+          onAgain={reset}
+        />
+      ) : (
+        <div className="space-y-4 px-6 py-5">
+          {/* Shared provider config applied to every key. */}
+          {(showBaseURL || hasRegions || isCloudflare) && (
+            <div className="space-y-3 rounded-xl border border-[var(--border)] bg-[var(--bg-subtle)] p-4">
+              <p className="text-xs font-medium text-[var(--text-muted)]">Shared settings (applied to every key)</p>
+              {hasRegions && (
+                <Field label="Region">
+                  <select
+                    value={region}
+                    onChange={(e) => setRegion(e.target.value)}
+                    className="w-full rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2 text-sm focus:border-accent-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/40"
+                  >
+                    {(provider.regions ?? []).map((r) => (
+                      <option key={r.id} value={r.id}>
+                        {r.label}
+                      </option>
+                    ))}
+                  </select>
+                </Field>
+              )}
+              {isCloudflare && (
+                <Field label="Cloudflare account ID">
+                  <Input value={accountID} onChange={(e) => setAccountID(e.target.value)} placeholder="abc123def456..." required />
+                </Field>
+              )}
+              {showBaseURL && (
+                <Field label={requiresBaseURL ? "Base URL" : "Base URL (optional)"}>
+                  <Input
+                    value={baseURL}
+                    onChange={(e) => setBaseURL(e.target.value)}
+                    placeholder="for custom endpoints"
+                    required={requiresBaseURL}
+                  />
+                </Field>
+              )}
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">API keys</label>
+              <button
+                type="button"
+                onClick={() => fileRef.current?.click()}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-2 py-1 text-xs text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-subtle)] hover:text-[var(--text)]"
+              >
+                <FileText className="h-3.5 w-3.5" />
+                Load file
+              </button>
+              <input ref={fileRef} type="file" accept=".txt,.csv,text/plain,text/csv" className="hidden" onChange={onFile} />
+            </div>
+            <textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={8}
+              spellCheck={false}
+              placeholder={`${keyPlaceholder}\nlabel-2, ${keyPlaceholder}\n# lines starting with # are comments`}
+              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2 font-mono text-xs placeholder:text-[var(--text-muted)] focus:border-accent-400 focus:outline-none"
+            />
+            <p className="text-[11px] leading-relaxed text-[var(--text-muted)]">
+              One key per line. Optional inline label: <code className="font-mono">label,key</code>. Blank lines and{" "}
+              <code className="font-mono">#</code> comments are ignored.
+            </p>
+          </div>
+
+          {/* Live parse preview. */}
+          {text.trim() && (
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <Badge tone={validCount > 0 ? "success" : "neutral"}>{validCount} ready</Badge>
+              {parsed.duplicates > 0 && <Badge tone="warning">{parsed.duplicates} duplicate</Badge>}
+              {parsed.errors.length > 0 && <Badge tone="danger">{parsed.errors.length} invalid</Badge>}
+              {parsed.errors.slice(0, 3).map((err) => (
+                <span key={err.line} className="text-[var(--text-muted)]">
+                  line {err.line}: {err.message}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <label className="flex cursor-pointer items-start gap-2.5 rounded-xl border border-[var(--border)] bg-[var(--bg-subtle)] p-3">
+            <input
+              type="checkbox"
+              checked={validate}
+              onChange={(e) => setValidate(e.target.checked)}
+              className="mt-0.5 h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--color-accent-500)]"
+            />
+            <span className="text-xs leading-relaxed text-[var(--text-muted)]">
+              <span className="font-medium text-[var(--text)]">Validate each key against the upstream</span> before saving.
+              Slower for large batches and may hit provider rate limits. Off by default.
+            </span>
+          </label>
+
+          <div className="flex gap-3">
+            <Button type="button" variant="ghost" onClick={onClose} className="flex-1">
+              Cancel
+            </Button>
+            <Button type="button" onClick={() => importMut.mutate()} disabled={!canImport} className="flex-1">
+              {importMut.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+              {importMut.isPending ? "Importing…" : `Import ${validCount || ""}`.trim()}
+            </Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+// BulkResultsView renders the per-row outcome of a bulk import.
+function BulkResultsView({
+  results,
+  onClose,
+  onAgain,
+}: {
+  results: BulkAccountResult[];
+  onClose: () => void;
+  onAgain: () => void;
+}) {
+  const created = results.filter((r) => r.status === "created").length;
+  const skipped = results.filter((r) => r.status === "skipped").length;
+  const failed = results.filter((r) => r.status === "error").length;
+
+  return (
+    <div className="space-y-4 px-6 py-5">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge tone="success">{created} added</Badge>
+        {skipped > 0 && <Badge tone="warning">{skipped} skipped</Badge>}
+        {failed > 0 && <Badge tone="danger">{failed} failed</Badge>}
+      </div>
+      <div className="max-h-72 divide-y divide-[var(--border)] overflow-y-auto rounded-xl border border-[var(--border)]">
+        {results.map((r) => (
+          <div key={r.index} className="flex items-center gap-3 px-3 py-2 text-xs">
+            {r.status === "created" ? (
+              <CheckCircle className="h-4 w-4 shrink-0 text-emerald-500" />
+            ) : r.status === "skipped" ? (
+              <AlertCircle className="h-4 w-4 shrink-0 text-amber-500" />
+            ) : (
+              <XCircle className="h-4 w-4 shrink-0 text-red-500" />
+            )}
+            <span className="w-10 shrink-0 text-[var(--text-muted)]">#{r.index + 1}</span>
+            <span className="flex-1 truncate font-medium">{r.label || "(unlabeled)"}</span>
+            {r.error && <span className="truncate text-[var(--text-muted)]" title={r.error}>{r.error}</span>}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-3">
+        <Button type="button" variant="ghost" onClick={onAgain} className="flex-1">
+          <Layers className="h-4 w-4" />
+          Import more
+        </Button>
+        <Button type="button" onClick={onClose} className="flex-1">
+          <Check className="h-4 w-4" />
+          Done
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/pages/ProxyPools.tsx
+++ b/frontend/src/pages/ProxyPools.tsx
@@ -1,13 +1,14 @@
-import { useState } from "react";
+import { useState, useMemo, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Network, Plus, Trash2, Play, Upload, Pencil, X, Check,
   ToggleLeft, ToggleRight, Loader2, CheckCircle2, XCircle, CircleDot,
-  RefreshCw,
+  RefreshCw, AlertCircle, FileText,
 } from "lucide-react";
 import { api, type ProxyPool } from "../lib/api";
 import { PageHeader } from "../components/Layout";
 import { useToast } from "../components/Toast";
+import { parseProxies, runPool } from "../lib/bulk";
 import {
   Card, Button, Input, Field, Badge, Spinner, EmptyState, Modal,
 } from "../components/ui";
@@ -330,40 +331,77 @@ function PoolForm({ pool, onClose }: { pool?: ProxyPool; onClose: () => void }) 
 
 // ─── Batch Import ────────────────────────────────────────────────────────────
 
+interface ProxyImportResult {
+  index: number;
+  label: string;
+  status: "created" | "error";
+  error?: string;
+}
+
+// proxyLabel derives a readable pool name from a proxy URL (host:port),
+// falling back to the raw value when the URL can't be parsed.
+function proxyLabel(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.port ? `${u.hostname}:${u.port}` : u.hostname;
+  } catch {
+    return url;
+  }
+}
+
+const PROXY_IMPORT_CONCURRENCY = 6;
+
 function BatchImport({ onClose }: { onClose: () => void }) {
   const qc = useQueryClient();
   const toast = useToast();
   const [name, setName] = useState("");
   const [text, setText] = useState("");
   const [importing, setImporting] = useState(false);
+  const [results, setResults] = useState<ProxyImportResult[] | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const parsed = useMemo(() => parseProxies(text), [text]);
+  const validCount = parsed.entries.length;
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const content = await file.text();
+    setText((prev) => (prev.trim() ? `${prev.replace(/\s+$/, "")}\n${content}` : content));
+    e.target.value = "";
+  };
 
   const handleImport = async () => {
-    const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
-    if (lines.length === 0) return;
-
+    if (validCount === 0) return;
     setImporting(true);
-    let created = 0, failed = 0;
 
-    for (const line of lines) {
-      let url = line;
-      if (!line.includes("://")) {
-        const parts = line.split(":");
-        if (parts.length === 4) url = `http://${parts[2]}:${parts[3]}@${parts[0]}:${parts[1]}`;
-        else url = `http://${line}`;
-      }
-      try {
-        await api.createProxyPool({ name: name || `pool-${Date.now()}`, proxy_url: url });
-        created++;
-      } catch { failed++; }
-    }
+    const entries = parsed.entries;
+    const res = await runPool<typeof entries[number], ProxyImportResult>(
+      entries,
+      PROXY_IMPORT_CONCURRENCY,
+      async (entry, i) => {
+        const poolName =
+          entry.name?.trim() ||
+          (name.trim() ? `${name.trim()}-${i + 1}` : proxyLabel(entry.url));
+        try {
+          await api.createProxyPool({ name: poolName, proxy_url: entry.url });
+          return { index: i, label: poolName, status: "created" as const };
+        } catch (err) {
+          return { index: i, label: poolName, status: "error" as const, error: (err as Error).message };
+        }
+      },
+    );
 
     setImporting(false);
+    setResults(res);
     qc.invalidateQueries({ queryKey: ["proxy-pools"] });
-    toast.success(
-      "Batch import complete",
-      `${created} proxy pool${created !== 1 ? "s" : ""} created.${failed > 0 ? ` ${failed} failed to import.` : ""}`,
-    );
-    onClose();
+    const created = res.filter((r) => r.status === "created").length;
+    const failed = res.length - created;
+    if (failed === 0) {
+      toast.success("Batch import complete", `${created} proxy pool${created !== 1 ? "s" : ""} created.`);
+    } else {
+      toast.error("Batch import finished with errors", `${created} created, ${failed} failed.`);
+    }
   };
 
   return (
@@ -374,24 +412,85 @@ function BatchImport({ onClose }: { onClose: () => void }) {
           <X className="h-4 w-4" />
         </button>
       </div>
-      <div className="space-y-3 px-4 py-4">
-        <p className="text-xs text-[var(--text-muted)]">
-          Paste proxy URLs, one per line. Supports <code className="font-mono">protocol://user:pass@host:port</code> and <code className="font-mono">host:port:user:pass</code> formats.
-        </p>
-        <Field label="Pool name">
-          <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="imported-pool" className="max-w-sm" />
-        </Field>
-        <textarea value={text} onChange={(e) => setText(e.target.value)} rows={8}
-          placeholder={"http://user:pass@host:port\nsocks5://host:port\nhost:port:user:pass"}
-          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2 font-mono text-xs placeholder:text-[var(--text-muted)] focus:border-accent-400 focus:outline-none" />
-        <div className="flex items-center gap-2">
-          <Button onClick={handleImport} disabled={!text.trim() || importing}>
-            {importing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
-            {importing ? "Importing…" : "Import"}
-          </Button>
-          <Button variant="ghost" onClick={onClose}>Cancel</Button>
+
+      {results ? (
+        <div className="space-y-3 px-4 py-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge tone="success">{results.filter((r) => r.status === "created").length} created</Badge>
+            {results.some((r) => r.status === "error") && (
+              <Badge tone="danger">{results.filter((r) => r.status === "error").length} failed</Badge>
+            )}
+          </div>
+          <div className="max-h-60 divide-y divide-[var(--border)] overflow-y-auto rounded-lg border border-[var(--border)]">
+            {results.map((r) => (
+              <div key={r.index} className="flex items-center gap-3 px-3 py-2 text-xs">
+                {r.status === "created" ? (
+                  <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+                ) : (
+                  <XCircle className="h-4 w-4 shrink-0 text-red-500" />
+                )}
+                <span className="flex-1 truncate font-medium">{r.label}</span>
+                {r.error && <span className="truncate text-[var(--text-muted)]" title={r.error}>{r.error}</span>}
+              </div>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" onClick={() => { setResults(null); setText(""); }}>
+              <Upload className="h-4 w-4" /> Import more
+            </Button>
+            <Button onClick={onClose}>
+              <Check className="h-4 w-4" /> Done
+            </Button>
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="space-y-3 px-4 py-4">
+          <p className="text-xs text-[var(--text-muted)]">
+            Paste proxy URLs, one per line. Supports <code className="font-mono">protocol://user:pass@host:port</code> and{" "}
+            <code className="font-mono">host:port:user:pass</code>. Add an optional name with{" "}
+            <code className="font-mono">name,url</code>. Blank lines and <code className="font-mono">#</code> comments are ignored.
+          </p>
+          <Field label="Pool name prefix (optional)">
+            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="imported-pool" className="max-w-sm" />
+          </Field>
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium">Proxies</span>
+            <button
+              type="button"
+              onClick={() => fileRef.current?.click()}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-2 py-1 text-xs text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-subtle)] hover:text-[var(--text)]"
+            >
+              <FileText className="h-3.5 w-3.5" /> Load file
+            </button>
+            <input ref={fileRef} type="file" accept=".txt,.csv,text/plain,text/csv" className="hidden" onChange={onFile} />
+          </div>
+          <textarea value={text} onChange={(e) => setText(e.target.value)} rows={8}
+            spellCheck={false}
+            placeholder={"http://user:pass@host:port\nsocks5://host:port\nhost:port:user:pass\n# comment line"}
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2 font-mono text-xs placeholder:text-[var(--text-muted)] focus:border-accent-400 focus:outline-none" />
+
+          {text.trim() && (
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <Badge tone={validCount > 0 ? "success" : "neutral"}>{validCount} ready</Badge>
+              {parsed.duplicates > 0 && <Badge tone="warning">{parsed.duplicates} duplicate</Badge>}
+              {parsed.errors.length > 0 && <Badge tone="danger">{parsed.errors.length} invalid</Badge>}
+              {parsed.errors.slice(0, 3).map((err) => (
+                <span key={err.line} className="inline-flex items-center gap-1 text-[var(--text-muted)]">
+                  <AlertCircle className="h-3 w-3" /> line {err.line}: {err.message}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <Button onClick={handleImport} disabled={validCount === 0 || importing}>
+              {importing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+              {importing ? "Importing…" : `Import ${validCount || ""}`.trim()}
+            </Button>
+            <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          </div>
+        </div>
+      )}
     </Card>
   );
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Sparkles, Zap, MessageSquare, Layers, Route, Wifi, Monitor, Database, Clock,
-  ArrowUpCircle, CheckCircle2, ExternalLink, XCircle, Terminal,
+  ArrowUpCircle, CheckCircle2, ExternalLink, XCircle, Terminal, RefreshCw,
   Gauge, Eye, EyeOff, KeyRound, Download, Upload, ShieldCheck, Info,
   Palette, Shield,
 } from "lucide-react";
@@ -1693,6 +1693,28 @@ function DatabaseSettings() {
 
 function UpdatesSettings() {
   const { data, isLoading, isError } = useUpdateInfo();
+  const qc = useQueryClient();
+  const toast = useToast();
+  const [checking, setChecking] = useState(false);
+
+  const checkNow = async () => {
+    setChecking(true);
+    try {
+      const fresh = await api.updateCheck(true);
+      qc.setQueryData(["update-check"], fresh);
+      if (!fresh.checked) {
+        toast.error("Update check failed", "Could not reach GitHub. Try again later.");
+      } else if (fresh.update_available) {
+        toast.success("Update available", `${fresh.latest} is ready to install.`);
+      } else {
+        toast.success("Up to date", `You're running the latest version (${fresh.current}).`);
+      }
+    } catch (e) {
+      toast.error("Update check failed", (e as Error).message);
+    } finally {
+      setChecking(false);
+    }
+  };
 
   const publishedLabel = data?.published_at
     ? new Date(data.published_at).toLocaleDateString(undefined, {
@@ -1708,6 +1730,12 @@ function UpdatesSettings() {
         title="Updates"
         description="Check for new KeiRouter releases and read the latest changelog."
         icon={ArrowUpCircle}
+        action={
+          <Button variant="ghost" className="h-8 px-3 text-xs" onClick={checkNow} disabled={checking}>
+            <RefreshCw className={`h-3.5 w-3.5 ${checking ? "animate-spin" : ""}`} />
+            {checking ? "Checking…" : "Check now"}
+          </Button>
+        }
       />
       <div className="border-t border-[var(--border)] px-6 py-4">
         {isLoading ? (


### PR DESCRIPTION
## Summary

Matures the bulk-upload flow, adds multi-select bulk actions for provider keys, tightens credential validation, and makes the update checker more responsive.

### Bulk upload (keys + proxies)
- New standardized paste/CSV format shared across importers (`frontend/src/lib/bulk.ts`): one entry per line, `#` comments, blank lines ignored, optional header, dedup.
- Backend `POST /accounts/bulk` (`admin.go`): per-row outcome (created / skipped / error), in-batch dedup, SSRF checks, optional upstream validation with a bounded worker pool, serialized DB writes.
- New **Bulk add API keys** modal in Provider Detail: shared settings (base URL / region / Cloudflare account), paste **or** load `.txt`/`.csv`, live parse preview, per-row results.
- Proxy Pools **Batch Import** reworked onto the same standard: concurrency, dedup, preview, per-line results, unique pool names.

### Multi-select for provider keys
- Checkbox per account + selection toolbar (select all / indeterminate).
- Bulk **Enable**, **Disable**, **Delete** (with confirm) for selected accounts.

### Credential validation accuracy (opt A)
- `OpenAICompatible` / `Anthropic` no longer trust a `200` from `/models` for keyed accounts (many gateways list models without auth). They confirm with an authenticated chat probe; strict providers and no-auth accounts keep the cheap path.
- Bad keys are now caught by "Test all" and validated bulk import.

### Update checker
- Cache TTL reduced from 6h → **15 min**.
- New `Refresh()` (force re-check) behind `GET /update/check?refresh=1` and a **"Check now"** button in Settings.

## Testing
- `go build ./...`, `go test ./internal/connectors/ ./internal/gateway/ ./internal/update/` — all pass (added tests for bulk import outcomes and the authenticated validation probe).
- `npm run typecheck` and `npm run build` — pass.
