### PR TITLE
feat: chain strategy ordering, streaming usage synthesis, and provider quota improvements

### DIFF
--- a/backend/internal/connectors/connectors_test.go
+++ b/backend/internal/connectors/connectors_test.go
@@ -306,3 +306,36 @@ func TestOpenAICompatible_ValidateNoAuthTrustsModels200(t *testing.T) {
 	require.NoError(t, c.Validate(context.Background(), core.Credentials{}))
 	require.False(t, *chatProbed, "no-auth accounts should not issue a chat probe")
 }
+
+func TestOpenAICompatibleModelSource_ListModelsPublicNoCreds(t *testing.T) {
+	// A provider whose /models endpoint is public (e.g. sumopod) must be
+	// discoverable without credentials, so the model catalog populates before
+	// an account is connected.
+	srv, _ := publicModelsServer(t, "good-key")
+	src := &OpenAICompatibleModelSource{provider: "sumopod", defaultBase: srv.URL}
+
+	models, err := src.ListModels(context.Background(), core.Credentials{})
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+	require.Equal(t, "m1", models[0].ID)
+	require.Equal(t, core.ServiceLLM, models[0].Kind)
+}
+
+func TestGetLiveModelSource_DynamicOpenAIProvider(t *testing.T) {
+	id := "custom-openai-testdisco"
+	RegisterDynamicProvider(DynamicProvider{
+		ID:      id,
+		Dialect: core.DialectOpenAI,
+		BaseURL: "https://example.test/v1",
+	})
+	t.Cleanup(func() { UnregisterDynamicProvider(id) })
+
+	src := GetLiveModelSource(id)
+	require.NotNil(t, src, "dynamic OpenAI-compatible providers should get a live model source")
+
+	// A dynamic Anthropic provider has no OpenAI-style /models discovery.
+	aid := "custom-anthropic-testdisco"
+	RegisterDynamicProvider(DynamicProvider{ID: aid, Dialect: core.DialectAnthropic, BaseURL: "https://example.test"})
+	t.Cleanup(func() { UnregisterDynamicProvider(aid) })
+	require.Nil(t, GetLiveModelSource(aid))
+}

--- a/backend/internal/connectors/models.go
+++ b/backend/internal/connectors/models.go
@@ -317,7 +317,6 @@ func ModelsForProvider(providerID string) []ModelSpec {
 	return append(merged, custom...)
 }
 
-
 // ModelsByKind returns all (providerID, model) pairs across the catalog that
 // serve the given service kind, excluding hidden providers.
 type ProviderModel struct {
@@ -378,7 +377,16 @@ func RegisterLiveModelSource(provider string, src LiveModelSource) {
 
 // GetLiveModelSource returns the live model source for a provider, or nil.
 func GetLiveModelSource(provider string) LiveModelSource {
-	return liveModelSources[provider]
+	if src, ok := liveModelSources[provider]; ok {
+		return src
+	}
+	// Dynamic (user-defined) OpenAI-compatible providers are not in the static
+	// registry, so build a discovery source on demand. This lets a custom
+	// provider's /models endpoint populate the catalog just like a built-in one.
+	if p, ok := DynamicProviderByID(provider); ok && p.Dialect == core.DialectOpenAI {
+		return &OpenAICompatibleModelSource{provider: p.ID, defaultBase: p.BaseURL}
+	}
+	return nil
 }
 
 // QuotaEntry is one upstream quota bucket (e.g. AGENTIC_REQUEST usage).

--- a/backend/internal/core/request.go
+++ b/backend/internal/core/request.go
@@ -54,6 +54,13 @@ type ChatRequest struct {
 	// Stream requests an incremental SSE response.
 	Stream bool `json:"stream"`
 
+	// IncludeUsage reflects the client's opt-in to receive a usage event on the
+	// streaming response (OpenAI's stream_options.include_usage). When set, the
+	// pipeline guarantees a final usage event is emitted to the client even if
+	// the upstream provider never reports one — synthesizing an estimate as a
+	// fallback. Router-internal; never serialized upstream.
+	IncludeUsage bool `json:"-"`
+
 	// Reasoning controls extended thinking / reasoning effort where supported.
 	Reasoning *ReasoningConfig `json:"reasoning,omitempty"`
 

--- a/backend/internal/core/tokens.go
+++ b/backend/internal/core/tokens.go
@@ -1,0 +1,39 @@
+package core
+
+// Token estimation helpers. These use the common ~4 chars/token heuristic,
+// which is accurate enough for client-side budgeting and for synthesizing a
+// usage event when an upstream provider omits token counts from a stream.
+
+// EstimateTokensFromChars approximates a token count from a character count.
+// Returns 0 for non-positive input.
+func EstimateTokensFromChars(chars int) int {
+	if chars <= 0 {
+		return 0
+	}
+	return (chars + 3) / 4
+}
+
+// EstimatePromptTokens approximates the prompt token count for a request over
+// system text, message content, tool-call arguments, tool results, and tool
+// definitions.
+func EstimatePromptTokens(req *ChatRequest) int {
+	if req == nil {
+		return 0
+	}
+	chars := len(req.System)
+	for _, m := range req.Messages {
+		for _, part := range m.Content {
+			chars += len(part.Text)
+			if part.ToolCall != nil {
+				chars += len(part.ToolCall.Arguments)
+			}
+			if part.ToolResult != nil {
+				chars += len(part.ToolResult.Content)
+			}
+		}
+	}
+	for _, t := range req.Tools {
+		chars += len(t.Name) + len(t.Description) + len(t.Parameters)
+	}
+	return EstimateTokensFromChars(chars)
+}

--- a/backend/internal/core/tokens_test.go
+++ b/backend/internal/core/tokens_test.go
@@ -1,0 +1,39 @@
+package core
+
+import "testing"
+
+func TestEstimateTokensFromChars(t *testing.T) {
+	cases := []struct {
+		chars int
+		want  int
+	}{
+		{0, 0},
+		{-5, 0},
+		{1, 1},
+		{4, 1},
+		{5, 2},
+		{100, 25},
+	}
+	for _, tc := range cases {
+		if got := EstimateTokensFromChars(tc.chars); got != tc.want {
+			t.Errorf("EstimateTokensFromChars(%d) = %d, want %d", tc.chars, got, tc.want)
+		}
+	}
+}
+
+func TestEstimatePromptTokens(t *testing.T) {
+	if got := EstimatePromptTokens(nil); got != 0 {
+		t.Errorf("nil request = %d, want 0", got)
+	}
+
+	req := &ChatRequest{
+		System: "1234", // 4 chars -> 1 token
+		Messages: []Message{
+			{Role: RoleUser, Content: []ContentPart{{Type: PartText, Text: "12345678"}}}, // 8 chars
+		},
+	}
+	// 12 chars total -> (12+3)/4 = 3 tokens
+	if got := EstimatePromptTokens(req); got != 3 {
+		t.Errorf("EstimatePromptTokens = %d, want 3", got)
+	}
+}

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -269,37 +269,58 @@ func (s *Server) adminProviderModels(w http.ResponseWriter, r *http.Request) {
 		seen[m.ID] = true
 	}
 
-	// Live model discovery (best-effort, requires a connected account).
-	if src := connectors.GetLiveModelSource(providerID); src != nil && s.accounts != nil && s.vault != nil {
-		accs, err := s.accounts.ListByProvider(r.Context(), adminTenant, providerID)
-		if err == nil {
-			for _, acc := range accs {
-				if acc.Disabled {
-					continue
-				}
-				creds, err := s.vault.Open(acc)
-				if err != nil {
-					continue
-				}
-				ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-				models, merr := src.ListModels(ctx, creds)
-				cancel()
-				if merr != nil || len(models) == 0 {
-					continue
-				}
-				for _, lm := range models {
-					kind := modelKind(lm.Kind)
-					if kindFilter != "" && kind != kindFilter {
-						continue
-					}
-					if seen[lm.ID] {
-						continue
-					}
-					out = append(out, modelInfo{ID: lm.ID, Name: lm.Name, Kind: string(kind)})
-					seen[lm.ID] = true
-				}
-				break // only use first valid account
+	// Live model discovery (best-effort). A connected account's credentials are
+	// preferred since most upstreams gate /models behind auth. When no account
+	// yields models and nothing else is in the catalog, fall back to an
+	// unauthenticated fetch so providers whose /models endpoint is public (e.g.
+	// sumopod) still populate before an account is connected.
+	if src := connectors.GetLiveModelSource(providerID); src != nil {
+		appendLive := func(creds core.Credentials) bool {
+			ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+			models, merr := src.ListModels(ctx, creds)
+			cancel()
+			if merr != nil || len(models) == 0 {
+				return false
 			}
+			added := false
+			for _, lm := range models {
+				kind := modelKind(lm.Kind)
+				if kindFilter != "" && kind != kindFilter {
+					continue
+				}
+				if seen[lm.ID] {
+					continue
+				}
+				out = append(out, modelInfo{ID: lm.ID, Name: lm.Name, Kind: string(kind)})
+				seen[lm.ID] = true
+				added = true
+			}
+			return added
+		}
+
+		discovered := false
+		if s.accounts != nil && s.vault != nil {
+			if accs, err := s.accounts.ListByProvider(r.Context(), adminTenant, providerID); err == nil {
+				for _, acc := range accs {
+					if acc.Disabled {
+						continue
+					}
+					creds, oerr := s.vault.Open(acc)
+					if oerr != nil {
+						continue
+					}
+					if appendLive(creds) {
+						discovered = true
+						break // only use first valid account
+					}
+				}
+			}
+		}
+
+		// Public fallback: only when we have nothing else to show, to avoid an
+		// extra upstream round-trip for providers that already have models.
+		if !discovered && len(out) == 0 {
+			appendLive(core.Credentials{})
 		}
 	}
 

--- a/backend/internal/gateway/gateway_e2e_test.go
+++ b/backend/internal/gateway/gateway_e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/budget"
 	"github.com/mydisha/keirouter/backend/internal/config"
 	"github.com/mydisha/keirouter/backend/internal/connectors"
+	"github.com/mydisha/keirouter/backend/internal/core"
 	"github.com/mydisha/keirouter/backend/internal/crypto"
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
 	"github.com/mydisha/keirouter/backend/internal/identity"
@@ -225,4 +226,138 @@ func TestE2E_StreamingChat(t *testing.T) {
 	require.Contains(t, out, `"content":"par"`)
 	require.Contains(t, out, `"content":"tial"`)
 	require.Contains(t, out, "[DONE]")
+}
+
+// streamNoUsageUpstream streams content + a finish chunk but NEVER reports
+// usage — the common case for many OpenAI-compatible providers that reject
+// stream_options.include_usage. Used to prove the pipeline synthesizes a usage
+// event for clients that opted in.
+func streamNoUsageUpstream() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flush, _ := w.(http.Flusher)
+		for _, l := range []string{
+			`data: {"choices":[{"delta":{"role":"assistant","content":"par"}}]}`,
+			`data: {"choices":[{"delta":{"content":"tial"}}]}`,
+			`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+		} {
+			fmt.Fprintf(w, "%s\n\n", l)
+			if flush != nil {
+				flush.Flush()
+			}
+		}
+	}
+}
+
+// lastStreamUsage scans an OpenAI SSE body and returns the last usage block
+// found across all chunks (nil if none carried usage).
+func lastStreamUsage(t *testing.T, sse string) *core.Usage {
+	t.Helper()
+	var found *core.Usage
+	for _, line := range strings.Split(sse, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var chunk struct {
+			Usage *core.Usage `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		if chunk.Usage != nil {
+			u := *chunk.Usage
+			found = &u
+		}
+	}
+	return found
+}
+
+// TestE2E_StreamingChat_IncludeUsageInjected proves the improvement: when the
+// client opts in via stream_options.include_usage and the provider never
+// reports usage, the gateway synthesizes and delivers a usage event.
+func TestE2E_StreamingChat_IncludeUsageInjected(t *testing.T) {
+	h := newE2E(t, streamNoUsageUpstream())
+
+	body := `{"model":"openai/gpt-4o","stream":true,"stream_options":{"include_usage":true},"messages":[{"role":"user","content":"hi"}]}`
+	resp := h.post(t, "/v1/chat/completions", body, h.apiKey)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	out := string(raw)
+
+	// Content still streamed through.
+	require.Contains(t, out, `"content":"par"`)
+	require.Contains(t, out, "[DONE]")
+
+	// A usage event was synthesized and delivered to the client.
+	usage := lastStreamUsage(t, out)
+	require.NotNil(t, usage, "expected an injected usage event, got none")
+	require.Greater(t, usage.CompletionTokens, 0, "completion tokens should be estimated from streamed output")
+	require.Greater(t, usage.TotalTokens, 0, "total tokens should be non-zero")
+}
+
+// TestE2E_StreamingChat_NoUsageWithoutOptIn is the regression guard: without
+// stream_options.include_usage, a provider that omits usage must NOT get a
+// synthesized usage event (respect the OpenAI contract + preserve prior
+// behavior).
+func TestE2E_StreamingChat_NoUsageWithoutOptIn(t *testing.T) {
+	h := newE2E(t, streamNoUsageUpstream())
+
+	body := `{"model":"openai/gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`
+	resp := h.post(t, "/v1/chat/completions", body, h.apiKey)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	out := string(raw)
+
+	require.Contains(t, out, `"content":"par"`)
+	require.Contains(t, out, "[DONE]")
+	require.Nil(t, lastStreamUsage(t, out), "no usage event should be injected without include_usage")
+}
+
+// TestE2E_StreamingChat_ProviderUsageNotDoubled verifies that when the provider
+// DOES report usage, we pass it through and do not overwrite it with an
+// estimate (sawUsage short-circuits injection).
+func TestE2E_StreamingChat_ProviderUsageNotDoubled(t *testing.T) {
+	streamWithUsage := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flush, _ := w.(http.Flusher)
+		for _, l := range []string{
+			`data: {"choices":[{"delta":{"role":"assistant","content":"hi"}}]}`,
+			`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: {"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33}}`,
+			`data: [DONE]`,
+		} {
+			fmt.Fprintf(w, "%s\n\n", l)
+			if flush != nil {
+				flush.Flush()
+			}
+		}
+	}
+	h := newE2E(t, streamWithUsage)
+
+	body := `{"model":"openai/gpt-4o","stream":true,"stream_options":{"include_usage":true},"messages":[{"role":"user","content":"hi"}]}`
+	resp := h.post(t, "/v1/chat/completions", body, h.apiKey)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	usage := lastStreamUsage(t, string(raw))
+	require.NotNil(t, usage)
+	// The real provider numbers survive — not replaced by the ~4 char/token estimate.
+	require.Equal(t, 11, usage.PromptTokens)
+	require.Equal(t, 22, usage.CompletionTokens)
+	require.Equal(t, 33, usage.TotalTokens)
 }

--- a/backend/internal/gateway/gemini.go
+++ b/backend/internal/gateway/gemini.go
@@ -67,7 +67,7 @@ func (s *Server) handleGeminiGenerate(w http.ResponseWriter, r *http.Request) {
 		RequestID:     chimiddleware.GetReqID(r.Context()),
 	}
 
-	resolved, err := resolveTargets(r.Context(), s.chains, s.aliases, tenantID, req.Model)
+	resolved, err := resolveTargets(r.Context(), s.chains, s.aliases, s.latencyReader(), tenantID, req.Model)
 	if err != nil {
 		var bad badModelError
 		if errors.As(err, &bad) {

--- a/backend/internal/gateway/handlers.go
+++ b/backend/internal/gateway/handlers.go
@@ -190,7 +190,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request, dialect core
 		fmt.Sprintf("Model:    %s\nMessages: %d\nStream:   %v\nTenant:   %s\nKey:      %s (%s)",
 			req.Model, len(req.Messages), req.Stream, tenantID, key.Name, key.ID))
 
-	resolved, err := resolveTargets(r.Context(), s.chains, s.aliases, tenantID, req.Model)
+	resolved, err := resolveTargets(r.Context(), s.chains, s.aliases, s.latencyReader(), tenantID, req.Model)
 	if err != nil {
 		var bad badModelError
 		if errors.As(err, &bad) {
@@ -680,7 +680,7 @@ func (s *Server) handleKeyUsage(w http.ResponseWriter, r *http.Request) {
 		modelOut = append(modelOut, map[string]any{
 			"provider": m.Provider, "model": m.Model,
 			"total_requests": m.TotalRequests,
-			"prompt_tokens": m.PromptTokens, "completion_tokens": m.CompletionTokens,
+			"prompt_tokens":  m.PromptTokens, "completion_tokens": m.CompletionTokens,
 			"cost_usd": float64(m.CostMicros) / 1_000_000,
 		})
 	}

--- a/backend/internal/gateway/handlers.go
+++ b/backend/internal/gateway/handlers.go
@@ -108,28 +108,7 @@ func (s *Server) handleAnthropicCountTokens(w http.ResponseWriter, r *http.Reque
 // the ~4 chars/token heuristic over system text, message content, tool-call
 // arguments, and tool results.
 func estimateInputTokens(req *core.ChatRequest) int {
-	if req == nil {
-		return 0
-	}
-	chars := len(req.System)
-	for _, m := range req.Messages {
-		for _, part := range m.Content {
-			chars += len(part.Text)
-			if part.ToolCall != nil {
-				chars += len(part.ToolCall.Arguments)
-			}
-			if part.ToolResult != nil {
-				chars += len(part.ToolResult.Content)
-			}
-		}
-	}
-	for _, t := range req.Tools {
-		chars += len(t.Name) + len(t.Description) + len(t.Parameters)
-	}
-	if chars <= 0 {
-		return 0
-	}
-	return (chars + 3) / 4
+	return core.EstimatePromptTokens(req)
 }
 
 // handleOpenAIResponses serves /v1/responses in the OpenAI Responses dialect

--- a/backend/internal/gateway/insights.go
+++ b/backend/internal/gateway/insights.go
@@ -370,6 +370,7 @@ func bucketTimeline(points []store.TimeBucket, from, to time.Time, n int) []time
 func (s *Server) adminQuotaUsage(w http.ResponseWriter, r *http.Request) {
 	period := r.URL.Query().Get("period")
 	tz := r.URL.Query().Get("tz")
+	provider := r.URL.Query().Get("provider")
 	since := sinceForPeriod(period, tz)
 	ctx := r.Context()
 
@@ -377,6 +378,15 @@ func (s *Server) adminQuotaUsage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
+	}
+	if provider != "" {
+		filtered := accs[:0]
+		for _, a := range accs {
+			if a.Provider == provider {
+				filtered = append(filtered, a)
+			}
+		}
+		accs = filtered
 	}
 	byAcct, err := s.usage.ByAccount(ctx, adminTenant, since)
 	if err != nil {

--- a/backend/internal/gateway/media.go
+++ b/backend/internal/gateway/media.go
@@ -20,7 +20,7 @@ import (
 func (s *Server) mediaOptions(r *http.Request, model string) (pipeline.MediaOptions, error) {
 	key, _ := authedKey(r.Context())
 	tenantID := tenantOf(key)
-	resolved, err := resolveTargets(r.Context(), s.chains, s.aliases, tenantID, model)
+	resolved, err := resolveTargets(r.Context(), s.chains, s.aliases, s.latencyReader(), tenantID, model)
 	if err != nil {
 		return pipeline.MediaOptions{}, err
 	}

--- a/backend/internal/gateway/resolve.go
+++ b/backend/internal/gateway/resolve.go
@@ -2,11 +2,21 @@ package gateway
 
 import (
 	"context"
+	"math"
+	"sort"
 	"strings"
 
 	"github.com/mydisha/keirouter/backend/internal/connectors"
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
 	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+// Chain ordering strategy tokens (persisted on store.Chain.Strategy). "priority"
+// is the implicit default (declared order); "round_robin" is handled via the
+// dispatcher's rotation. "cost" and "latency" reorder the steps here.
+const (
+	chainStrategyCost    = "cost"
+	chainStrategyLatency = "latency"
 )
 
 // resolveResult carries both the targets and the strategy metadata needed
@@ -26,6 +36,14 @@ type AliasSource interface {
 	Get(ctx context.Context, alias string) (store.ModelAlias, error)
 }
 
+// LatencyReader reports the average observed latency (ms) for the given
+// provider/model targets within a tenant, keyed by "provider/model". Pairs with
+// no measurement are omitted. The latency chain strategy uses it to order steps
+// fastest-first; a nil reader (or an unmeasured pair) leaves the declared order.
+type LatencyReader interface {
+	AvgLatencyMS(ctx context.Context, tenantID string, targets []dispatch.Target) map[string]int
+}
+
 // resolveTargets turns an inbound model string into an ordered fallback chain.
 //
 // Four forms are supported, in priority order:
@@ -39,7 +57,7 @@ type AliasSource interface {
 //
 // When a chain is resolved, the returned resolveResult carries the chain ID
 // and strategy so the dispatcher can apply round-robin rotation.
-func resolveTargets(ctx context.Context, chains ChainSource, aliases AliasSource, tenantID, model string) (resolveResult, error) {
+func resolveTargets(ctx context.Context, chains ChainSource, aliases AliasSource, latency LatencyReader, tenantID, model string) (resolveResult, error) {
 	model = strings.TrimSpace(model)
 	if model == "" {
 		return resolveResult{}, errBadModel("model is required")
@@ -47,7 +65,7 @@ func resolveTargets(ctx context.Context, chains ChainSource, aliases AliasSource
 
 	// chain:<name>
 	if name, ok := strings.CutPrefix(model, "chain:"); ok {
-		return chainResult(ctx, chains, tenantID, name)
+		return chainResult(ctx, chains, latency, tenantID, name)
 	}
 
 	// provider/model — resolve provider alias (e.g. "mmtp" -> "xiaomi-tokenplan").
@@ -59,7 +77,7 @@ func resolveTargets(ctx context.Context, chains ChainSource, aliases AliasSource
 	}
 
 	// bare name -> try a chain first
-	res, err := chainResult(ctx, chains, tenantID, model)
+	res, err := chainResult(ctx, chains, latency, tenantID, model)
 	if err == nil {
 		return res, nil
 	}
@@ -78,17 +96,37 @@ func resolveTargets(ctx context.Context, chains ChainSource, aliases AliasSource
 }
 
 // chainResult resolves a chain by name and extracts its strategy metadata.
-func chainResult(ctx context.Context, chains ChainSource, tenantID, name string) (resolveResult, error) {
+func chainResult(ctx context.Context, chains ChainSource, latency LatencyReader, tenantID, name string) (resolveResult, error) {
 	list, err := chains.ListByTenant(ctx, tenantID)
 	if err != nil {
 		return resolveResult{}, err
 	}
 	for _, c := range list {
 		if c.Name == name {
-			targets := dispatch.TargetsFromChain(c)
-			if len(targets) == 0 {
+			steps := dispatch.TargetsFromChain(c)
+			if len(steps) == 0 {
 				return resolveResult{}, errBadModel("chain has no steps: " + name)
 			}
+
+			opts := dispatch.PlanOptions{ChainID: c.ID}
+			// Ordering strategies reorder the chain steps before the optional
+			// fallback model is appended, so the explicit last-resort target
+			// always stays last. round-robin rotates at dispatch time; the
+			// other strategies produce a fixed order tried in sequence.
+			switch normalizeStrategyToken(c.Strategy) {
+			case string(dispatch.StrategyRoundRobin), "round_robin", "roundrobin":
+				opts.Strategy = dispatch.StrategyRoundRobin
+			case chainStrategyCost:
+				steps = orderStepsByCost(steps)
+				opts.Strategy = dispatch.StrategyFallback
+			case chainStrategyLatency:
+				steps = orderStepsByLatency(ctx, latency, tenantID, steps)
+				opts.Strategy = dispatch.StrategyFallback
+			default:
+				opts.Strategy = dispatch.StrategyFallback
+			}
+
+			targets := steps
 			// Append fallback model as last-resort target when configured.
 			if c.FallbackProvider != "" && c.FallbackModel != "" {
 				targets = append(targets, dispatch.Target{
@@ -96,19 +134,49 @@ func chainResult(ctx context.Context, chains ChainSource, tenantID, name string)
 					Model:    c.FallbackModel,
 				})
 			}
-			opts := dispatch.PlanOptions{
-				ChainID: c.ID,
-			}
-			switch normalizeStrategyToken(c.Strategy) {
-			case string(dispatch.StrategyRoundRobin), "round_robin", "roundrobin":
-				opts.Strategy = dispatch.StrategyRoundRobin
-			default:
-				opts.Strategy = dispatch.StrategyFallback
-			}
 			return resolveResult{Targets: targets, PlanOpts: opts}, nil
 		}
 	}
 	return resolveResult{}, errBadModel("no chain named " + name)
+}
+
+// orderStepsByCost returns the steps ordered cheapest-first by the sum of a
+// model's input and output per-million-token rates. The sort is stable, so
+// steps with equal (or unknown) cost keep their declared order; models with no
+// price entry sink to the end as a last resort.
+func orderStepsByCost(steps []dispatch.Target) []dispatch.Target {
+	key := func(t dispatch.Target) float64 {
+		if mp, ok := connectors.ModelPriceByProviderModel(t.Provider, t.Model); ok {
+			return mp.InputPerM + mp.OutputPerM
+		}
+		return math.MaxFloat64
+	}
+	out := append([]dispatch.Target(nil), steps...)
+	sort.SliceStable(out, func(i, j int) bool { return key(out[i]) < key(out[j]) })
+	return out
+}
+
+// orderStepsByLatency returns the steps ordered fastest-first by average
+// observed probe latency. Steps with no measurement (or when no reader is
+// available) keep their declared order and sink behind measured steps, so a
+// chain still routes predictably before any health data has been collected.
+func orderStepsByLatency(ctx context.Context, latency LatencyReader, tenantID string, steps []dispatch.Target) []dispatch.Target {
+	if latency == nil {
+		return steps
+	}
+	measured := latency.AvgLatencyMS(ctx, tenantID, steps)
+	if len(measured) == 0 {
+		return steps
+	}
+	key := func(t dispatch.Target) int {
+		if ms, ok := measured[t.Provider+"/"+t.Model]; ok {
+			return ms
+		}
+		return math.MaxInt
+	}
+	out := append([]dispatch.Target(nil), steps...)
+	sort.SliceStable(out, func(i, j int) bool { return key(out[i]) < key(out[j]) })
+	return out
 }
 
 // badModelError signals an unresolvable model string (a client error).
@@ -117,3 +185,48 @@ type badModelError struct{ msg string }
 func (e badModelError) Error() string { return e.msg }
 
 func errBadModel(msg string) error { return badModelError{msg: msg} }
+
+// healthLatencyReader adapts the account-health store into a LatencyReader by
+// averaging background probe latency across a tenant's accounts for each
+// provider/model pair. It reads the health rows once per call, so ordering a
+// chain costs a single query regardless of step count.
+type healthLatencyReader struct{ health *store.HealthRepo }
+
+func (h healthLatencyReader) AvgLatencyMS(ctx context.Context, tenantID string, targets []dispatch.Target) map[string]int {
+	out := make(map[string]int)
+	if h.health == nil || len(targets) == 0 {
+		return out
+	}
+	rows, err := h.health.List(ctx, tenantID)
+	if err != nil {
+		return out
+	}
+	want := make(map[string]bool, len(targets))
+	for _, t := range targets {
+		want[t.Provider+"/"+t.Model] = true
+	}
+	type agg struct{ sum, n int }
+	sums := make(map[string]*agg)
+	for _, row := range rows {
+		k := row.Provider + "/" + row.Model
+		if !want[k] || row.LatencyMS <= 0 {
+			continue
+		}
+		a := sums[k]
+		if a == nil {
+			a = &agg{}
+			sums[k] = a
+		}
+		a.sum += row.LatencyMS
+		a.n++
+	}
+	for k, a := range sums {
+		if a.n > 0 {
+			out[k] = a.sum / a.n
+		}
+	}
+	return out
+}
+
+// latencyReader returns the LatencyReader used by the latency chain strategy.
+func (s *Server) latencyReader() LatencyReader { return healthLatencyReader{health: s.health} }

--- a/backend/internal/gateway/resolve_targets_test.go
+++ b/backend/internal/gateway/resolve_targets_test.go
@@ -28,7 +28,7 @@ func (f *fakeAliases) Get(_ context.Context, _ string) (store.ModelAlias, error)
 }
 
 func TestResolveTargetsEmptyModel(t *testing.T) {
-	_, err := resolveTargets(context.Background(), &fakeChains{}, &fakeAliases{}, "t1", "  ")
+	_, err := resolveTargets(context.Background(), &fakeChains{}, &fakeAliases{}, nil, "t1", "  ")
 	if err == nil {
 		t.Fatal("expected error for empty model")
 	}
@@ -38,7 +38,7 @@ func TestResolveTargetsEmptyModel(t *testing.T) {
 }
 
 func TestResolveTargetsProviderModel(t *testing.T) {
-	res, err := resolveTargets(context.Background(), &fakeChains{}, &fakeAliases{}, "t1", "openai/gpt-4o")
+	res, err := resolveTargets(context.Background(), &fakeChains{}, &fakeAliases{}, nil, "t1", "openai/gpt-4o")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestResolveTargetsProviderModel(t *testing.T) {
 
 func TestResolveTargetsKeepsExtraSlashes(t *testing.T) {
 	// Vendor-namespaced model ids keep the remaining slashes in the model.
-	res, err := resolveTargets(context.Background(), &fakeChains{}, &fakeAliases{}, "t1", "openrouter/anthropic/claude-3.5")
+	res, err := resolveTargets(context.Background(), &fakeChains{}, &fakeAliases{}, nil, "t1", "openrouter/anthropic/claude-3.5")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestResolveTargetsChainPrefix(t *testing.T) {
 		FallbackModel:    "gemini-2.0",
 	}}}
 
-	res, err := resolveTargets(context.Background(), chains, &fakeAliases{}, "t1", "chain:fast")
+	res, err := resolveTargets(context.Background(), chains, &fakeAliases{}, nil, "t1", "chain:fast")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestResolveTargetsChainDefaultStrategyIsFallback(t *testing.T) {
 			{Position: 0, Provider: "openai", Model: "gpt-4o"},
 		},
 	}}}
-	res, err := resolveTargets(context.Background(), chains, &fakeAliases{}, "t1", "chain:safe")
+	res, err := resolveTargets(context.Background(), chains, &fakeAliases{}, nil, "t1", "chain:safe")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestResolveTargetsBareNameChain(t *testing.T) {
 			{Position: 0, Provider: "openai", Model: "gpt-4o"},
 		},
 	}}}
-	res, err := resolveTargets(context.Background(), chains, &fakeAliases{}, "t1", "myroute")
+	res, err := resolveTargets(context.Background(), chains, &fakeAliases{}, nil, "t1", "myroute")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestResolveTargetsBareNameAlias(t *testing.T) {
 	// No matching chain, but an alias resolves.
 	chains := &fakeChains{chains: nil}
 	aliases := &fakeAliases{alias: store.ModelAlias{Alias: "gpt", Target: "openai/gpt-4o"}}
-	res, err := resolveTargets(context.Background(), chains, aliases, "t1", "gpt")
+	res, err := resolveTargets(context.Background(), chains, aliases, nil, "t1", "gpt")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestResolveTargetsBareNameAlias(t *testing.T) {
 func TestResolveTargetsUnresolvable(t *testing.T) {
 	chains := &fakeChains{chains: nil}
 	aliases := &fakeAliases{err: errors.New("not found")}
-	_, err := resolveTargets(context.Background(), chains, aliases, "t1", "mystery")
+	_, err := resolveTargets(context.Background(), chains, aliases, nil, "t1", "mystery")
 	if err == nil {
 		t.Fatal("expected error for unresolvable bare name")
 	}
@@ -157,8 +157,105 @@ func TestResolveTargetsUnresolvable(t *testing.T) {
 
 func TestResolveTargetsChainNotFound(t *testing.T) {
 	chains := &fakeChains{chains: []store.Chain{{ID: "c1", Name: "other"}}}
-	_, err := resolveTargets(context.Background(), chains, &fakeAliases{}, "t1", "chain:missing")
+	_, err := resolveTargets(context.Background(), chains, &fakeAliases{}, nil, "t1", "chain:missing")
 	if err == nil {
 		t.Fatal("expected error for missing chain")
+	}
+}
+
+// fakeLatency reports canned average latencies keyed by "provider/model".
+type fakeLatency struct{ ms map[string]int }
+
+func (f fakeLatency) AvgLatencyMS(_ context.Context, _ string, targets []dispatch.Target) map[string]int {
+	out := make(map[string]int)
+	for _, t := range targets {
+		if v, ok := f.ms[t.Provider+"/"+t.Model]; ok {
+			out[t.Provider+"/"+t.Model] = v
+		}
+	}
+	return out
+}
+
+func TestResolveTargetsCostStrategyOrdersCheapestFirst(t *testing.T) {
+	// deepseek-chat (0.14 + 0.28) is far cheaper than anthropic claude / openai
+	// gpt-4o, so the cost strategy must float it to the front while the explicit
+	// fallback model stays last.
+	chains := &fakeChains{chains: []store.Chain{{
+		ID:       "c-cost",
+		Name:     "thrifty",
+		Strategy: "cost",
+		Steps: []store.ChainStep{
+			{Position: 0, Provider: "openai", Model: "gpt-4o"},
+			{Position: 1, Provider: "deepseek", Model: "deepseek-chat"},
+		},
+		FallbackProvider: "openai",
+		FallbackModel:    "gpt-4o",
+	}}}
+
+	res, err := resolveTargets(context.Background(), chains, &fakeAliases{}, nil, "t1", "chain:thrifty")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.PlanOpts.Strategy != dispatch.StrategyFallback {
+		t.Fatalf("Strategy = %v, want fallback", res.PlanOpts.Strategy)
+	}
+	if len(res.Targets) != 3 {
+		t.Fatalf("got %d targets, want 3: %+v", len(res.Targets), res.Targets)
+	}
+	if res.Targets[0].Provider != "deepseek" {
+		t.Fatalf("cheapest first = %+v, want deepseek step leading", res.Targets[0])
+	}
+	// The explicit fallback model remains the last resort.
+	if res.Targets[2].Provider != "openai" || res.Targets[2].Model != "gpt-4o" {
+		t.Fatalf("last target = %+v, want fallback openai/gpt-4o", res.Targets[2])
+	}
+}
+
+func TestResolveTargetsLatencyStrategyOrdersFastestFirst(t *testing.T) {
+	chains := &fakeChains{chains: []store.Chain{{
+		ID:       "c-lat",
+		Name:     "snappy",
+		Strategy: "latency",
+		Steps: []store.ChainStep{
+			{Position: 0, Provider: "openai", Model: "gpt-4o"},
+			{Position: 1, Provider: "anthropic", Model: "claude-3.5"},
+		},
+	}}}
+	latency := fakeLatency{ms: map[string]int{
+		"openai/gpt-4o":        900,
+		"anthropic/claude-3.5": 120,
+	}}
+
+	res, err := resolveTargets(context.Background(), chains, &fakeAliases{}, latency, "t1", "chain:snappy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Targets) != 2 {
+		t.Fatalf("got %d targets, want 2: %+v", len(res.Targets), res.Targets)
+	}
+	if res.Targets[0].Provider != "anthropic" {
+		t.Fatalf("fastest first = %+v, want anthropic leading", res.Targets[0])
+	}
+}
+
+func TestResolveTargetsLatencyStrategyKeepsOrderWithoutData(t *testing.T) {
+	// With no measurements yet, the declared order is preserved so routing stays
+	// predictable before the background health probe has collected samples.
+	chains := &fakeChains{chains: []store.Chain{{
+		ID:       "c-lat2",
+		Name:     "coldstart",
+		Strategy: "latency",
+		Steps: []store.ChainStep{
+			{Position: 0, Provider: "openai", Model: "gpt-4o"},
+			{Position: 1, Provider: "anthropic", Model: "claude-3.5"},
+		},
+	}}}
+
+	res, err := resolveTargets(context.Background(), chains, &fakeAliases{}, fakeLatency{}, "t1", "chain:coldstart")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Targets[0].Provider != "openai" {
+		t.Fatalf("declared order not preserved: %+v", res.Targets)
 	}
 }

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -476,7 +476,13 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 		// whose arguments are not reassembled into one complete JSON object.
 		// The channel path runs the ToolArgSanitizer, which buffers and
 		// reassembles those fragments before rendering.
-		if len(attemptReq.Tools) == 0 && req.Metadata.SourceDialect == attempt.Conn.Dialect() {
+		//
+		// include_usage also forces the channel path: the client asked for a
+		// guaranteed usage event, which pumpStream synthesizes when the provider
+		// omits one. Raw byte piping can't inject a synthetic event, so we trade
+		// the zero-copy throughput for correct usage accounting on these opt-in
+		// requests.
+		if len(attemptReq.Tools) == 0 && !req.IncludeUsage && req.Metadata.SourceDialect == attempt.Conn.Dialect() {
 			if ds, ok := attempt.Conn.(core.DirectStreamable); ok {
 				body, _, rawErr := ds.StreamRaw(callCtx, attemptReq, attempt.Creds, streamCfg)
 				if rawErr != nil {
@@ -655,11 +661,31 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 	var streamBuf strings.Builder
 
 	var usage core.Usage
+	// sawUsage tracks whether the upstream ever emitted a usage event with real
+	// token counts. completionChars accumulates the assistant's streamed output
+	// (text + reasoning) length so we can synthesize a usage estimate when the
+	// client requested include_usage but the provider reported nothing.
+	var sawUsage bool
+	var completionChars int
 	for {
 		select {
 		case chunk, ok := <-in:
 			if !ok {
 				// Upstream closed — stream complete.
+				// If the client opted into a usage event (stream_options.
+				// include_usage) but the provider never sent one, synthesize an
+				// estimate so the client still receives a final usage event.
+				// Mirrors 9router's estimateUsage/addBufferToUsage behavior.
+				if req.IncludeUsage && !sawUsage {
+					est := estimateStreamUsage(req, completionChars)
+					if est.TotalTokens > 0 {
+						select {
+						case out <- core.StreamChunk{Type: core.ChunkUsage, Usage: &est}:
+						case <-stallCtx.Done():
+						}
+						usage = est
+					}
+				}
 				// Record actual total upstream duration as latency; TTFT is
 				// stored separately in ttft_ms by recordWithTTFT.
 				totalLatency := time.Since(started)
@@ -668,8 +694,16 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 				return
 			}
 			resetStall()
-			if chunk.Type == core.ChunkUsage && chunk.Usage != nil {
-				usage = mergeUsage(usage, *chunk.Usage)
+			switch chunk.Type {
+			case core.ChunkUsage:
+				if chunk.Usage != nil {
+					usage = mergeUsage(usage, *chunk.Usage)
+					if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 || chunk.Usage.TotalTokens > 0 {
+						sawUsage = true
+					}
+				}
+			case core.ChunkText, core.ChunkThinking:
+				completionChars += len(chunk.Delta)
 			}
 
 			// Outbound guardrail scan for streamed text. We accumulate every
@@ -734,6 +768,21 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 			p.budgetConfirm(scope, cost)
 			return
 		}
+	}
+}
+
+// estimateStreamUsage synthesizes a usage snapshot for a streaming response
+// when the upstream provider reported no token counts. Prompt tokens are
+// estimated from the request; completion tokens from the streamed output
+// length. Both use the ~4 chars/token heuristic. Used only as a fallback so
+// include_usage clients always receive a usage event.
+func estimateStreamUsage(req *core.ChatRequest, completionChars int) core.Usage {
+	prompt := core.EstimatePromptTokens(req)
+	completion := core.EstimateTokensFromChars(completionChars)
+	return core.Usage{
+		PromptTokens:     prompt,
+		CompletionTokens: completion,
+		TotalTokens:      prompt + completion,
 	}
 }
 

--- a/backend/internal/pipeline/usage_estimate_test.go
+++ b/backend/internal/pipeline/usage_estimate_test.go
@@ -1,0 +1,49 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+// TestEstimateStreamUsage verifies the fallback usage estimate combines a
+// prompt estimate from the request with a completion estimate from the streamed
+// output length.
+func TestEstimateStreamUsage(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "12345678"}}}, // 8 chars -> 2 tokens
+		},
+	}
+	// completionChars = 40 -> (40+3)/4 = 10 tokens
+	got := estimateStreamUsage(req, 40)
+	if got.PromptTokens != 2 {
+		t.Errorf("PromptTokens = %d, want 2", got.PromptTokens)
+	}
+	if got.CompletionTokens != 10 {
+		t.Errorf("CompletionTokens = %d, want 10", got.CompletionTokens)
+	}
+	if got.TotalTokens != 12 {
+		t.Errorf("TotalTokens = %d, want 12", got.TotalTokens)
+	}
+}
+
+// TestEstimateStreamUsage_NoOutput verifies a request with no streamed output
+// still reports the prompt estimate and a zero completion.
+func TestEstimateStreamUsage_NoOutput(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "1234"}}}, // 4 chars -> 1 token
+		},
+	}
+	got := estimateStreamUsage(req, 0)
+	if got.PromptTokens != 1 {
+		t.Errorf("PromptTokens = %d, want 1", got.PromptTokens)
+	}
+	if got.CompletionTokens != 0 {
+		t.Errorf("CompletionTokens = %d, want 0", got.CompletionTokens)
+	}
+	if got.TotalTokens != 1 {
+		t.Errorf("TotalTokens = %d, want 1", got.TotalTokens)
+	}
+}

--- a/backend/internal/transform/openai.go
+++ b/backend/internal/transform/openai.go
@@ -91,6 +91,14 @@ func (OpenAICodec) ParseRequest(body []byte) (*core.ChatRequest, error) {
 		Stream:      raw.Stream,
 		ToolChoice:  raw.ToolChoice,
 	}
+	// stream_options.include_usage: the client opts in to a usage event on the
+	// streaming response. We don't forward this upstream (many OpenAI-compatible
+	// providers 400 on it — see renderOAIRequest), but the pipeline honors it by
+	// guaranteeing a final usage event, synthesizing an estimate if the provider
+	// omits one.
+	if raw.Stream && raw.StreamOpts != nil && raw.StreamOpts.IncludeUsage {
+		req.IncludeUsage = true
+	}
 	if raw.ReasoningEffort != "" {
 		req.Reasoning = &core.ReasoningConfig{Effort: raw.ReasoningEffort}
 	} else if raw.Thinking != nil && raw.Thinking.Type != "" {

--- a/backend/internal/transform/openai_includeusage_test.go
+++ b/backend/internal/transform/openai_includeusage_test.go
@@ -1,0 +1,40 @@
+package transform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenAI_ParseRequest_IncludeUsage verifies stream_options.include_usage is
+// captured into the canonical request so the pipeline can guarantee a usage
+// event on the streaming response.
+func TestOpenAI_ParseRequest_IncludeUsage(t *testing.T) {
+	t.Run("opted in", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-4o","stream":true,"stream_options":{"include_usage":true},"messages":[{"role":"user","content":"hi"}]}`)
+		req, err := OpenAICodec{}.ParseRequest(body)
+		require.NoError(t, err)
+		require.True(t, req.IncludeUsage)
+	})
+
+	t.Run("opted out", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-4o","stream":true,"stream_options":{"include_usage":false},"messages":[{"role":"user","content":"hi"}]}`)
+		req, err := OpenAICodec{}.ParseRequest(body)
+		require.NoError(t, err)
+		require.False(t, req.IncludeUsage)
+	})
+
+	t.Run("no stream_options", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+		req, err := OpenAICodec{}.ParseRequest(body)
+		require.NoError(t, err)
+		require.False(t, req.IncludeUsage)
+	})
+
+	t.Run("non-stream request ignores include_usage", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-4o","stream":false,"stream_options":{"include_usage":true},"messages":[{"role":"user","content":"hi"}]}`)
+		req, err := OpenAICodec{}.ParseRequest(body)
+		require.NoError(t, err)
+		require.False(t, req.IncludeUsage)
+	})
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1093,6 +1093,8 @@ export const api = {
 
   quota: (period: string) =>
     request<{ accounts: QuotaAccount[]; since: string }>("GET", `/quota?period=${period}&tz=${browserTZ()}`),
+  quotaByProvider: (provider: string) =>
+    request<{ accounts: QuotaAccount[]; since: string }>("GET", `/quota?period=today&tz=${browserTZ()}&provider=${provider}`),
 
   consoleLog: () => request<{ logs: ConsoleLogEntry[] }>("GET", "/console"),
 

--- a/frontend/src/pages/ProviderDetail.tsx
+++ b/frontend/src/pages/ProviderDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Plus, Trash2, Plug, X, Zap, ArrowUp, ArrowDown, CheckCircle, ToggleLeft, ToggleRight, Search, Route, AlertCircle, AlertTriangle, RefreshCw, Globe, Copy, Check, Upload, Loader2, XCircle, Layers, FileText } from "lucide-react";
-import { api, type DeviceCode, type OAuthProvider, type Provider, type Account, type ProxyPool, type UpstreamQuota, type ProviderRoutingSettings, type BulkAccountResult } from "../lib/api";
+import { api, type DeviceCode, type OAuthProvider, type Provider, type Account, type ProxyPool, type UpstreamQuota, type ProviderRoutingSettings, type BulkAccountResult, type QuotaAccount } from "../lib/api";
 import { KiroConnectModal } from "../components/KiroConnectModal";
 import { QoderConnectModal } from "../components/QoderConnectModal";
 import { KilocodeConnectModal } from "../components/KilocodeConnectModal";
@@ -54,6 +54,15 @@ export function ProviderDetailPage() {
 
   const providers = useQuery({ queryKey: ["providers"], queryFn: () => api.providers() });
   const accounts = useQuery({ queryKey: ["accounts"], queryFn: () => api.listAccounts() });
+  const bulkQuota = useQuery({
+    queryKey: ["quota", "today", id],
+    queryFn: () => api.quotaByProvider(id!),
+    enabled: !!id,
+    staleTime: 60_000,
+  });
+  const quotaMap: Record<string, QuotaAccount> = Object.fromEntries(
+    (bulkQuota.data?.accounts ?? []).map((a) => [a.id, a]),
+  );
   const oauthProviders = useQuery({ queryKey: ["oauth-providers"], queryFn: () => api.oauthProviders() });
   const pools = useQuery({ queryKey: ["proxy-pools"], queryFn: () => api.listProxyPools() });
   const routing = useQuery({
@@ -601,6 +610,7 @@ export function ProviderDetailPage() {
                     onUpdateProxy={(patch) => updateAccount.mutate({ id: a.id, patch })}
                     testResult={testResults[a.id]}
                     disabledByBatch={testingAll}
+                    quotaData={quotaMap[a.id]}
                   />
                 ))}
               </div>
@@ -980,6 +990,7 @@ function AccountRow({
   onUpdateProxy,
   testResult,
   disabledByBatch,
+  quotaData,
 }: {
   account: Account;
   index: number;
@@ -994,6 +1005,7 @@ function AccountRow({
   onUpdateProxy: (patch: { priority?: number; proxy_pool_id?: string; disabled?: boolean }) => void;
   testResult?: { status: "testing" | "ok" | "error"; message?: string };
   disabledByBatch?: boolean;
+  quotaData?: QuotaAccount;
 }) {
   const testing = testResult?.status === "testing";
   const [localPriority, setLocalPriority] = useState(a.priority);
@@ -1012,14 +1024,7 @@ function AccountRow({
     }
   };
 
-  const quota = useQuery({
-    queryKey: ["account-quota", a.id],
-    queryFn: () => api.accountQuota(a.id),
-    staleTime: 60_000,
-    enabled: !a.disabled,
-  });
-
-  const hasQuota = quota.data?.supported && quota.data?.quotas && quota.data.quotas.length > 0;
+  const hasQuota = !!quotaData?.upstream_quotas && quotaData.upstream_quotas.length > 0;
   const boundPool = pools.find((p) => p.id === a.proxy_pool_id);
 
   return (
@@ -1158,17 +1163,17 @@ function AccountRow({
       </div>
 
       {/* Quota / credit info */}
-      {hasQuota && quota.data && (
+      {hasQuota && quotaData && (
         <div className="mt-2.5 rounded-lg border border-[var(--border)] bg-[var(--bg-subtle)] px-3 py-2.5">
           <div className="mb-2 flex items-center gap-2">
             <Zap className="h-3.5 w-3.5 text-[var(--text-muted)]" />
             <span className="text-xs font-medium">
-              {quota.data.plan_name ? `${quota.data.plan_name} — Credits` : "Credits & Quota"}
+              {quotaData.plan_name ? `${quotaData.plan_name} — Credits` : "Credits & Quota"}
             </span>
           </div>
-          {quota.data.quotas && (
+          {quotaData.upstream_quotas && (
             <div className="space-y-2">
-              {quota.data.quotas.map((q) => (
+              {quotaData.upstream_quotas.map((q) => (
                 <QuotaBarInline key={q.resource_type} quota={q} />
               ))}
             </div>


### PR DESCRIPTION
## What

Improvements to routing chains, streaming usage reporting, model discovery, and provider quota fetching:

- **Latency/cost-based chain ordering**: Chains can now order steps by observed latency or provider cost, in addition to round-robin, while preserving the fallback model as last resort.
- **Streaming usage synthesis**: Clients that opt in via `stream_options.include_usage` are guaranteed a final usage event, even when the upstream provider omits or rejects it. Adds token estimation helpers for client-side budgeting.
- **Live model discovery**: `GetLiveModelSource` supports dynamic OpenAI-compatible providers, and `adminProviderModels` falls back to unauthenticated discovery so public `/models` endpoints populate the catalog before accounts connect.
- **Provider quota filtering**: New `provider` query parameter on the quota usage endpoint plus a bulk `quotaByProvider` API method, eliminating the N+1 per-account quota queries in `ProviderDetail`.

## Why

Chains needed smarter failover ordering, streaming clients needed reliable usage reporting regardless of upstream behavior, and the provider detail view was making redundant per-account quota requests.

## How

- Added a `LatencyReader` interface and `orderStepsByCost` / `orderStepsByLatency` helpers wired into `resolveTargets` and `chainResult`.
- Added `tokens.go` with `EstimateTokensFromChars` / `EstimatePromptTokens`, an `IncludeUsage` field on `ChatRequest`, and usage-event synthesis in the streaming pipeline.
- Refactored model discovery to build discovery sources on demand with an extracted `appendLive` helper.
- Replaced per-account quota queries with a single bulk provider quota fetch, filtered server-side.

## Checklist

- [ ] `make test` passes
- [ ] `make vet` passes
- [ ] `npm run lint` and `npm run typecheck` pass (frontend changed)
- [ ] Documentation updated (if applicable)
- [ ] Config example updated (if applicable)