### PR TITLE
fix(models): hide unauthenticated providers

### DIFF
--- a/backend/internal/connectors/models.go
+++ b/backend/internal/connectors/models.go
@@ -335,7 +335,7 @@ func ModelsByKind(kind core.ServiceKind) []ProviderModel {
 		if !core.HasServiceKind(spec.ServiceKinds, kind) {
 			continue
 		}
-		for _, mdl := range providerModels[spec.ID] {
+		for _, mdl := range ModelsForProvider(spec.ID) {
 			if mdl.Kind == kind {
 				out = append(out, ProviderModel{Provider: spec.ID, Model: mdl})
 			}
@@ -346,7 +346,7 @@ func ModelsByKind(kind core.ServiceKind) []ProviderModel {
 
 // FindModel locates a model by provider id and model id.
 func FindModel(providerID, modelID string) (ModelSpec, bool) {
-	for _, mdl := range providerModels[providerID] {
+	for _, mdl := range ModelsForProvider(providerID) {
 		if mdl.ID == modelID {
 			return mdl, true
 		}

--- a/backend/internal/gateway/models.go
+++ b/backend/internal/gateway/models.go
@@ -33,6 +33,8 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	tenantID := tenantOf(key)
 
 	data := make([]modelEntry, 0, 64)
+	seen := make(map[string]struct{}, 64)
+	usableProviders := s.usableModelProviders(r.Context(), tenantID)
 
 	// Chains are exposed as "combo" models, matching the upstream convention:
 	// a combo chains multiple providers with auto-fallback and is callable by
@@ -41,21 +43,26 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	chains, err := s.chains.ListByTenant(r.Context(), tenantID)
 	if err == nil {
 		for _, c := range chains {
-			data = append(data, modelEntry{
+			data = appendModelEntry(data, seen, modelEntry{
 				ID: c.Name, Object: "model", OwnedBy: "combo", Kind: string(core.ServiceLLM), Name: c.Name,
 			})
 		}
 	}
 
-	// Static catalog models.
+	// Static catalog models for providers the tenant has connected. Without this
+	// gate, discovery advertises provider/model ids that the dispatcher will later
+	// reject with "no accounts configured".
 	for _, pm := range connectors.ModelsByKind(core.ServiceLLM) {
-		data = append(data, modelEntry{
-			ID:      pm.Provider + "/" + pm.Model.ID,
-			Object:  "model",
-			OwnedBy: pm.Provider,
+		if !usableProviders[pm.Provider] {
+			continue
+		}
+		data = appendModelEntry(data, seen, modelEntry{
+			ID:       pm.Provider + "/" + pm.Model.ID,
+			Object:   "model",
+			OwnedBy:  pm.Provider,
 			Provider: pm.Provider,
-			Kind:    string(core.ServiceLLM),
-			Name:    pm.Model.Name,
+			Kind:     string(core.ServiceLLM),
+			Name:     pm.Model.Name,
 		})
 	}
 
@@ -64,14 +71,17 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	// replace, the static catalog).
 	liveModels := s.fetchLiveModels(r.Context(), tenantID)
 	for provider, models := range liveModels {
+		if !usableProviders[provider] {
+			continue
+		}
 		for _, lm := range models {
-			data = append(data, modelEntry{
-				ID:      provider + "/" + lm.ID,
-				Object:  "model",
-				OwnedBy: provider,
+			data = appendModelEntry(data, seen, modelEntry{
+				ID:       provider + "/" + lm.ID,
+				Object:   "model",
+				OwnedBy:  provider,
 				Provider: provider,
-				Kind:    string(lm.Kind),
-				Name:    lm.Name,
+				Kind:     string(lm.Kind),
+				Name:     lm.Name,
 			})
 		}
 	}
@@ -99,8 +109,14 @@ func (s *Server) handleListModelsByKind(w http.ResponseWriter, r *http.Request) 
 
 	pairs := connectors.ModelsByKind(kind)
 	data := make([]modelEntry, 0, len(pairs))
+	seen := make(map[string]struct{}, len(pairs))
+	key, _ := authedKey(r.Context())
+	usableProviders := s.usableModelProviders(r.Context(), tenantOf(key))
 	for _, pm := range pairs {
-		data = append(data, modelEntry{
+		if !usableProviders[pm.Provider] {
+			continue
+		}
+		data = appendModelEntry(data, seen, modelEntry{
 			ID:         pm.Provider + "/" + pm.Model.ID,
 			Object:     "model",
 			OwnedBy:    pm.Provider,
@@ -136,7 +152,7 @@ func (s *Server) fetchLiveModels(ctx context.Context, tenantID string) map[strin
 		// Use the first non-disabled account.
 		var acc store.Account
 		for _, a := range accs {
-			if !a.Disabled {
+			if !a.Disabled && !a.NeedsReconnect {
 				acc = a
 				break
 			}
@@ -159,6 +175,35 @@ func (s *Server) fetchLiveModels(ctx context.Context, tenantID string) map[strin
 	return result
 }
 
+func (s *Server) usableModelProviders(ctx context.Context, tenantID string) map[string]bool {
+	usable := map[string]bool{}
+	if s.accounts == nil {
+		return usable
+	}
+	accs, err := s.accounts.ListByTenant(ctx, tenantID)
+	if err != nil {
+		return usable
+	}
+	for _, acc := range accs {
+		if acc.Provider == "" || acc.Disabled || acc.NeedsReconnect {
+			continue
+		}
+		usable[acc.Provider] = true
+	}
+	return usable
+}
+
+func appendModelEntry(data []modelEntry, seen map[string]struct{}, entry modelEntry) []modelEntry {
+	if entry.ID == "" {
+		return data
+	}
+	if _, ok := seen[entry.ID]; ok {
+		return data
+	}
+	seen[entry.ID] = struct{}{}
+	return append(data, entry)
+}
+
 // handleModelInfo serves GET /v1/models/info?id=<provider/model>: it returns
 // metadata for a single model (kind, dimensions, provider, name).
 func (s *Server) handleModelInfo(w http.ResponseWriter, r *http.Request) {
@@ -171,6 +216,11 @@ func (s *Server) handleModelInfo(w http.ResponseWriter, r *http.Request) {
 	provider, model, ok := strings.Cut(id, "/")
 	if !ok || provider == "" || model == "" {
 		writeError(w, http.StatusBadRequest, "id must be in provider/model form")
+		return
+	}
+	key, _ := authedKey(r.Context())
+	if !s.usableModelProviders(r.Context(), tenantOf(key))[provider] {
+		writeError(w, http.StatusNotFound, "unknown model: "+id)
 		return
 	}
 

--- a/backend/internal/gateway/models_test.go
+++ b/backend/internal/gateway/models_test.go
@@ -1,0 +1,171 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mydisha/keirouter/backend/internal/config"
+	"github.com/mydisha/keirouter/backend/internal/crypto"
+	"github.com/mydisha/keirouter/backend/internal/identity"
+	"github.com/mydisha/keirouter/backend/internal/store"
+	"github.com/mydisha/keirouter/backend/internal/vault"
+)
+
+func TestListModelsOnlyShowsConnectedProviders(t *testing.T) {
+	gw, apiKey := newModelDiscoveryTestGateway(t, []store.Account{
+		modelDiscoveryAccount("acc-openai", "openai", false, false),
+		modelDiscoveryAccount("acc-anthropic-disabled", "anthropic", true, false),
+		modelDiscoveryAccount("acc-gemini-reconnect", "gemini", false, true),
+	})
+
+	body := getAuthedJSON(t, gw, apiKey, "/v1/models")
+	models := modelIDsFromResponse(t, body)
+
+	require.NotEmpty(t, models)
+	require.Contains(t, models, "openai/gpt-4o")
+	require.NotContains(t, models, "anthropic/claude-sonnet-4-20250514")
+	require.NotContains(t, models, "gemini/gemini-2.5-pro")
+	for _, id := range models {
+		if strings.Contains(id, "/") {
+			require.Truef(t, strings.HasPrefix(id, "openai/"), "unexpected unconnected provider model %q", id)
+		}
+	}
+}
+
+func TestListModelsByKindOnlyShowsConnectedProviders(t *testing.T) {
+	gw, apiKey := newModelDiscoveryTestGateway(t, []store.Account{
+		modelDiscoveryAccount("acc-openai", "openai", false, false),
+	})
+
+	body := getAuthedJSON(t, gw, apiKey, "/v1/models/embedding")
+	models := modelIDsFromResponse(t, body)
+
+	require.Contains(t, models, "openai/text-embedding-3-small")
+	for _, id := range models {
+		require.Truef(t, strings.HasPrefix(id, "openai/"), "unexpected unconnected provider model %q", id)
+	}
+}
+
+func TestModelInfoOnlyShowsConnectedProviders(t *testing.T) {
+	gw, apiKey := newModelDiscoveryTestGateway(t, []store.Account{
+		modelDiscoveryAccount("acc-openai", "openai", false, false),
+	})
+
+	body := getAuthedJSON(t, gw, apiKey, "/v1/models/info?id=openai/gpt-4o")
+	require.Equal(t, "openai", body["provider"])
+	require.Equal(t, "gpt-4o", body["model"])
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models/info?id=anthropic/claude-sonnet-4-20250514", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	gw.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
+}
+
+func TestListModelsStillShowsChains(t *testing.T) {
+	gw, apiKey := newModelDiscoveryTestGateway(t, nil)
+	require.NoError(t, gw.chains.Create(context.Background(), store.Chain{
+		ID:       "chain-fast",
+		TenantID: store.DefaultTenantID,
+		Name:     "fast",
+		Strategy: "fallback",
+		Steps: []store.ChainStep{{
+			Position: 0,
+			Provider: "openai",
+			Model:    "gpt-4o",
+		}},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}))
+
+	body := getAuthedJSON(t, gw, apiKey, "/v1/models")
+	models := modelIDsFromResponse(t, body)
+
+	require.Equal(t, []string{"fast"}, models)
+}
+
+func newModelDiscoveryTestGateway(t *testing.T, accounts []store.Account) (*Server, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := store.Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: ":memory:"}, t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, db.Migrate(ctx))
+	require.NoError(t, db.Tenants().EnsureDefault(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	mk, err := crypto.GenerateMasterKey()
+	require.NoError(t, err)
+	sealer, err := crypto.NewSealer(mk)
+	require.NoError(t, err)
+	v := vault.New(sealer)
+
+	for _, acc := range accounts {
+		require.NoError(t, v.Seal(&acc, vault.NewSecret{APIKey: "sk-test"}))
+		require.NoError(t, db.Accounts().Create(ctx, acc))
+	}
+
+	idSvc := identity.New(db.APIKeys())
+	issued, err := idSvc.Create(ctx, store.DefaultTenantID, "", "test-key")
+	require.NoError(t, err)
+
+	gw := New(Deps{
+		Config:   config.Default(),
+		Identity: idSvc,
+		Chains:   db.Chains(),
+		Accounts: db.Accounts(),
+		Vault:    v,
+	})
+	return gw, issued.Plaintext
+}
+
+func modelDiscoveryAccount(id, provider string, disabled, needsReconnect bool) store.Account {
+	now := time.Now()
+	return store.Account{
+		ID:             id,
+		TenantID:       store.DefaultTenantID,
+		Provider:       provider,
+		Label:          id,
+		AuthKind:       store.AuthAPIKey,
+		Priority:       10,
+		Disabled:       disabled,
+		NeedsReconnect: needsReconnect,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+}
+
+func getAuthedJSON(t *testing.T, gw *Server, apiKey, path string) map[string]any {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	gw.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	return body
+}
+
+func modelIDsFromResponse(t *testing.T, body map[string]any) []string {
+	t.Helper()
+	items, ok := body["data"].([]any)
+	require.True(t, ok)
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		require.True(t, ok)
+		id, ok := m["id"].(string)
+		require.True(t, ok)
+		out = append(out, id)
+	}
+	return out
+}


### PR DESCRIPTION
## What

Gate model discovery so `/v1/models`, `/v1/models/{kind}`, and `/v1/models/info` only expose models from providers that the tenant has authenticated and can use.

## Why

This is related to #32. The OpenCode plugin added there fetches models from `/v1/models`; without this backend filter, OpenCode sees many catalog models from providers that have no configured auth/account, causing unusable models to appear in the picker.

## How

- Added provider gating based on tenant accounts.
- Excludes providers whose account is disabled or marked `NeedsReconnect`.
- Keeps tenant-owned chains visible.
- Deduplicates static and live-discovered model entries.
- Applies the same gate to model metadata lookup and returns `404` for unconnected providers to avoid leaking provider availability.
- Added gateway tests for connected providers, disabled/reconnect accounts, chains, kind-filtered discovery, and model info gating.

## Verification

- `go test ./backend/internal/gateway`
- `go test ./backend/...`
- Live local check: only configured Mimo providers were returned from `/v1/models`; unconfigured `anthropic`, `openai`, and `kiro` model info probes returned `404`.