### PR TITLE
feat(health): provider health dashboard with telemetry and probes

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/guardrails/pii"
 	"github.com/mydisha/keirouter/backend/internal/guardrails/topics"
 	"github.com/mydisha/keirouter/backend/internal/guardrails/toxicity"
+	"github.com/mydisha/keirouter/backend/internal/health"
 	"github.com/mydisha/keirouter/backend/internal/healthcheck"
 	"github.com/mydisha/keirouter/backend/internal/httputil"
 	"github.com/mydisha/keirouter/backend/internal/identity"
@@ -62,6 +63,8 @@ type App struct {
 	guardrailRetention *guardrails.RetentionSweeper
 	meter              *meter.Meter
 	healthChecker      *healthcheck.Checker
+	providerHealth     *health.Service
+	probeRunner        *health.ProbeRunner
 
 	// bg tracks long-lived background workers that touch the DB (oauth
 	// keepalive, health checker, cooldown sweeper) so shutdown can wait for
@@ -299,6 +302,19 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 		CleanupInterval: cfg.Limits.CleanupInterval,
 	})
 
+	// Actionable provider health dashboard: real-traffic telemetry aggregation
+	// + synthetic probe runner. Best-effort, never blocks the request path.
+	healthSvc := health.New(health.Config{
+		Enabled:              cfg.ProviderHealth.Enabled,
+		QueueSize:            cfg.ProviderHealth.QueueSize,
+		CurrentFlushInterval: cfg.ProviderHealth.CurrentFlushInterval,
+		SnapshotInterval:     cfg.ProviderHealth.SnapshotInterval,
+		RollingWindow:        cfg.ProviderHealth.RollingWindow,
+		LatencyThresholds:    cfg.ProviderHealth.LatencyThresholds,
+	}, log, db.ProviderHealth())
+	probeRunner := health.NewProbeRunner(log, db.ProviderHealth(), db.Accounts(), connRegistry, v,
+		cfg.ProviderHealth.LatencyThresholds, cfg.ProviderHealth.ProbeTimeout)
+
 	pipe := pipeline.New(pipeline.Deps{
 		Dispatcher:         disp,
 		Meter:              mtr,
@@ -313,6 +329,7 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 		RequestTimeout:     cfg.Server.RequestTimeout,
 		StreamStallTimeout: cfg.Server.StreamStallTimeout,
 		TimeoutReader:      timeoutNotifier,
+		Telemetry:          healthSvc,
 	})
 
 	// Resolve frontend dist directory. Check common install locations, then cwd.
@@ -379,6 +396,8 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 		GuardrailTenantFlags: guardrailTenantPolicy,
 		Health:               db.Health(),
 		HealthChecker:        healthChecker,
+		ProviderHealth:       healthSvc,
+		ProbeRunner:          probeRunner,
 	})
 
 	srv := &http.Server{
@@ -393,7 +412,7 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 	// usable without a manual "connect" step in the dashboard.
 	seedFreeAccounts(ctx, db.Accounts(), log)
 
-	return &App{cfg: cfg, log: log, db: db, accounts: db.Accounts(), server: srv, keepAlive: keepAlive, guardrailAudit: guardrailAudit, guardrailRetention: guardrailRetention, meter: mtr, healthChecker: healthChecker}, nil
+	return &App{cfg: cfg, log: log, db: db, accounts: db.Accounts(), server: srv, keepAlive: keepAlive, guardrailAudit: guardrailAudit, guardrailRetention: guardrailRetention, meter: mtr, healthChecker: healthChecker, providerHealth: healthSvc, probeRunner: probeRunner}, nil
 }
 
 // seedFreeAccounts auto-creates a default account for providers that are free
@@ -473,6 +492,11 @@ func (a *App) Run(ctx context.Context) error {
 			a.healthChecker.Run(ctx, store.DefaultTenantID)
 		}()
 	}
+	// Provider health telemetry aggregator (best-effort, non-blocking).
+	// It manages its own goroutine; Close is called during shutdown to flush.
+	if a.providerHealth != nil {
+		a.providerHealth.Start(ctx)
+	}
 
 	// Background cooldown sweeper: periodically clears expired cooldowns so
 	// accounts recover automatically without a restart.
@@ -525,6 +549,9 @@ func (a *App) Run(ctx context.Context) error {
 		}
 		if a.meter != nil {
 			a.meter.Close(a.cfg.Meter.ShutdownFlushTimeout)
+		}
+		if a.providerHealth != nil {
+			a.providerHealth.Close(5 * time.Second)
 		}
 		return a.db.Close()
 	case err := <-errCh:

--- a/backend/internal/clitools/claude.go
+++ b/backend/internal/clitools/claude.go
@@ -8,8 +8,9 @@ import (
 // ClaudeTool auto-configures Claude Code (~/.claude/settings.json).
 type ClaudeTool struct{}
 
-func (t *ClaudeTool) ID() string   { return "claude" }
-func (t *ClaudeTool) Name() string { return "Claude Code" }
+func (t *ClaudeTool) ID() string      { return "claude" }
+func (t *ClaudeTool) Name() string    { return "Claude Code" }
+func (t *ClaudeTool) Command() string { return "claude" }
 
 func (t *ClaudeTool) configPath(homeDir string) string {
 	return expandHome(homeDir, "~/.claude/settings.json")
@@ -21,7 +22,7 @@ func (t *ClaudeTool) DetectStatus(homeDir string) (bool, bool, string, error) {
 		return false, false, path, nil
 	}
 	var cfg map[string]any
-	if err := readJSON(path, &cfg); err != nil {
+	if err := readJSONC(path, &cfg); err != nil {
 		return true, false, path, nil
 	}
 	return true, t.hasKeiRouter(cfg), path, nil

--- a/backend/internal/clitools/cline.go
+++ b/backend/internal/clitools/cline.go
@@ -10,6 +10,9 @@ type ClineTool struct{}
 func (t *ClineTool) ID() string   { return "cline" }
 func (t *ClineTool) Name() string { return "Cline / Roo" }
 
+// Command returns "" — Cline is a VS Code extension, not a standalone CLI.
+func (t *ClineTool) Command() string { return "" }
+
 func (t *ClineTool) globalStatePath(homeDir string) string {
 	return expandHome(homeDir, "~/.cline/data/globalState.json")
 }
@@ -23,7 +26,7 @@ func (t *ClineTool) DetectStatus(homeDir string) (bool, bool, string, error) {
 		return false, false, path, nil
 	}
 	var cfg map[string]any
-	if err := readJSON(path, &cfg); err != nil {
+	if err := readJSONC(path, &cfg); err != nil {
 		return true, false, path, nil
 	}
 	v, _ := cfg["openAiBaseUrl"].(string)

--- a/backend/internal/clitools/codex.go
+++ b/backend/internal/clitools/codex.go
@@ -10,8 +10,9 @@ import (
 // CodexTool auto-configures Codex CLI (~/.codex/config.toml + auth.json).
 type CodexTool struct{}
 
-func (t *CodexTool) ID() string   { return "codex" }
-func (t *CodexTool) Name() string { return "Codex CLI" }
+func (t *CodexTool) ID() string      { return "codex" }
+func (t *CodexTool) Name() string    { return "Codex CLI" }
+func (t *CodexTool) Command() string { return "codex" }
 
 func (t *CodexTool) configPath(homeDir string) string {
 	return expandHome(homeDir, "~/.codex/config.toml")
@@ -56,9 +57,9 @@ func (t *CodexTool) Configure(homeDir, baseURL, apiKey string, models []string) 
 		providers = make(map[string]any)
 	}
 	providers["keirouter"] = map[string]any{
-		"name":      "KeiRouter",
-		"base_url":  ensureSuffix(baseURL, "/v1"),
-		"wire_api":  "responses",
+		"name":     "KeiRouter",
+		"base_url": ensureSuffix(baseURL, "/v1"),
+		"wire_api": "responses",
 	}
 	cfg["model_providers"] = providers
 

--- a/backend/internal/clitools/copilot.go
+++ b/backend/internal/clitools/copilot.go
@@ -13,6 +13,9 @@ type CopilotTool struct{}
 func (t *CopilotTool) ID() string   { return "copilot" }
 func (t *CopilotTool) Name() string { return "GitHub Copilot (VS Code)" }
 
+// Command returns "" — Copilot is a VS Code extension, not a standalone CLI.
+func (t *CopilotTool) Command() string { return "" }
+
 func (t *CopilotTool) configPath(homeDir string) string {
 	return platformConfigPath(homeDir, "chatLanguageModels.json")
 }
@@ -23,7 +26,7 @@ func (t *CopilotTool) DetectStatus(homeDir string) (bool, bool, string, error) {
 		return false, false, path, nil
 	}
 	var entries []map[string]any
-	if err := readJSON(path, &entries); err != nil {
+	if err := readJSONC(path, &entries); err != nil {
 		// Might be an object, not array — still installed.
 		return true, false, path, nil
 	}
@@ -56,30 +59,30 @@ func (t *CopilotTool) Configure(homeDir, baseURL, apiKey string, models []string
 	modelEntries := make([]map[string]any, len(models))
 	for i, m := range models {
 		modelEntries[i] = map[string]any{
-			"id":           m,
-			"name":         m,
-			"url":          fmt.Sprintf("%s/v1/chat/completions#models.ai.azure.com", baseURL),
-			"toolCalling":  true,
+			"id":              m,
+			"name":            m,
+			"url":             fmt.Sprintf("%s/v1/chat/completions#models.ai.azure.com", baseURL),
+			"toolCalling":     true,
 			"maxInputTokens":  128000,
 			"maxOutputTokens": 16384,
 		}
 	}
 	if len(modelEntries) == 0 {
 		modelEntries = []map[string]any{{
-			"id":           "gpt-4o",
-			"name":         "gpt-4o",
-			"url":          fmt.Sprintf("%s/v1/chat/completions#models.ai.azure.com", baseURL),
-			"toolCalling":  true,
+			"id":              "gpt-4o",
+			"name":            "gpt-4o",
+			"url":             fmt.Sprintf("%s/v1/chat/completions#models.ai.azure.com", baseURL),
+			"toolCalling":     true,
 			"maxInputTokens":  128000,
 			"maxOutputTokens": 16384,
 		}}
 	}
 
 	entry := map[string]any{
-		"name":    "KeiRouter",
-		"vendor":  "azure",
-		"apiKey":  apiKey,
-		"models":  modelEntries,
+		"name":   "KeiRouter",
+		"vendor": "azure",
+		"apiKey": apiKey,
+		"models": modelEntries,
 	}
 	filtered = append(filtered, entry)
 

--- a/backend/internal/clitools/deepseek.go
+++ b/backend/internal/clitools/deepseek.go
@@ -9,8 +9,9 @@ import (
 // DeepSeekTool auto-configures DeepSeek TUI (~/.deepseek/config.toml).
 type DeepSeekTool struct{}
 
-func (t *DeepSeekTool) ID() string   { return "deepseek" }
-func (t *DeepSeekTool) Name() string { return "DeepSeek TUI" }
+func (t *DeepSeekTool) ID() string      { return "deepseek" }
+func (t *DeepSeekTool) Name() string    { return "DeepSeek TUI" }
+func (t *DeepSeekTool) Command() string { return "deepseek" }
 
 func (t *DeepSeekTool) configPath(homeDir string) string {
 	return expandHome(homeDir, "~/.deepseek/config.toml")

--- a/backend/internal/clitools/detect.go
+++ b/backend/internal/clitools/detect.go
@@ -1,0 +1,250 @@
+package clitools
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// detectTimeout caps how long a single tool's detection (config read + version
+// probe) may run. Keeps one misbehaving CLI from stalling the whole batch.
+const detectTimeout = 3 * time.Second
+
+// versionProbeTimeout caps the `<cmd> --version` subprocess call.
+const versionProbeTimeout = 1500 * time.Millisecond
+
+// lookupBinary resolves name to an absolute executable path using an augmented
+// PATH. On Windows, npm/cargo/pnpm global bin dirs are often absent from PATH
+// for GUI-launched apps, so they are prepended explicitly. Returns ("", false)
+// when the binary cannot be found.
+//
+// Unlike shelling out to `which`/`where`, this uses exec.LookPath directly —
+// no subprocess, cross-platform, and respects PATHEXT on Windows.
+func lookupBinary(name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	if p, err := exec.LookPath(name); err == nil {
+		return p, true
+	}
+	// Retry with an augmented PATH covering common global bin locations that
+	// may not be inherited when the gateway is launched by a desktop entry,
+	// systemd, or a GUI session.
+	for _, dir := range extraBinDirs() {
+		candidate := filepath.Join(dir, exeName(name))
+		if abs, err := filepath.Abs(candidate); err == nil {
+			if isExecutable(abs) {
+				return abs, true
+			}
+		}
+	}
+	return "", false
+}
+
+// exeName appends the .exe suffix on Windows when not already present.
+func exeName(name string) string {
+	if runtime.GOOS == "windows" && !strings.HasSuffix(strings.ToLower(name), ".exe") {
+		return name + ".exe"
+	}
+	return name
+}
+
+// extraBinDirs returns platform-specific global binary directories that are
+// commonly missing from a server process's PATH.
+func extraBinDirs() []string {
+	home, _ := os.UserHomeDir()
+	var dirs []string
+	switch runtime.GOOS {
+	case "windows":
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			dirs = append(dirs,
+				filepath.Join(appdata, "npm"),
+				filepath.Join(appdata, "pnpm"),
+			)
+		}
+		if local := os.Getenv("LOCALAPPDATA"); local != "" {
+			dirs = append(dirs,
+				filepath.Join(local, "pnpm"),
+				filepath.Join(local, "Microsoft", "WinGet", "Links"),
+			)
+		}
+		if home != "" {
+			dirs = append(dirs, filepath.Join(home, ".cargo", "bin"),
+				filepath.Join(home, ".opencode", "bin"))
+		}
+	case "darwin":
+		if home != "" {
+			dirs = append(dirs,
+				"/opt/homebrew/bin",
+				"/usr/local/bin",
+				filepath.Join(home, ".cargo", "bin"),
+				filepath.Join(home, ".local", "bin"),
+				filepath.Join(home, ".bun", "bin"),
+				filepath.Join(home, ".opencode", "bin"),
+			)
+		}
+	default: // linux / *bsd
+		if home != "" {
+			dirs = append(dirs,
+				filepath.Join(home, ".local", "bin"),
+				filepath.Join(home, ".cargo", "bin"),
+				filepath.Join(home, ".bun", "bin"),
+				filepath.Join(home, ".opencode", "bin"),
+				filepath.Join(home, "go", "bin"),
+				"/usr/local/bin",
+			)
+		}
+	}
+	return dirs
+}
+
+// isExecutable reports whether path exists and is executable (regular file
+// with any exec bit on POSIX, or any file on Windows).
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return !info.IsDir()
+	}
+	return !info.IsDir() && info.Mode().Perm()&0o111 != 0
+}
+
+// detectVersion runs `<bin> --version` (falling back to `-v` / `version`) with
+// a short timeout and returns the first line of output. Returns "" on any
+// failure — version is best-effort and must never block detection.
+func detectVersion(binPath, name string) string {
+	if binPath == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout)
+	defer cancel()
+
+	for _, args := range [][]string{{"--version"}, {"-v"}, {"version"}, {"-V"}} {
+		out, err := exec.CommandContext(ctx, binPath, args...).Output()
+		if ctx.Err() == context.DeadlineExceeded {
+			return ""
+		}
+		if err != nil {
+			continue
+		}
+		line := strings.TrimSpace(string(out))
+		if line == "" {
+			continue
+		}
+		// Some CLIs print a banner before the version; take the first
+		// non-empty line that contains a digit.
+		sc := bufio.NewScanner(strings.NewReader(line))
+		for sc.Scan() {
+			l := strings.TrimSpace(sc.Text())
+			if l != "" && strings.ContainsAny(l, "0123456789") {
+				return truncateVersion(l)
+			}
+		}
+		if line != "" {
+			return truncateVersion(line)
+		}
+	}
+	return ""
+}
+
+// truncateVersion caps version strings so a chatty CLI cannot flood the UI.
+func truncateVersion(s string) string {
+	const max = 120
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}
+
+// parseJSONC best-effort strips JSONC artifacts (// line comments and trailing
+// commas) so that user-edited config files with JSONC syntax do not break JSON
+// parsing and misreport a tool as "not configured".
+func parseJSONC(raw string) string {
+	var b strings.Builder
+	b.Grow(len(raw))
+	sc := bufio.NewScanner(strings.NewReader(raw))
+	// Allow long single-line JSONC files.
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		// Strip // comments that are not inside a string. Simple heuristic:
+		// cut at the first // that follows only whitespace/JSON tokens. This
+		// mirrors the tolerance the frontend applies and is intentionally
+		// conservative — quoted URLs rarely contain "//" preceded by a space.
+		if idx := indexLineComment(line); idx >= 0 {
+			line = line[:idx]
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	// Strip trailing commas before } or ].
+	s := b.String()
+	s = stripTrailingCommas(s)
+	return s
+}
+
+// indexLineComment returns the byte index of a `//` line comment start, or -1.
+// It skips `//` inside double-quoted strings.
+func indexLineComment(line string) int {
+	inStr := false
+	escaped := false
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			inStr = !inStr
+			continue
+		}
+		if !inStr && c == '/' && i+1 < len(line) && line[i+1] == '/' {
+			return i
+		}
+	}
+	return -1
+}
+
+// stripTrailingCommas removes commas that immediately precede a closing } or ],
+// allowing lenient parsing of hand-edited JSONC configs.
+func stripTrailingCommas(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ',' {
+			j := i + 1
+			for j < len(s) && (s[j] == ' ' || s[j] == '\t' || s[j] == '\n' || s[j] == '\r') {
+				j++
+			}
+			if j < len(s) && (s[j] == '}' || s[j] == ']') {
+				continue
+			}
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+// readJSONC is readJSON with JSONC tolerance: strips comments and trailing
+// commas before unmarshalling. Used for user-edited config files (Claude,
+// OpenCode, Cline, etc.) that commonly contain JSONC.
+func readJSONC(path string, v any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(parseJSONC(string(data))), v)
+}

--- a/backend/internal/clitools/droid.go
+++ b/backend/internal/clitools/droid.go
@@ -9,8 +9,9 @@ import (
 // DroidTool auto-configures Factory Droid (~/.factory/settings.json).
 type DroidTool struct{}
 
-func (t *DroidTool) ID() string   { return "droid" }
-func (t *DroidTool) Name() string { return "Factory Droid" }
+func (t *DroidTool) ID() string      { return "droid" }
+func (t *DroidTool) Name() string    { return "Factory Droid" }
+func (t *DroidTool) Command() string { return "droid" }
 
 func (t *DroidTool) configPath(homeDir string) string {
 	return expandHome(homeDir, "~/.factory/settings.json")

--- a/backend/internal/clitools/hermes.go
+++ b/backend/internal/clitools/hermes.go
@@ -9,8 +9,9 @@ import (
 // HermesTool auto-configures Hermes Agent (~/.hermes/config.yaml + .env).
 type HermesTool struct{}
 
-func (t *HermesTool) ID() string   { return "hermes" }
-func (t *HermesTool) Name() string { return "Hermes Agent" }
+func (t *HermesTool) ID() string      { return "hermes" }
+func (t *HermesTool) Name() string    { return "Hermes Agent" }
+func (t *HermesTool) Command() string { return "hermes" }
 
 func (t *HermesTool) configPath(homeDir string) string {
 	return expandHome(homeDir, "~/.hermes/config.yaml")

--- a/backend/internal/clitools/jcode.go
+++ b/backend/internal/clitools/jcode.go
@@ -9,8 +9,9 @@ import (
 // JcodeTool auto-configures jcode (~/.jcode/config.toml + env file).
 type JcodeTool struct{}
 
-func (t *JcodeTool) ID() string   { return "jcode" }
-func (t *JcodeTool) Name() string { return "jcode" }
+func (t *JcodeTool) ID() string      { return "jcode" }
+func (t *JcodeTool) Name() string    { return "jcode" }
+func (t *JcodeTool) Command() string { return "jcode" }
 
 func (t *JcodeTool) configPath(homeDir string) string {
 	return expandHome(homeDir, "~/.jcode/config.toml")

--- a/backend/internal/clitools/kilo.go
+++ b/backend/internal/clitools/kilo.go
@@ -10,6 +10,9 @@ type KiloTool struct{}
 func (t *KiloTool) ID() string   { return "kilo" }
 func (t *KiloTool) Name() string { return "Kilo Code" }
 
+// Command returns "" — Kilo Code is a VS Code extension, not a standalone CLI.
+func (t *KiloTool) Command() string { return "" }
+
 func (t *KiloTool) configPath(homeDir string) string {
 	return expandHome(homeDir, "~/.local/share/kilo/auth.json")
 }
@@ -20,7 +23,7 @@ func (t *KiloTool) DetectStatus(homeDir string) (bool, bool, string, error) {
 		return false, false, path, nil
 	}
 	var cfg map[string]any
-	if err := readJSON(path, &cfg); err != nil {
+	if err := readJSONC(path, &cfg); err != nil {
 		return true, false, path, nil
 	}
 	if oc, ok := cfg["openai-compatible"].(map[string]any); ok {

--- a/backend/internal/clitools/openclaw.go
+++ b/backend/internal/clitools/openclaw.go
@@ -7,8 +7,9 @@ import (
 // OpenClawTool auto-configures OpenClaw (~/.openclaw/openclaw.json).
 type OpenClawTool struct{}
 
-func (t *OpenClawTool) ID() string   { return "openclaw" }
-func (t *OpenClawTool) Name() string { return "OpenClaw" }
+func (t *OpenClawTool) ID() string      { return "openclaw" }
+func (t *OpenClawTool) Name() string    { return "OpenClaw" }
+func (t *OpenClawTool) Command() string { return "openclaw" }
 
 func (t *OpenClawTool) configPath(homeDir string) string {
 	return expandHome(homeDir, "~/.openclaw/openclaw.json")

--- a/backend/internal/clitools/opencode.go
+++ b/backend/internal/clitools/opencode.go
@@ -2,15 +2,25 @@ package clitools
 
 import (
 	"os"
+	"path/filepath"
 )
 
 // OpenCodeTool auto-configures OpenCode (~/.config/opencode/opencode.json).
 type OpenCodeTool struct{}
 
-func (t *OpenCodeTool) ID() string   { return "opencode" }
-func (t *OpenCodeTool) Name() string { return "OpenCode" }
+func (t *OpenCodeTool) ID() string      { return "opencode" }
+func (t *OpenCodeTool) Name() string    { return "OpenCode" }
+func (t *OpenCodeTool) Command() string { return "opencode" }
 
+// configPath resolves the OpenCode config path. OpenCode honors XDG_CONFIG_HOME
+// (and the opencode.json file is JSONC-tolerant). Falls back to ~/.config.
 func (t *OpenCodeTool) configPath(homeDir string) string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		if !filepath.IsAbs(xdg) {
+			xdg = filepath.Join(homeDir, xdg)
+		}
+		return filepath.Join(xdg, "opencode", "opencode.json")
+	}
 	return expandHome(homeDir, "~/.config/opencode/opencode.json")
 }
 

--- a/backend/internal/clitools/registry.go
+++ b/backend/internal/clitools/registry.go
@@ -7,11 +7,15 @@
 package clitools
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // Tool describes a CLI tool that can be auto-configured to use KeiRouter.
@@ -20,6 +24,11 @@ type Tool interface {
 	ID() string
 	// Name returns the human-readable display name.
 	Name() string
+	// Command returns the CLI binary name used to verify installation
+	// (e.g. "claude", "codex"). Return "" for tools that ship only as IDE
+	// extensions (cline, copilot, kilo) — those are detected via their config
+	// files instead of a binary lookup.
+	Command() string
 	// DetectStatus checks whether the tool is installed and whether KeiRouter
 	// is already configured. configPath is the path that was checked.
 	DetectStatus(homeDir string) (installed, configured bool, configPath string, err error)
@@ -36,6 +45,15 @@ type Status struct {
 	Installed  bool   `json:"installed"`
 	Configured bool   `json:"configured"`
 	ConfigPath string `json:"config_path"`
+	// BinaryPath is the resolved executable path, or "" when no binary was
+	// found (e.g. IDE-only tools or uninstalled CLIs).
+	BinaryPath string `json:"binary_path,omitempty"`
+	// Version is the best-effort version string reported by the binary, or ""
+	// when unavailable.
+	Version string `json:"version,omitempty"`
+	// Error holds a detection error message when detection failed for reasons
+	// other than the tool simply being absent.
+	Error string `json:"error,omitempty"`
 }
 
 // Registry holds all known CLI tools.
@@ -76,17 +94,104 @@ func (r *Registry) All() []Tool {
 	return out
 }
 
-// DetectAll returns the status of every registered tool.
+// DetectAll returns the status of every registered tool. Detection runs in
+// parallel with a per-tool timeout so one slow or misbehaving CLI cannot stall
+// the batch. For each tool, detection combines:
+//   - a binary lookup (exec.LookPath over an augmented PATH) — so a stale
+//     config file left behind after uninstall no longer false-positives as
+//     "installed";
+//   - the tool's own config-file check; and
+//   - a best-effort `<cmd> --version` probe.
+//
+// A tool counts as installed if EITHER its binary is on PATH OR its config
+// file exists (the config file is the only signal for IDE-only extensions).
 func (r *Registry) DetectAll(homeDir string) []Status {
-	out := make([]Status, 0, len(r.tools))
-	for _, t := range r.All() {
-		inst, conf, path, _ := t.DetectStatus(homeDir)
-		out = append(out, Status{
-			ID: t.ID(), Name: t.Name(),
-			Installed: inst, Configured: conf, ConfigPath: path,
+	tools := r.All()
+	out := make([]Status, len(tools))
+	idx := make(map[string]int, len(tools))
+	for i, t := range tools {
+		idx[t.ID()] = i
+		out[i] = Status{ID: t.ID(), Name: t.Name()}
+	}
+
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(context.Background())
+	for i, t := range tools {
+		i, t := i, t
+		g.Go(func() error {
+			ctx, cancel := context.WithTimeout(gctx, detectTimeout)
+			defer cancel()
+
+			st := detectOne(ctx, t, homeDir)
+			mu.Lock()
+			out[i] = st
+			mu.Unlock()
+			return nil
 		})
 	}
+	_ = g.Wait()
 	return out
+}
+
+// detectOne runs the full detection pipeline for a single tool. It never
+// panics on errors — failures are surfaced via Status.Error so the UI can
+// distinguish "not installed" from "detection broke".
+func detectOne(ctx context.Context, t Tool, homeDir string) Status {
+	st := Status{ID: t.ID(), Name: t.Name()}
+
+	// Binary lookup (no timeout needed — exec.LookPath is fast).
+	if bin, ok := lookupBinary(t.Command()); ok {
+		st.BinaryPath = bin
+	}
+
+	// Tool-specific config check. Wrapped so a panic/long read cannot kill the
+	// goroutine; the ctx timeout bounds the whole pipeline.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		inst, conf, path, err := t.DetectStatus(homeDir)
+		if err != nil {
+			st.Error = err.Error()
+		}
+		st.ConfigPath = path
+		// A tool is installed if the binary is on PATH OR its config file
+		// exists. This avoids false negatives when the binary is shadowed by
+		// a shell alias/function, and avoids false positives being the only
+		// signal: a stale config alone still counts, because the user may have
+		// a non-standard install location.
+		st.Installed = inst || st.BinaryPath != ""
+		st.Configured = conf
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		if st.Error == "" {
+			st.Error = "detection timed out"
+		}
+		// If we already found a binary, keep "installed" true even on timeout.
+		if st.BinaryPath != "" {
+			st.Installed = true
+		}
+	}
+
+	// Best-effort version probe (skipped on timeout). Only probe real CLIs;
+	// IDE extensions have no binary.
+	if st.BinaryPath != "" && ctx.Err() == nil {
+		vctx, vcancel := context.WithTimeout(context.Background(), versionProbeTimeout)
+		v := make(chan string, 1)
+		go func() {
+			v <- detectVersion(st.BinaryPath, t.Command())
+		}()
+		select {
+		case ver := <-v:
+			st.Version = ver
+		case <-vctx.Done():
+		}
+		vcancel()
+	}
+
+	return st
 }
 
 // ---- common helpers --------------------------------------------------------

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Meter      MeterConfig      `koanf:"meter"`
 	Limits     LimitsConfig     `koanf:"limits"`
 	Health     HealthConfig     `koanf:"health"`
+	ProviderHealth ProviderHealthConfig `koanf:"provider_health"`
 	Log        LogConfig        `koanf:"log"`
 	Data       DataConfig       `koanf:"data"`
 	Guardrails GuardrailsConfig `koanf:"guardrails"`
@@ -155,6 +156,50 @@ type HealthConfig struct {
 	MaxModelsPerProvider int           `koanf:"max_models_per_provider"`
 }
 
+// ProviderHealthConfig controls the actionable provider health dashboard:
+// real-traffic telemetry aggregation, synthetic probes, and latency thresholds.
+type ProviderHealthConfig struct {
+	// Enabled gates telemetry recording and the probe worker.
+	Enabled bool `koanf:"enabled"`
+	// ProbeInterval is the scheduled probe cadence.
+	ProbeInterval time.Duration `koanf:"probe_interval"`
+	// ProbeTimeout bounds one probe call.
+	ProbeTimeout time.Duration `koanf:"probe_timeout"`
+	// FailureThreshold is how many consecutive probe failures mark a target
+	// unhealthy when no real traffic exists.
+	FailureThreshold int `koanf:"failure_threshold"`
+	// QueueSize is the async telemetry channel capacity.
+	QueueSize int `koanf:"queue_size"`
+	// CurrentFlushInterval recomputes provider_health_current this often.
+	CurrentFlushInterval time.Duration `koanf:"current_flush_interval"`
+	// SnapshotInterval writes 1-minute snapshot rows this often.
+	SnapshotInterval time.Duration `koanf:"snapshot_interval"`
+	// RollingWindow is the lookback for current-state aggregation.
+	RollingWindow time.Duration `koanf:"rolling_window"`
+	// LatencyThresholds maps capability to its p95 threshold in ms.
+	LatencyThresholds map[string]int `koanf:"latency_thresholds"`
+	// Capabilities controls which capability types are auto-probed.
+	Capabilities ProviderHealthCapabilityConfig `koanf:"capabilities"`
+}
+
+// ProviderHealthCapabilityConfig toggles per-capability scheduled probes. Image,
+// audio, and search are off by default to avoid expensive probes.
+type ProviderHealthCapabilityConfig struct {
+	ChatCompletions ProviderHealthProbeConfig `koanf:"chat_completions"`
+	Embeddings      ProviderHealthProbeConfig `koanf:"embeddings"`
+	ImageGeneration ProviderHealthProbeConfig `koanf:"image_generation"`
+	Audio           ProviderHealthProbeConfig `koanf:"audio"`
+	Search          ProviderHealthProbeConfig `koanf:"search"`
+}
+
+// ProviderHealthProbeConfig configures one capability's probe payload.
+type ProviderHealthProbeConfig struct {
+	Enabled  bool   `koanf:"enabled"`
+	MaxTokens int   `koanf:"max_tokens"`
+	Prompt   string `koanf:"prompt"`
+	Input    string `koanf:"input"`
+}
+
 // LogConfig controls structured logging.
 type LogConfig struct {
 	// Level: debug, info, warn, error.
@@ -253,6 +298,27 @@ func Default() Config {
 			SuccessThreshold:     1,
 			RecentModelWindow:    24 * time.Hour,
 			MaxModelsPerProvider: 8,
+		},
+		ProviderHealth: ProviderHealthConfig{
+			Enabled:              true,
+			ProbeInterval:        60 * time.Second,
+			ProbeTimeout:         15 * time.Second,
+			FailureThreshold:     3,
+			QueueSize:            5000,
+			CurrentFlushInterval: 30 * time.Second,
+			SnapshotInterval:     60 * time.Second,
+			RollingWindow:        15 * time.Minute,
+			LatencyThresholds: map[string]int{
+				"chat_completions": 10_000,
+				"embeddings":       5_000,
+				"image_generation": 60_000,
+				"audio":            60_000,
+				"search":           15_000,
+			},
+			Capabilities: ProviderHealthCapabilityConfig{
+				ChatCompletions: ProviderHealthProbeConfig{Enabled: true, MaxTokens: 5, Prompt: "Reply with OK only."},
+				Embeddings:      ProviderHealthProbeConfig{Enabled: true, Input: "health check"},
+			},
 		},
 		Log: LogConfig{Level: "info", Format: "text"},
 	}

--- a/backend/internal/connectors/anthropic.go
+++ b/backend/internal/connectors/anthropic.go
@@ -122,8 +122,20 @@ func (c *Anthropic) Validate(ctx context.Context, creds core.Credentials) error 
 // non-auth HTTP response (e.g. an unknown probe model) still proves the key was
 // accepted.
 func (c *Anthropic) messagesAuthProbe(ctx context.Context, creds core.Credentials) error {
+	// Custom anthropic-compatible gateways may not expose the canonical Claude
+	// model id; probing with it can trip a 403 model_not_allowed that gets
+	// misclassified as an auth failure. When no real model is registered for
+	// this provider, skip the chat probe — the GET /models probe in Validate
+	// already confirmed the key works.
+	probeModel := firstCatalogModel(c.id)
+	if probeModel == "" {
+		if IsCustomProviderID(c.id) {
+			return nil
+		}
+		probeModel = "claude-sonnet-4-20250514"
+	}
 	chatURL := joinURL(c.baseURL(creds), "messages")
-	probeBody := []byte(`{"model":"claude-sonnet-4-20250514","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}`)
+	probeBody := []byte(`{"model":"` + probeModel + `","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}`)
 	_, err := doJSON(ctx, c.id, "validate", chatURL, probeBody, c.headers(creds))
 	if err == nil {
 		return nil

--- a/backend/internal/connectors/connectors_test.go
+++ b/backend/internal/connectors/connectors_test.go
@@ -333,9 +333,13 @@ func TestGetLiveModelSource_DynamicOpenAIProvider(t *testing.T) {
 	src := GetLiveModelSource(id)
 	require.NotNil(t, src, "dynamic OpenAI-compatible providers should get a live model source")
 
-	// A dynamic Anthropic provider has no OpenAI-style /models discovery.
+	// A dynamic Anthropic provider now gets an Anthropic-compatible model source
+	// (GET /v1/models discovery), mirroring the OpenAI-compatible path.
 	aid := "custom-anthropic-testdisco"
 	RegisterDynamicProvider(DynamicProvider{ID: aid, Dialect: core.DialectAnthropic, BaseURL: "https://example.test"})
 	t.Cleanup(func() { UnregisterDynamicProvider(aid) })
-	require.Nil(t, GetLiveModelSource(aid))
+	asrc := GetLiveModelSource(aid)
+	require.NotNil(t, asrc, "dynamic Anthropic-compatible providers should get a live model source")
+	_, ok := asrc.(*AnthropicCompatibleModelSource)
+	require.True(t, ok, "dynamic Anthropic provider should yield an AnthropicCompatibleModelSource")
 }

--- a/backend/internal/connectors/models.go
+++ b/backend/internal/connectors/models.go
@@ -2,6 +2,11 @@ package connectors
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
@@ -413,13 +418,84 @@ func GetLiveModelSource(provider string) LiveModelSource {
 	if src, ok := liveModelSources[provider]; ok {
 		return src
 	}
-	// Dynamic (user-defined) OpenAI-compatible providers are not in the static
-	// registry, so build a discovery source on demand. This lets a custom
-	// provider's /models endpoint populate the catalog just like a built-in one.
-	if p, ok := DynamicProviderByID(provider); ok && p.Dialect == core.DialectOpenAI {
-		return &OpenAICompatibleModelSource{provider: p.ID, defaultBase: p.BaseURL}
+	// Dynamic (user-defined) providers are not in the static registry, so build
+	// a discovery source on demand. This lets a custom provider's /models
+	// endpoint populate the catalog just like a built-in one.
+	if p, ok := DynamicProviderByID(provider); ok {
+		switch p.Dialect {
+		case core.DialectOpenAI:
+			return &OpenAICompatibleModelSource{provider: p.ID, defaultBase: p.BaseURL}
+		case core.DialectAnthropic:
+			return &AnthropicCompatibleModelSource{provider: p.ID, defaultBase: p.BaseURL}
+		}
 	}
 	return nil
+}
+
+// AnthropicCompatibleModelSource implements LiveModelSource for custom
+// anthropic-compatible dynamic providers by fetching GET <base>/v1/models
+// (Anthropic shape: {"data":[{"id":"...","display_name":"..."}]}).
+type AnthropicCompatibleModelSource struct {
+	provider    string
+	defaultBase string
+}
+
+func (s *AnthropicCompatibleModelSource) ListModels(ctx context.Context, creds core.Credentials) ([]ModelSpec, error) {
+	base := s.defaultBase
+	if creds.BaseURL != "" {
+		base = creds.BaseURL
+	}
+	for key, val := range creds.Extra {
+		base = strings.ReplaceAll(base, "{"+key+"}", val)
+	}
+	base = strings.TrimRight(base, "/")
+	base = strings.TrimSuffix(base, "/messages")
+	base = strings.TrimSuffix(base, "/v1")
+	url := strings.TrimRight(base, "/") + "/v1/models"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if k := strings.TrimSpace(creds.APIKey); k != "" {
+		req.Header.Set("x-api-key", k)
+	} else if t := strings.TrimSpace(creds.AccessToken); t != "" {
+		req.Header.Set("Authorization", bearer(t))
+	}
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := sharedClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8*1024))
+		return nil, fmt.Errorf("GET /v1/models returned %d: %s", resp.StatusCode, truncateError(body))
+	}
+
+	var envelope struct {
+		Data []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("decode /v1/models response: %w", err)
+	}
+	out := make([]ModelSpec, 0, len(envelope.Data))
+	for _, e := range envelope.Data {
+		if e.ID == "" {
+			continue
+		}
+		name := e.DisplayName
+		if name == "" {
+			name = e.ID
+		}
+		out = append(out, ModelSpec{ID: e.ID, Name: name, Kind: core.ServiceLLM})
+	}
+	return out, nil
 }
 
 // QuotaEntry is one upstream quota bucket (e.g. AGENTIC_REQUEST usage).

--- a/backend/internal/connectors/openai_compatible.go
+++ b/backend/internal/connectors/openai_compatible.go
@@ -332,6 +332,18 @@ func (c *OpenAICompatible) Validate(ctx context.Context, creds core.Credentials)
 // (e.g. a 400/404 for an unknown probe model) still proves the key was accepted.
 func (c *OpenAICompatible) chatAuthProbe(ctx context.Context, creds core.Credentials) error {
 	probeModel := firstCatalogModel(c.id)
+	// Custom/dynamic providers may have no catalog models until the user imports
+	// them. Sending a synthetic "test" model id to such endpoints triggers
+	// upstream403 model_not_allowed, which is misclassified as an auth failure.
+	// When no real model is known, skip the chat probe for custom providers and
+	// rely on the GET /models probe above. Built-in providers keep the "test"
+	// fallback so a bad key is still rejected when /models is publicly readable.
+	if probeModel == "" {
+		if IsCustomProviderID(c.id) {
+			return nil
+		}
+		probeModel = "test"
+	}
 	body, _ := json.Marshal(map[string]any{
 		"model": probeModel,
 		"messages": []map[string]string{
@@ -368,7 +380,7 @@ func firstCatalogModel(provider string) string {
 			return m.ID
 		}
 	}
-	return "test"
+	return ""
 }
 
 func strictModelsValidation(provider string) bool {

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -72,6 +72,7 @@ func (s *Server) mountAdmin(r chi.Router) {
 	r.Get("/quota", s.adminQuotaUsage)
 	r.Get("/health/accounts", s.adminListAccountHealth)
 	r.Post("/health/check-now", s.adminRunHealthCheck)
+	s.mountProviderHealth(r)
 	r.Get("/console", s.adminConsoleLog)
 	r.Delete("/console", s.adminConsoleClear)
 	r.Get("/console/stream", s.adminConsoleStream)
@@ -254,7 +255,7 @@ func (s *Server) adminProviderModels(w http.ResponseWriter, r *http.Request) {
 	// ModelsForProvider). Flag any entry that is a user-defined custom model.
 	static := connectors.ModelsForProvider(providerID)
 	seen := map[string]bool{}
-	var out []modelInfo
+	out := make([]modelInfo, 0, len(static))
 	for _, m := range static {
 		kind := modelKind(m.Kind)
 		if kindFilter != "" && kind != kindFilter {

--- a/backend/internal/gateway/admin_custom_providers.go
+++ b/backend/internal/gateway/admin_custom_providers.go
@@ -2,11 +2,11 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
 	"time"
-
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -31,9 +31,52 @@ func (s *Server) mountCustomProviders(r chi.Router) {
 	r.Post("/providers/{id}/custom-models", s.adminCreateCustomModel)
 	r.Patch("/providers/{id}/custom-models/{modelDBID}", s.adminUpdateCustomModel)
 	r.Delete("/providers/{id}/custom-models/{modelDBID}", s.adminDeleteCustomModel)
+
+	// Import models: fetch the upstream /models listing and persist each entry
+	// as a custom model, so a custom provider becomes routable without manual
+	// model entry. Available for any provider with a LiveModelSource.
+	r.Post("/providers/{id}/import-models", s.adminImportModels)
 }
 
 var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// aliasInputRe constrains a user-provided alias to url-safe slug characters
+// (letters, digits, hyphen). slugify then lowercases/compacts it.
+var aliasInputRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]*$`)
+
+// resolveCustomAlias derives the routing alias for a custom provider. When the
+// user supplies an alias it is validated (slug-safe, 1-32 chars, no collision
+// with an existing provider alias/id other than the provider's own id). When
+// omitted, it defaults to the slugified display name, falling back to the
+// unique provider id when the name yields no usable slug.
+func resolveCustomAlias(rawAlias, name, ownID string) (string, error) {
+	raw := strings.TrimSpace(rawAlias)
+	if raw == "" {
+		// Default from the display name.
+		if a := slugify(name); a != "" {
+			if _, ok := connectors.SpecByAlias(a); !ok && a != ownID {
+				return a, nil
+			}
+		}
+		return ownID, nil
+	}
+	if !aliasInputRe.MatchString(raw) {
+		return "", fmt.Errorf("alias must contain only letters, digits, and hyphens")
+	}
+	alias := slugify(raw)
+	if alias == "" {
+		return "", fmt.Errorf("alias must contain only letters, digits, and hyphens")
+	}
+	if len(alias) > 32 {
+		return "", fmt.Errorf("alias must be 32 characters or fewer")
+	}
+	if alias != ownID {
+		if _, ok := connectors.SpecByAlias(alias); ok {
+			return "", fmt.Errorf("alias already in use: %s", alias)
+		}
+	}
+	return alias, nil
+}
 
 // slugify produces a short url-safe token from a display name.
 func slugify(s string) string {
@@ -91,6 +134,7 @@ func (s *Server) adminCreateCustomProvider(w http.ResponseWriter, r *http.Reques
 		DisplayName string `json:"display_name"`
 		Dialect     string `json:"dialect"` // "openai" | "anthropic"
 		BaseURL     string `json:"base_url"`
+		Alias       *string `json:"alias"` // optional routing prefix; defaults to the generated id
 	}
 	if !decodeJSON(w, r, &body) {
 		return
@@ -123,11 +167,25 @@ func (s *Server) adminCreateCustomProvider(w http.ResponseWriter, r *http.Reques
 		return false
 	})
 
+	// Alias is the user-facing routing prefix ("<alias>/<model>"). It is NOT
+	// forced under the custom-openai-/custom-anthropic- namespace, mirroring
+	// the decoupling of internal node id from the user-chosen prefix.
+	// Empty defaults to the slugified name (fallback: the unique id).
+	var aliasInput string
+	if body.Alias != nil {
+		aliasInput = *body.Alias
+	}
+	alias, aerr := resolveCustomAlias(aliasInput, name, id)
+	if aerr != nil {
+		writeError(w, http.StatusBadRequest, aerr.Error())
+		return
+	}
+
 	p := store.CustomProvider{
 		ID:          id,
 		TenantID:    adminTenant,
 		DisplayName: name,
-		Alias:       id, // alias defaults to the full unique id; user can override
+		Alias:       alias,
 		Dialect:     string(dialect),
 		BaseURL:     baseURL,
 		CreatedAt:   time.Now(),
@@ -165,10 +223,12 @@ func (s *Server) adminUpdateCustomProvider(w http.ResponseWriter, r *http.Reques
 		}
 	}
 	if body.Alias != nil {
-		existing.Alias = strings.TrimSpace(*body.Alias)
-		if existing.Alias == "" {
-			existing.Alias = existing.ID
+		alias, aerr := resolveCustomAlias(*body.Alias, existing.DisplayName, existing.ID)
+		if aerr != nil {
+			writeError(w, http.StatusBadRequest, aerr.Error())
+			return
 		}
+		existing.Alias = alias
 	}
 	if body.BaseURL != nil {
 		b := strings.TrimSpace(*body.BaseURL)
@@ -212,7 +272,7 @@ func (s *Server) adminDeleteCustomProvider(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) adminListCustomModels(w http.ResponseWriter, r *http.Request) {
 	providerID := chi.URLParam(r, "id")
-	models, err := s.db.CustomProviders().ListModelsByProvider(r.Context(), providerID)
+	models, err := s.db.CustomProviders().ListManualModelsByProvider(r.Context(), providerID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "internal server error"))
 		return
@@ -401,4 +461,95 @@ func uniqueCustomProviderID(prefix, name string, taken func(string) bool) string
 		return candidate
 	}
 	return prefix + slug + "-" + strings.Split(uuid.NewString(), "-")[0]
+}
+
+// adminImportModels fetches the upstream /models listing for a provider and
+// persists each discovered model as a custom model, so a custom provider
+// becomes routable without manual model entry. Models already registered are
+// skipped (matched by model id). Requires a LiveModelSource for the provider;
+// credentials are taken from the first enabled account, if any.
+func (s *Server) adminImportModels(w http.ResponseWriter, r *http.Request) {
+	providerID := chi.URLParam(r, "id")
+	if _, ok := connectors.SpecByID(providerID); !ok {
+		writeError(w, http.StatusNotFound, "unknown provider: "+providerID)
+		return
+	}
+	src := connectors.GetLiveModelSource(providerID)
+	if src == nil {
+		writeError(w, http.StatusBadRequest, "provider does not support model discovery")
+		return
+	}
+
+	// Collect credentials from the first enabled account, if any.
+	var creds core.Credentials
+	if s.accounts != nil && s.vault != nil {
+		accs, err := s.accounts.ListByProvider(r.Context(), adminTenant, providerID)
+		if err == nil {
+			for _, acc := range accs {
+				if acc.Disabled {
+					continue
+				}
+				if c, oerr := s.vault.Open(acc); oerr == nil {
+					creds = c
+					break
+				}
+			}
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+	discovered, err := src.ListModels(ctx, creds)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "model discovery failed: "+sanitizeError(s.log, err, "model discovery failed"))
+		return
+	}
+
+	existing, _ := s.db.CustomProviders().ListModelsByProvider(r.Context(), providerID)
+	seen := make(map[string]bool, len(existing))
+	for _, m := range existing {
+		seen[m.ModelID] = true
+	}
+
+	imported := 0
+	skipped := 0
+	for _, m := range discovered {
+		if m.ID == "" || seen[m.ID] {
+			skipped++
+			continue
+		}
+		name := m.Name
+		if name == "" {
+			name = m.ID
+		}
+		kind := string(m.Kind)
+		if kind == "" {
+			kind = string(core.ServiceLLM)
+		}
+		cm := store.CustomModel{
+			ID:          uuid.NewString(),
+			TenantID:    adminTenant,
+			ProviderID:  providerID,
+			ModelID:     m.ID,
+			DisplayName: name,
+			Kind:        kind,
+			Source:      "imported",
+		}
+		if err := s.db.CustomProviders().CreateModel(r.Context(), cm); err != nil {
+			// Likely a unique-constraint race; skip rather than abort the batch.
+			skipped++
+			continue
+		}
+		seen[m.ID] = true
+		imported++
+	}
+	if imported > 0 {
+		s.reloadCustomModels(r.Context(), providerID)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"provider_id": providerID,
+		"imported":    imported,
+		"skipped":     skipped,
+		"total":       len(discovered),
+	})
 }

--- a/backend/internal/gateway/clitools.go
+++ b/backend/internal/gateway/clitools.go
@@ -26,6 +26,9 @@ func (s *Server) handleCLITools(w http.ResponseWriter, r *http.Request) {
 		Installed  bool   `json:"installed"`
 		Configured bool   `json:"configured"`
 		ConfigPath string `json:"config_path"`
+		BinaryPath string `json:"binary_path,omitempty"`
+		Version    string `json:"version,omitempty"`
+		Error      string `json:"error,omitempty"`
 	}
 	statusMap := make(map[string]clitools.Status, len(statuses))
 	for _, st := range statuses {
@@ -38,6 +41,9 @@ func (s *Server) handleCLITools(w http.ResponseWriter, r *http.Request) {
 			tr.Installed = st.Installed
 			tr.Configured = st.Configured
 			tr.ConfigPath = st.ConfigPath
+			tr.BinaryPath = st.BinaryPath
+			tr.Version = st.Version
+			tr.Error = st.Error
 		}
 		tools = append(tools, tr)
 	}

--- a/backend/internal/gateway/handlers.go
+++ b/backend/internal/gateway/handlers.go
@@ -771,8 +771,24 @@ func (s *Server) handlePortalKeyUsage(w http.ResponseWriter, r *http.Request) {
 		s.log.Error("key usage: summarize failed", "err", err)
 	}
 
-	// Daily usage series for the portal chart (last 30 days).
-	daily, _ := s.usage.DailyByKey(ctx, key.ID, now.AddDate(0, 0, -30))
+	// days lookback for charts, model breakdown, and recent requests.
+	// Default is 30 days. Valid values: 7, 14, 30, 90.
+	days := 30
+	if d := r.URL.Query().Get("days"); d != "" {
+		switch d {
+		case "7":
+			days = 7
+		case "14":
+			days = 14
+		case "30":
+			days = 30
+		case "90":
+			days = 90
+		}
+	}
+
+	// Daily usage series for the portal chart.
+	daily, _ := s.usage.DailyByKey(ctx, key.ID, now.AddDate(0, 0, -days))
 	var dailyOut []map[string]any
 	for _, d := range daily {
 		dailyOut = append(dailyOut, map[string]any{
@@ -784,8 +800,8 @@ func (s *Server) handlePortalKeyUsage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Per-model breakdown for this key (last 30 days).
-	models, _ := s.usage.ByModelByKey(ctx, key.ID, now.AddDate(0, 0, -30))
+	// Per-model breakdown for this key.
+	models, _ := s.usage.ByModelByKey(ctx, key.ID, now.AddDate(0, 0, -days))
 	var modelOut []map[string]any
 	for _, m := range models {
 		modelOut = append(modelOut, map[string]any{
@@ -796,6 +812,53 @@ func (s *Server) handlePortalKeyUsage(w http.ResponseWriter, r *http.Request) {
 			"completion_tokens": m.CompletionTokens,
 			"cost_usd":          float64(m.CostMicros) / 1_000_000,
 		})
+	}
+
+	// Recent per-request records with token in/out and optimization flags.
+	recent, _ := s.usage.RecentByKey(ctx, key.ID, now.AddDate(0, 0, -days), 200)
+	recentOut := make([]map[string]any, 0, len(recent))
+	for _, rec := range recent {
+		entry := map[string]any{
+			"id":                rec.ID,
+			"provider":          rec.Provider,
+			"model":             rec.Model,
+			"prompt_tokens":     rec.PromptTokens,
+			"completion_tokens": rec.CompletionTokens,
+			"cost_usd":          float64(rec.CostMicros) / 1_000_000,
+			"cache_hit":         rec.CacheHit,
+			"latency_ms":        rec.LatencyMS,
+			"created_at":        rec.CreatedAt,
+			"optimizations":     []string{},
+		}
+		var optNames []string
+		if rec.SlimActive || rec.SlimBytesSaved >0 {
+			if rec.SlimBytesSaved >0 {
+				entry["slim_bytes_saved"] = rec.SlimBytesSaved
+				entry["slim_tokens_saved"] = rec.SlimTokensSaved
+			}
+			if rec.SlimRules != "" {
+				entry["slim_rules"] = rec.SlimRules
+			}
+			optNames = append(optNames, "RTK")
+		}
+		if rec.CavemanActive {
+			optNames = append(optNames, "Caveman")
+		}
+		if rec.TerseActive {
+			optNames = append(optNames, "Terse")
+		}
+		if rec.HeadroomActive {
+			entry["headroom_tokens_saved"] = rec.HeadroomTokensSaved
+			optNames = append(optNames, "Headroom")
+		}
+		if rec.PonytailActive {
+			optNames = append(optNames, "Ponytail")
+		}
+		entry["optimizations"] = optNames
+		if rec.TTFTMS > 0 {
+			entry["ttft_ms"] = rec.TTFTMS
+		}
+		recentOut = append(recentOut, entry)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -811,6 +874,8 @@ func (s *Server) handlePortalKeyUsage(w http.ResponseWriter, r *http.Request) {
 		},
 		"daily":  dailyOut,
 		"models": modelOut,
+		"recent": recentOut,
+		"days":   days,
 	})
 }
 

--- a/backend/internal/gateway/provider_health.go
+++ b/backend/internal/gateway/provider_health.go
@@ -1,0 +1,589 @@
+package gateway
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/mydisha/keirouter/backend/internal/health"
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+// mountProviderHealth registers the actionable provider health dashboard API.
+// These sit alongside the existing /health/accounts endpoints and reuse the
+// same admin auth + loopback middleware.
+func (s *Server) mountProviderHealth(r chi.Router) {
+	r.Get("/health/overview", s.adminHealthOverview)
+	r.Get("/health/providers/{provider}", s.adminHealthProviderDetail)
+	r.Get("/health/models", s.adminHealthModels)
+	r.Get("/health/chains", s.adminHealthChains)
+	r.Get("/health/chains/{id}", s.adminHealthChainDetail)
+	r.Get("/health/probes", s.adminHealthProbeHistory)
+	r.Post("/health/probes/run", s.adminHealthRunProbe)
+}
+
+// parseRange resolves a ?range= duration (e.g. 1h, 24h) to a since time.
+// Defaults to 1h. Caps at 30d to bound snapshot scans.
+func parseRange(raw string) time.Time {
+	d := parseRangeDuration(raw)
+	if d <= 0 {
+		d = time.Hour
+	}
+	if d > 30*24*time.Hour {
+		d = 30 * 24 * time.Hour
+	}
+	return time.Now().Add(-d)
+}
+
+func parseRangeDuration(raw string) time.Duration {
+	switch raw {
+	case "5m":
+		return 5 * time.Minute
+	case "15m":
+		return 15 * time.Minute
+	case "1h", "":
+		return time.Hour
+	case "6h":
+		return 6 * time.Hour
+	case "24h":
+		return 24 * time.Hour
+	case "7d":
+		return 7 * 24 * time.Hour
+	case "30d":
+		return 30 * 24 * time.Hour
+	}
+	if d, err := time.ParseDuration(raw); err == nil {
+		return d
+	}
+	return time.Hour
+}
+
+// adminHealthOverview returns summary cards + a per-provider status table.
+func (s *Server) adminHealthOverview(w http.ResponseWriter, r *http.Request) {
+	if s.providerHealth == nil && s.db == nil {
+		writeError(w, http.StatusServiceUnavailable, "provider health not configured")
+		return
+	}
+	statusFilter := r.URL.Query().Get("status")
+	_ = parseRange(r.URL.Query().Get("range"))
+
+	rows, err := s.db.ProviderHealth().ListCurrent(r.Context(), statusFilter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "internal server error"))
+		return
+	}
+
+	// Aggregate by provider for the summary cards + provider table.
+	type provAgg struct {
+		provider          string
+		status            string
+		score             int
+		accounts          map[string]struct{}
+		models            map[string]struct{}
+		requests          int64
+		successes         int64
+		failures          int64
+		fallbacks         int64
+		latencyP95        int
+		ttftP95           int
+		lastProbe         *time.Time
+		mainIssue         string
+		recommendation    string
+	}
+	byProvider := map[string]*provAgg{}
+	summary := map[string]int64{
+		"healthy": 0, "degraded": 0, "unhealthy": 0, "unknown": 0, "disabled": 0,
+		"fallbacks": 0, "rate_limit_events": 0,
+	}
+	var totalP95 int
+	var p95Count int
+
+	for _, c := range rows {
+		summary[c.HealthStatus]++
+		summary["fallbacks"] += c.FallbackCount
+
+		agg, ok := byProvider[c.Provider]
+		if !ok {
+			agg = &provAgg{
+				provider:  c.Provider,
+				accounts:  map[string]struct{}{},
+				models:    map[string]struct{}{},
+				score:     100,
+				status:    health.StatusHealthy,
+			}
+			byProvider[c.Provider] = agg
+		}
+		if c.ProviderAccountID != "" {
+			agg.accounts[c.ProviderAccountID] = struct{}{}
+		}
+		if c.Model != "" {
+			agg.models[c.Model] = struct{}{}
+		}
+		agg.requests += c.RequestCount
+		// successes derived from success_rate * requests (approx for rollup).
+		agg.successes += int64(float64(c.RequestCount) * c.SuccessRate)
+		agg.failures += int64(float64(c.RequestCount) * c.ErrorRate)
+		agg.fallbacks += c.FallbackCount
+		if c.LatencyP95Ms != nil && *c.LatencyP95Ms > agg.latencyP95 {
+			agg.latencyP95 = *c.LatencyP95Ms
+		}
+		if c.TTFTP95Ms != nil && *c.TTFTP95Ms > agg.ttftP95 {
+			agg.ttftP95 = *c.TTFTP95Ms
+		}
+		if c.LastProbeAt != nil && (agg.lastProbe == nil || c.LastProbeAt.After(*agg.lastProbe)) {
+			agg.lastProbe = c.LastProbeAt
+		}
+		// Roll up status: worst status wins, and lowest score.
+		if rank(c.HealthStatus) > rank(agg.status) {
+			agg.status = c.HealthStatus
+		}
+		if c.HealthScore < agg.score {
+			agg.score = c.HealthScore
+		}
+		if c.MainIssue != nil && *c.MainIssue != "" && agg.mainIssue == "" {
+			agg.mainIssue = *c.MainIssue
+		}
+		if c.Recommendation != nil && *c.Recommendation != "" && agg.recommendation == "" {
+			agg.recommendation = *c.Recommendation
+		}
+		if c.LatencyP95Ms != nil {
+			totalP95 += *c.LatencyP95Ms
+			p95Count++
+		}
+	}
+
+	providers := make([]map[string]any, 0, len(byProvider))
+	for _, agg := range byProvider {
+		entry := map[string]any{
+			"provider":         agg.provider,
+			"status":           agg.status,
+			"score":            agg.score,
+			"accounts":         len(agg.accounts),
+			"models_monitored": len(agg.models),
+			"success_rate":     pct(agg.successes, agg.requests),
+			"error_rate":       pct(agg.failures, agg.requests),
+			"latency_p95_ms":   agg.latencyP95,
+			"ttft_p95_ms":      agg.ttftP95,
+			"fallback_count":   agg.fallbacks,
+			"main_issue":       agg.mainIssue,
+			"recommendation":   agg.recommendation,
+		}
+		if agg.lastProbe != nil {
+			entry["last_probe_at"] = *agg.lastProbe
+		}
+		providers = append(providers, entry)
+	}
+
+	avgP95 := 0
+	if p95Count > 0 {
+		avgP95 = totalP95 / p95Count
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"summary": map[string]any{
+			"healthy":           summary["healthy"],
+			"degraded":          summary["degraded"],
+			"unhealthy":         summary["unhealthy"],
+			"unknown":           summary["unknown"],
+			"disabled":          summary["disabled"],
+			"fallbacks":         summary["fallbacks"],
+			"avg_p95_latency_ms": avgP95,
+		},
+		"providers": providers,
+	})
+}
+
+// adminHealthProviderDetail returns detailed metrics + snapshots for one provider.
+func (s *Server) adminHealthProviderDetail(w http.ResponseWriter, r *http.Request) {
+	provider := chi.URLParam(r, "provider")
+	since := parseRange(r.URL.Query().Get("range"))
+
+	rows, err := s.db.ProviderHealth().ListCurrentByProvider(r.Context(), provider)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "internal server error"))
+		return
+	}
+	if len(rows) == 0 {
+		writeError(w, http.StatusNotFound, "no health data for provider: "+provider)
+		return
+	}
+
+	var requests, fallbacks int64
+	var successes, failures int64
+	var score int = 100
+	status := health.StatusHealthy
+	var mainIssue, recommendation string
+	errBreakdown := map[string]int64{}
+	var lp95, ttft95 int
+
+	for _, c := range rows {
+		requests += c.RequestCount
+		successes += int64(float64(c.RequestCount) * c.SuccessRate)
+		failures += int64(float64(c.RequestCount) * c.ErrorRate)
+		fallbacks += c.FallbackCount
+		if c.HealthScore < score {
+			score = c.HealthScore
+		}
+		if rank(c.HealthStatus) > rank(status) {
+			status = c.HealthStatus
+		}
+		if c.MainIssue != nil && *c.MainIssue != "" && mainIssue == "" {
+			mainIssue = *c.MainIssue
+		}
+		if c.Recommendation != nil && *c.Recommendation != "" && recommendation == "" {
+			recommendation = *c.Recommendation
+		}
+		if c.LatencyP95Ms != nil && *c.LatencyP95Ms > lp95 {
+			lp95 = *c.LatencyP95Ms
+		}
+		if c.TTFTP95Ms != nil && *c.TTFTP95Ms > ttft95 {
+			ttft95 = *c.TTFTP95Ms
+		}
+	}
+
+	snaps, _ := s.db.ProviderHealth().ListSnapshots(r.Context(), provider, "", "", "", since)
+	for _, sn := range snaps {
+		errBreakdown["rate_limited"] += sn.RateLimitedCount
+		errBreakdown["auth_error"] += sn.AuthErrorCount
+		errBreakdown["quota_exceeded"] += sn.QuotaExceededCount
+		errBreakdown["timeout"] += sn.TimeoutCount
+		errBreakdown["provider_5xx"] += sn.Provider5xxCount
+		errBreakdown["bad_request"] += sn.BadRequestCount
+		errBreakdown["network_error"] += sn.NetworkErrorCount
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"provider":       provider,
+		"status":         status,
+		"score":          score,
+		"main_issue":     mainIssue,
+		"recommendation": recommendation,
+		"metrics": map[string]any{
+			"requests":        requests,
+			"success_rate":    pct(successes, requests),
+			"error_rate":      pct(failures, requests),
+			"latency_p95_ms":  lp95,
+			"ttft_p95_ms":     ttft95,
+			"fallback_count":  fallbacks,
+		},
+		"error_breakdown": errBreakdown,
+		"models":          rows,
+		"snapshots":       snaps,
+	})
+}
+
+// adminHealthModels returns the model-level health matrix.
+func (s *Server) adminHealthModels(w http.ResponseWriter, r *http.Request) {
+	statusFilter := r.URL.Query().Get("status")
+	rows, err := s.db.ProviderHealth().ListCurrent(r.Context(), statusFilter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "internal server error"))
+		return
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, c := range rows {
+		if c.Model == "" {
+			continue
+		}
+		entry := map[string]any{
+			"provider":        c.Provider,
+			"model":           c.Model,
+			"capability":      c.Capability,
+			"status":          c.HealthStatus,
+			"score":           c.HealthScore,
+			"success_rate":    pct(int64(float64(c.RequestCount)*c.SuccessRate), c.RequestCount),
+			"error_rate":      pct(int64(float64(c.RequestCount)*c.ErrorRate), c.RequestCount),
+			"fallback_count":  c.FallbackCount,
+			"last_updated_at": c.LastUpdatedAt,
+		}
+		if c.LatencyP95Ms != nil {
+			entry["latency_p95_ms"] = *c.LatencyP95Ms
+		}
+		if c.TTFTP95Ms != nil {
+			entry["ttft_p95_ms"] = *c.TTFTP95Ms
+		}
+		if c.MainIssue != nil {
+			entry["main_issue"] = *c.MainIssue
+		}
+		out = append(out, entry)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"models": out})
+}
+
+// adminHealthChains returns chain health: fallback rate, final failures, and
+// affected providers, derived from real-traffic telemetry joined with chain
+// config + current provider health.
+func (s *Server) adminHealthChains(w http.ResponseWriter, r *http.Request) {
+	chains, err := s.chains.ListByTenant(r.Context(), adminTenant)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "internal server error"))
+		return
+	}
+	healthRows, _ := s.db.ProviderHealth().ListCurrent(r.Context(), "")
+	healthByKey := map[string]store.ProviderHealthCurrent{}
+	for _, h := range healthRows {
+		healthByKey[store.HealthKey(h.Provider, h.ProviderAccountID, h.Model, h.Capability)] = h
+	}
+
+	// Real-traffic chain stats from the telemetry aggregator (rolling window).
+	chainStats := map[string]health.ChainStat{}
+	if s.providerHealth != nil {
+		for _, st := range s.providerHealth.ChainStats() {
+			chainStats[st.ChainID] = st
+		}
+	}
+
+	out := make([]map[string]any, 0, len(chains))
+	for _, c := range chains {
+		worstStatus := health.StatusHealthy
+		var affectedProvider, affectedModel, mainIssue string
+		for _, step := range c.Steps {
+			// Match any account/capability for this provider+model.
+			for _, h := range healthRows {
+				if h.Provider == step.Provider && h.Model == step.Model {
+					if rank(h.HealthStatus) > rank(worstStatus) {
+						worstStatus = h.HealthStatus
+						affectedProvider = step.Provider
+						affectedModel = step.Model
+						if h.MainIssue != nil {
+							mainIssue = *h.MainIssue
+						}
+					}
+				}
+			}
+		}
+		entry := map[string]any{
+			"chain_id":           c.ID,
+			"name":               c.Name,
+			"status":             worstStatus,
+			"affected_provider":  affectedProvider,
+			"affected_model":     affectedModel,
+			"main_issue":         mainIssue,
+			"step_count":         len(c.Steps),
+		}
+		if st, ok := chainStats[c.ID]; ok {
+			entry["requests"] = st.Requests
+			entry["fallback_rate"] = st.FallbackRate * 100
+			entry["final_failure_count"] = st.FinalFailures
+			entry["fallback_count"] = st.Fallbacks
+		} else {
+			entry["requests"] = 0
+			entry["fallback_rate"] = 0.0
+			entry["final_failure_count"] = 0
+			entry["fallback_count"] = 0
+		}
+		entry["recommendation"] = chainRecommendation(worstStatus, mainIssue, affectedProvider, affectedModel)
+		out = append(out, entry)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"chains": out})
+}
+
+// adminHealthChainDetail returns step-level health + usage for one chain.
+func (s *Server) adminHealthChainDetail(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	c, err := s.chains.Get(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "chain not found")
+		return
+	}
+	healthRows, _ := s.db.ProviderHealth().ListCurrent(r.Context(), "")
+	chainStats := map[string]health.ChainStat{}
+	if s.providerHealth != nil {
+		for _, st := range s.providerHealth.ChainStats() {
+			chainStats[st.ChainID] = st
+		}
+	}
+
+	steps := make([]map[string]any, 0, len(c.Steps))
+	for _, step := range c.Steps {
+		var status string = health.StatusUnknown
+		var mainIssue string
+		var score int = 100
+		for _, h := range healthRows {
+			if h.Provider == step.Provider && h.Model == step.Model {
+				if rank(h.HealthStatus) > rank(status) || status == health.StatusUnknown {
+					status = h.HealthStatus
+					score = h.HealthScore
+					if h.MainIssue != nil {
+						mainIssue = *h.MainIssue
+					}
+				}
+			}
+		}
+		steps = append(steps, map[string]any{
+			"position":  step.Position,
+			"provider":  step.Provider,
+			"model":     step.Model,
+			"status":    status,
+			"score":     score,
+			"main_issue": mainIssue,
+		})
+	}
+
+	resp := map[string]any{
+		"chain_id": c.ID,
+		"name":     c.Name,
+		"strategy": c.Strategy,
+		"steps":    steps,
+	}
+	if st, ok := chainStats[c.ID]; ok {
+		resp["requests"] = st.Requests
+		resp["fallback_rate"] = st.FallbackRate * 100
+		resp["final_failure_count"] = st.FinalFailures
+		resp["fallback_count"] = st.Fallbacks
+	}
+	if c.FallbackProvider != "" {
+		resp["fallback_provider"] = c.FallbackProvider
+		resp["fallback_model"] = c.FallbackModel
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// chainRecommendation derives a next-step suggestion from a chain's worst
+// provider status and the affected provider/model.
+func chainRecommendation(status, mainIssue, provider, model string) string {
+	switch status {
+	case health.StatusUnhealthy, health.StatusDegraded:
+		return "Move a healthy fallback provider above " + provider + "/" + model + " temporarily, or add capacity."
+	case health.StatusUnknown:
+		return "Run a manual probe on " + provider + "/" + model + " to populate health data."
+	}
+	_ = mainIssue
+	return ""
+}
+
+// adminHealthProbeHistory returns paginated probe results.
+func (s *Server) adminHealthProbeHistory(w http.ResponseWriter, r *http.Request) {
+	provider := r.URL.Query().Get("provider")
+	since := parseRange(r.URL.Query().Get("range"))
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	if limit <= 0 {
+		limit = 50
+	}
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page - 1) * limit
+
+	items, total, err := s.db.ProviderHealth().ListProbeResults(r.Context(), provider, since, limit, offset)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "internal server error"))
+		return
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, p := range items {
+		entry := map[string]any{
+			"time":                p.CreatedAt,
+			"provider":            p.Provider,
+			"provider_account_id": p.ProviderAccountID,
+			"model":               p.Model,
+			"capability":          p.Capability,
+			"status":              p.Status,
+			"triggered_by":        p.TriggeredBy,
+		}
+		if p.HTTPStatus != nil {
+			entry["http_status"] = *p.HTTPStatus
+		}
+		if p.LatencyMs != nil {
+			entry["latency_ms"] = *p.LatencyMs
+		}
+		if p.TTFTMs != nil {
+			entry["ttft_ms"] = *p.TTFTMs
+		}
+		if p.ErrorType != nil {
+			entry["error_type"] = *p.ErrorType
+		}
+		if p.ErrorMessage != nil {
+			entry["error_message"] = *p.ErrorMessage
+		}
+		out = append(out, entry)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"items": out,
+		"pagination": map[string]int{
+			"page":  page,
+			"limit": limit,
+			"total": total,
+		},
+	})
+}
+
+// adminHealthRunProbe triggers a manual synthetic probe.
+func (s *Server) adminHealthRunProbe(w http.ResponseWriter, r *http.Request) {
+	if s.probeRunner == nil {
+		writeError(w, http.StatusServiceUnavailable, "probe runner not configured")
+		return
+	}
+	var body struct {
+		Provider          string `json:"provider"`
+		ProviderAccountID string `json:"provider_account_id"`
+		Model             string `json:"model"`
+		Capability        string `json:"capability"`
+	}
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if body.Provider == "" || body.Model == "" {
+		writeError(w, http.StatusBadRequest, "provider and model are required")
+		return
+	}
+	res, err := s.probeRunner.Run(r.Context(), health.ProbeRequest{
+		Provider:          body.Provider,
+		ProviderAccountID: body.ProviderAccountID,
+		Model:             body.Model,
+		Capability:        body.Capability,
+		TriggeredBy:       "manual",
+	})
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	resp := map[string]any{
+		"status":   res.Status,
+		"provider": res.Provider,
+		"model":    res.Model,
+		"message":  "Probe completed successfully.",
+	}
+	if res.HTTPStatus != nil {
+		resp["http_status"] = *res.HTTPStatus
+	}
+	if res.LatencyMs != nil {
+		resp["latency_ms"] = *res.LatencyMs
+	}
+	if res.TTFTMs != nil {
+		resp["ttft_ms"] = *res.TTFTMs
+	}
+	if res.ErrorType != nil {
+		resp["error_type"] = *res.ErrorType
+	}
+	if res.ErrorMessage != nil {
+		resp["message"] = *res.ErrorMessage
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// rank orders statuses so the worst one wins in a rollup.
+func rank(status string) int {
+	switch status {
+	case health.StatusDisabled:
+		return 5
+	case health.StatusUnhealthy:
+		return 4
+	case health.StatusDegraded:
+		return 3
+	case health.StatusUnknown:
+		return 2
+	case health.StatusHealthy:
+		return 1
+	}
+	return 0
+}
+
+func pct(n, total int64) float64 {
+	if total <= 0 {
+		return 0
+	}
+	return float64(n) / float64(total) * 100
+}

--- a/backend/internal/gateway/server.go
+++ b/backend/internal/gateway/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
 	"github.com/mydisha/keirouter/backend/internal/fastjson"
 	"github.com/mydisha/keirouter/backend/internal/guardrails"
+	"github.com/mydisha/keirouter/backend/internal/health"
 	"github.com/mydisha/keirouter/backend/internal/healthcheck"
 	"github.com/mydisha/keirouter/backend/internal/identity"
 	"github.com/mydisha/keirouter/backend/internal/oauth"
@@ -85,6 +86,8 @@ type Server struct {
 	guardrailTestRL     *guardrailTestRateLimiter
 	health          *store.HealthRepo
 	healthChecker   *healthcheck.Checker
+	providerHealth  *health.Service
+	probeRunner     *health.ProbeRunner
 	router          chi.Router
 }
 
@@ -130,6 +133,8 @@ type Deps struct {
 	GuardrailTenantFlags *guardrails.SettingsTenantPolicy
 	Health          *store.HealthRepo
 	HealthChecker   *healthcheck.Checker
+	ProviderHealth  *health.Service
+	ProbeRunner     *health.ProbeRunner
 }
 
 // New builds a gateway Server and wires its routes.
@@ -194,6 +199,8 @@ func New(d Deps) *Server {
 		guardrailTestRL:     newGuardrailTestRateLimiter(10, time.Minute),
 		health:          d.Health,
 		healthChecker:   d.HealthChecker,
+		providerHealth:  d.ProviderHealth,
+		probeRunner:     d.ProbeRunner,
 	}
 	s.router = s.routes()
 	startSystemCollector(d.Resources)

--- a/backend/internal/health/chain_test.go
+++ b/backend/internal/health/chain_test.go
@@ -1,0 +1,54 @@
+package health
+
+import (
+	"testing"
+	"time"
+)
+
+// TestChainStats_Counting verifies the terminal-event counting model: a
+// request through a chain emits one terminal event (success or final-failure)
+// plus zero or more non-terminal fallback-failure events. Only terminal
+// events count as requests; FallbackTriggered on a terminal event means the
+// request fell back >=1 time.
+func TestChainStats_Counting(t *testing.T) {
+	svc := New(Config{Enabled: true, RollingWindow: time.Hour}, nil, nil)
+	defer svc.Close(time.Second)
+
+	now := time.Now()
+	// Chain "coding": 2 successful requests, 1 request that fell back twice
+	// then succeeded, 1 request that failed all attempts.
+	svc.ingest(ProviderTelemetryEvent{Timestamp: now, ChainID: "coding", Status: "success"})
+	svc.ingest(ProviderTelemetryEvent{Timestamp: now, ChainID: "coding", Status: "success"})
+	// request 3: two non-terminal fallback failures then success (fellBack=true)
+	svc.ingest(ProviderTelemetryEvent{Timestamp: now, ChainID: "coding", Status: "failed", FallbackTriggered: true})
+	svc.ingest(ProviderTelemetryEvent{Timestamp: now, ChainID: "coding", Status: "failed", FallbackTriggered: true})
+	svc.ingest(ProviderTelemetryEvent{Timestamp: now, ChainID: "coding", Status: "success", FallbackTriggered: true})
+	// request 4: one non-terminal fallback failure then final failure (fellBack=true)
+	svc.ingest(ProviderTelemetryEvent{Timestamp: now, ChainID: "coding", Status: "failed", FallbackTriggered: true})
+	svc.ingest(ProviderTelemetryEvent{Timestamp: now, ChainID: "coding", Status: "failed", FinalFailure: true, FallbackTriggered: true})
+
+	stats := svc.ChainStats()
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 chain, got %d", len(stats))
+	}
+	st := stats[0]
+	if st.ChainID != "coding" {
+		t.Fatalf("chain id = %s", st.ChainID)
+	}
+	if st.Requests != 4 {
+		t.Errorf("requests = %d, want 4", st.Requests)
+	}
+	if st.Successes != 3 {
+		t.Errorf("successes = %d, want 3", st.Successes)
+	}
+	if st.FinalFailures != 1 {
+		t.Errorf("final failures = %d, want 1", st.FinalFailures)
+	}
+	if st.Fallbacks != 2 {
+		t.Errorf("fallbacks = %d, want 2", st.Fallbacks)
+	}
+	wantRate := 2.0 / 4.0
+	if st.FallbackRate-wantRate > 1e-9 || wantRate-st.FallbackRate > 1e-9 {
+		t.Errorf("fallback rate = %v, want %v", st.FallbackRate, wantRate)
+	}
+}

--- a/backend/internal/health/errors.go
+++ b/backend/internal/health/errors.go
@@ -1,0 +1,134 @@
+// Package health implements the actionable provider health dashboard core:
+// error classification, health scoring, status derivation, recommendation
+// generation, telemetry recording, and aggregation.
+//
+// Health telemetry is best-effort: recording failures must never break the
+// gateway request path. The Service owns an async event queue and a background
+// aggregator that rolls recent events into provider_health_current and
+// provider_health_snapshots.
+package health
+
+import (
+	"strings"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+// ProviderErrorType is the normalized error classification used to compare
+// providers consistently regardless of upstream dialect.
+type ProviderErrorType string
+
+const (
+	ProviderErrorNone          ProviderErrorType = "none"
+	ProviderErrorAuth          ProviderErrorType = "auth_error"
+	ProviderErrorRateLimited   ProviderErrorType = "rate_limited"
+	ProviderErrorQuotaExceeded ProviderErrorType = "quota_exceeded"
+	ProviderErrorTimeout       ProviderErrorType = "timeout"
+	ProviderErrorProvider5xx   ProviderErrorType = "provider_5xx"
+	ProviderErrorBadRequest    ProviderErrorType = "bad_request"
+	ProviderErrorNetwork       ProviderErrorType = "network_error"
+	ProviderErrorUnsupported   ProviderErrorType = "unsupported_model_or_capability"
+	ProviderErrorUnknown       ProviderErrorType = "unknown"
+)
+
+// ClassifyError maps a core.ProviderError (already classified by the connector
+// layer from HTTP status + messages) to the dashboard's normalized type. This
+// keeps provider health comparable across upstreams.
+func ClassifyError(pe *core.ProviderError) ProviderErrorType {
+	if pe == nil {
+		return ProviderErrorNone
+	}
+	switch pe.Kind {
+	case core.ErrAuth:
+		return ProviderErrorAuth
+	case core.ErrRateLimit:
+		return ProviderErrorRateLimited
+	case core.ErrQuotaExhausted:
+		return ProviderErrorQuotaExceeded
+	case core.ErrTimeout:
+		return ProviderErrorTimeout
+	case core.ErrUpstream:
+		// Distinguish a 5xx response from a connection-level failure: a
+		// missing HTTP status means the request never reached the server
+		// (DNS, connection refused, TLS), which is a network error.
+		if pe.StatusCode == 0 {
+			return ProviderErrorNetwork
+		}
+		return ProviderErrorProvider5xx
+	case core.ErrBadRequest:
+		if isUnsupportedMessage(pe.Message) {
+			return ProviderErrorUnsupported
+		}
+		return ProviderErrorBadRequest
+	case core.ErrCapability:
+		return ProviderErrorUnsupported
+	default:
+		// ErrInternal, ErrBudgetBlocked, ErrPolicyBlocked — not provider
+		// failures, but surface as unknown for accounting completeness.
+		return ProviderErrorUnknown
+	}
+}
+
+// isUnsupportedMessage detects model/capability mismatch errors from the
+// upstream message text when the connector could not classify them precisely.
+func isUnsupportedMessage(msg string) bool {
+	m := strings.ToLower(msg)
+	return strings.Contains(m, "model not found") ||
+		strings.Contains(m, "does not support") ||
+		strings.Contains(m, "not supported") ||
+		strings.Contains(m, "unsupported model") ||
+		strings.Contains(m, "model_not_found")
+}
+
+// ErrorSeverityScore returns the 0-100 quality score contribution for an error
+// type. Auth and quota errors are severe (require user action); rate limits and
+// transient 5xx are medium (fallback may resolve them).
+func ErrorSeverityScore(t ProviderErrorType) int {
+	switch t {
+	case ProviderErrorNone:
+		return 100
+	case ProviderErrorBadRequest:
+		return 80
+	case ProviderErrorRateLimited:
+		return 65
+	case ProviderErrorTimeout:
+		return 60
+	case ProviderErrorProvider5xx:
+		return 55
+	case ProviderErrorNetwork:
+		return 50
+	case ProviderErrorUnknown:
+		return 50
+	case ProviderErrorQuotaExceeded:
+		return 30
+	case ProviderErrorAuth:
+		return 10
+	default:
+		return 50
+	}
+}
+
+// ErrorTypeCountColumn maps an error type to the snapshot counter column it
+// increments. Used by the aggregator.
+func ErrorTypeCountColumn(t ProviderErrorType) string {
+	switch t {
+	case ProviderErrorRateLimited:
+		return "rate_limited_count"
+	case ProviderErrorAuth:
+		return "auth_error_count"
+	case ProviderErrorQuotaExceeded:
+		return "quota_exceeded_count"
+	case ProviderErrorTimeout:
+		return "timeout_count"
+	case ProviderErrorProvider5xx:
+		return "provider_5xx_count"
+	case ProviderErrorBadRequest:
+		return "bad_request_count"
+	case ProviderErrorNetwork:
+		return "network_error_count"
+	case ProviderErrorUnsupported:
+		return "unsupported_count"
+	default:
+		return "unknown_error_count"
+	}
+}

--- a/backend/internal/health/health_test.go
+++ b/backend/internal/health/health_test.go
@@ -1,0 +1,142 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+func TestClassifyError(t *testing.T) {
+	cases := []struct {
+		name string
+		pe   *core.ProviderError
+		want ProviderErrorType
+	}{
+		{"nil", nil, ProviderErrorNone},
+		{"auth", &core.ProviderError{Kind: core.ErrAuth}, ProviderErrorAuth},
+		{"rate_limit", &core.ProviderError{Kind: core.ErrRateLimit}, ProviderErrorRateLimited},
+		{"quota", &core.ProviderError{Kind: core.ErrQuotaExhausted}, ProviderErrorQuotaExceeded},
+		{"timeout", &core.ProviderError{Kind: core.ErrTimeout}, ProviderErrorTimeout},
+		{"upstream_5xx", &core.ProviderError{Kind: core.ErrUpstream, StatusCode: 503}, ProviderErrorProvider5xx},
+		{"upstream_network", &core.ProviderError{Kind: core.ErrUpstream, StatusCode: 0}, ProviderErrorNetwork},
+		{"bad_request", &core.ProviderError{Kind: core.ErrBadRequest}, ProviderErrorBadRequest},
+		{"bad_request_unsupported_msg", &core.ProviderError{Kind: core.ErrBadRequest, Message: "model not found"}, ProviderErrorUnsupported},
+		{"capability", &core.ProviderError{Kind: core.ErrCapability}, ProviderErrorUnsupported},
+		{"internal", &core.ProviderError{Kind: core.ErrInternal}, ProviderErrorUnknown},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ClassifyError(c.pe); got != c.want {
+				t.Errorf("ClassifyError(%v) = %v, want %v", c.pe, got, c.want)
+			}
+		})
+	}
+}
+
+func TestErrorSeverityScore(t *testing.T) {
+	if ErrorSeverityScore(ProviderErrorNone) != 100 {
+		t.Fatal("none should be 100")
+	}
+	if ErrorSeverityScore(ProviderErrorAuth) >= ErrorSeverityScore(ProviderErrorRateLimited) {
+		t.Fatal("auth must be more severe than rate_limited")
+	}
+	if ErrorSeverityScore(ProviderErrorQuotaExceeded) >= ErrorSeverityScore(ProviderErrorProvider5xx) {
+		t.Fatal("quota must be more severe than 5xx")
+	}
+}
+
+func TestComputeScore_Healthy(t *testing.T) {
+	score := ComputeScore(ScoreInput{
+		SuccessRate:        1.0,
+		P95LatencyMs:       2_000,
+		LatencyThresholdMs: 10_000,
+		DominantErrorType:  ProviderErrorNone,
+		ConsecutiveFailures: 0,
+	})
+	if score < 90 {
+		t.Fatalf("perfect signals should be healthy (>=90), got %d", score)
+	}
+}
+
+func TestComputeScore_AuthErrors(t *testing.T) {
+	score := ComputeScore(ScoreInput{
+		SuccessRate:        0.5,
+		P95LatencyMs:       1_000,
+		LatencyThresholdMs: 10_000,
+		DominantErrorType:  ProviderErrorAuth,
+		ConsecutiveFailures: 3,
+	})
+	if score >= 65 {
+		t.Fatalf("auth errors with failures should be unhealthy (<65), got %d", score)
+	}
+}
+
+func TestComputeScore_HighLatency(t *testing.T) {
+	score := ComputeScore(ScoreInput{
+		SuccessRate:        0.99,
+		P95LatencyMs:       20_000,
+		LatencyThresholdMs: 10_000,
+		DominantErrorType:  ProviderErrorNone,
+	})
+	if score >= 90 {
+		t.Fatalf("2x threshold latency should not be healthy, got %d", score)
+	}
+}
+
+func TestStatusFromScore(t *testing.T) {
+	if StatusFromScore(95, true, false) != StatusHealthy {
+		t.Fatal("95 should be healthy")
+	}
+	if StatusFromScore(70, true, false) != StatusDegraded {
+		t.Fatal("70 should be degraded")
+	}
+	if StatusFromScore(40, true, false) != StatusUnhealthy {
+		t.Fatal("40 should be unhealthy")
+	}
+	if StatusFromScore(100, false, false) != StatusUnknown {
+		t.Fatal("no data should be unknown")
+	}
+	if StatusFromScore(10, true, true) != StatusDisabled {
+		t.Fatal("disabled overrides")
+	}
+}
+
+func TestMainIssue(t *testing.T) {
+	if MainIssue(ProviderErrorRateLimited, 0, 10_000, 0) != "rate_limited" {
+		t.Fatal("rate_limited issue")
+	}
+	if MainIssue(ProviderErrorNone, 20_000, 10_000, 0) != "high_latency" {
+		t.Fatal("high_latency issue")
+	}
+	if MainIssue(ProviderErrorNone, 1_000, 10_000, 5) != "fallback_spike" {
+		t.Fatal("fallback_spike issue")
+	}
+	if MainIssue(ProviderErrorNone, 1_000, 10_000, 0) != "" {
+		t.Fatal("no issue expected")
+	}
+}
+
+func TestRecommendationFor(t *testing.T) {
+	if r := RecommendationFor(ProviderErrorAuth); r == "" {
+		t.Fatal("auth recommendation must not be empty")
+	}
+	if r := RecommendationForIssue("high_latency"); r == "" {
+		t.Fatal("high_latency recommendation must not be empty")
+	}
+	if r := RecommendationForIssue(""); r != "" {
+		t.Fatal("empty issue should have empty recommendation")
+	}
+}
+
+func TestPercentile(t *testing.T) {
+	s := SortInts([]int{10, 20, 30, 40, 50, 60, 70, 80, 90, 100})
+	if p := Percentile(s, 50); p < 40 || p > 60 {
+		t.Fatalf("p50 expected ~50, got %d", p)
+	}
+	if p := Percentile(s, 95); p < 90 {
+		t.Fatalf("p95 expected near max, got %d", p)
+	}
+	if p := Percentile([]int{}, 50); p != 0 {
+		t.Fatal("empty percentile should be 0")
+	}
+}

--- a/backend/internal/health/probe.go
+++ b/backend/internal/health/probe.go
@@ -1,0 +1,327 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mydisha/keirouter/backend/internal/connectors"
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/mydisha/keirouter/backend/internal/store"
+	"github.com/mydisha/keirouter/backend/internal/vault"
+)
+
+// ProbeRunner executes synthetic provider probes and records their results.
+// It is shared by the manual probe API endpoint and may be reused by the
+// scheduled probe worker.
+type ProbeRunner struct {
+	log        *slog.Logger
+	repo       *store.ProviderHealthRepo
+	accounts   *store.AccountRepo
+	conns      *connectors.Registry
+	vault      *vault.Vault
+	thresholds LatencyThresholds
+	timeout    time.Duration
+}
+
+// NewProbeRunner builds a ProbeRunner.
+func NewProbeRunner(log *slog.Logger, repo *store.ProviderHealthRepo, accounts *store.AccountRepo, conns *connectors.Registry, vault *vault.Vault, thresholds LatencyThresholds, timeout time.Duration) *ProbeRunner {
+	if thresholds == nil {
+		thresholds = DefaultLatencyThresholds()
+	}
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ProbeRunner{log: log, repo: repo, accounts: accounts, conns: conns, vault: vault, thresholds: thresholds, timeout: timeout}
+}
+
+// ProbeRequest selects a probe target.
+type ProbeRequest struct {
+	Provider          string
+	ProviderAccountID string
+	Model             string
+	Capability        string // chat_completions | embeddings | ...
+	TriggeredBy       string // manual | scheduled | after_failure | startup
+}
+
+// ProbeResult is the outcome of one probe.
+type ProbeResult struct {
+	Provider          string
+	ProviderAccountID string
+	Model             string
+	Capability        string
+	Status            string // success | failed
+	HTTPStatus        *int
+	LatencyMs         *int
+	TTFTMs            *int
+	ErrorType         *string
+	ErrorMessage      *string
+	PromptTokens      *int
+	CompletionTokens  *int
+	CostMicroUSD      *int64
+}
+
+// Run executes one probe and persists the result. It never returns an error
+// for a failed upstream — that is a valid probe outcome. It returns an error
+// only for configuration problems (unknown provider, missing account).
+func (r *ProbeRunner) Run(ctx context.Context, req ProbeRequest) (ProbeResult, error) {
+	if req.Provider == "" || req.Model == "" {
+		return ProbeResult{}, fmt.Errorf("provider and model are required")
+	}
+	if req.TriggeredBy == "" {
+		req.TriggeredBy = "manual"
+	}
+	res := ProbeResult{
+		Provider:          req.Provider,
+		ProviderAccountID: req.ProviderAccountID,
+		Model:             req.Model,
+		Capability:        req.Capability,
+	}
+
+	conn, err := r.conns.Get(req.Provider)
+	if err != nil {
+		return res, fmt.Errorf("unknown provider: %s", req.Provider)
+	}
+
+	var creds core.Credentials
+	if r.vault != nil && r.accounts != nil && req.ProviderAccountID != "" {
+		acc, aerr := r.accounts.Get(ctx, req.ProviderAccountID)
+		if aerr != nil {
+			return res, fmt.Errorf("account not found: %s", req.ProviderAccountID)
+		}
+		if c, verr := r.vault.Open(acc); verr == nil {
+			creds = c
+		}
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
+	capability := req.Capability
+	if capability == "" {
+		capability = "chat_completions"
+		res.Capability = capability
+	}
+
+	start := time.Now()
+	var callErr error
+	var usage core.Usage
+
+	switch capability {
+	case "embeddings":
+		if mc, ok := conn.(core.MediaConnector); ok {
+			probeReq := &core.EmbeddingRequest{
+				Model: req.Model,
+				Input: []string{"health check"},
+			}
+			var resp *core.EmbeddingResponse
+			resp, callErr = mc.Embeddings(probeCtx, probeReq, creds)
+			if resp != nil {
+				usage = resp.Usage
+			}
+		} else {
+			callErr = fmt.Errorf("provider %s does not support embeddings", req.Provider)
+		}
+	default: // chat_completions
+		maxTok := 8
+		probeReq := &core.ChatRequest{
+			Model: req.Model,
+			Messages: []core.Message{{
+				Role: core.RoleUser,
+				Content: []core.ContentPart{{Type: core.PartText, Text: "Reply with OK only."}},
+			}},
+			MaxTokens: &maxTok,
+		}
+		var ttft time.Duration
+		streamCfg := core.StreamConfig{
+			OnFirstChunk: func(elapsed time.Duration) { ttft = elapsed },
+		}
+		stream, serr := conn.Stream(probeCtx, probeReq, creds, streamCfg)
+		if serr == nil {
+			sresp, drainErr := drainProbeStream(stream)
+			if drainErr != nil {
+				callErr = drainErr
+			} else if sresp != nil {
+				usage = sresp.Usage
+			}
+			if ttft > 0 {
+				ms := int(ttft.Milliseconds())
+				res.TTFTMs = &ms
+			}
+		} else {
+			// Fall back to unary for connectors that reject streaming.
+			uresp, cerr := conn.Chat(probeCtx, probeReq, creds)
+			callErr = cerr
+			if uresp != nil {
+				usage = uresp.Usage
+			}
+		}
+	}
+	latency := int(time.Since(start).Milliseconds())
+	res.LatencyMs = &latency
+
+	if callErr != nil {
+		pe := core.AsProviderError(callErr)
+		et := string(ClassifyError(pe))
+		msg := pe.Message
+		if msg == "" {
+			msg = callErr.Error()
+		}
+		res.Status = "failed"
+		res.ErrorType = &et
+		res.ErrorMessage = &msg
+		if pe.StatusCode > 0 {
+			sc := pe.StatusCode
+			res.HTTPStatus = &sc
+		}
+	} else {
+		res.Status = "success"
+		hs := 200
+		res.HTTPStatus = &hs
+	}
+	if usage.PromptTokens > 0 {
+		pt := usage.PromptTokens
+		res.PromptTokens = &pt
+	}
+	if usage.CompletionTokens > 0 {
+		ct := usage.CompletionTokens
+		res.CompletionTokens = &ct
+	}
+
+	if err := r.repo.InsertProbeResult(ctx, toStored(res, req.TriggeredBy)); err != nil {
+		r.log.Warn("probe result insert failed", "err", err, "provider", req.Provider, "model", req.Model)
+	}
+	r.applyProbeToCurrent(ctx, res, capability)
+	return res, nil
+}
+
+// applyProbeToCurrent updates provider_health_current from a probe outcome.
+// If the row already has traffic (request_count > 0), only last_probe_at is
+// refreshed so traffic-derived metrics are not clobbered. Otherwise the probe
+// verdict sets score/status directly.
+func (r *ProbeRunner) applyProbeToCurrent(ctx context.Context, res ProbeResult, capability string) {
+	existing, gerr := r.repo.GetCurrent(ctx, res.Provider, res.ProviderAccountID, res.Model, res.Capability)
+	now := time.Now()
+	if gerr == nil && existing.RequestCount > 0 {
+		_ = r.repo.UpdateProbeTimestamp(ctx, res.Provider, res.ProviderAccountID, res.Model, res.Capability, now)
+		return
+	}
+
+	var score int
+	var status string
+	var mainIssue, recommendation string
+	if res.Status == "success" {
+		score = 100
+		status = StatusHealthy
+	} else {
+		et := ProviderErrorUnknown
+		if res.ErrorType != nil {
+			et = ProviderErrorType(*res.ErrorType)
+		}
+		threshold := r.thresholds.ThresholdFor(capability)
+		p95 := 0
+		if res.LatencyMs != nil {
+			p95 = *res.LatencyMs
+		}
+		score = ComputeScore(ScoreInput{
+			SuccessRate:         0,
+			P95LatencyMs:        p95,
+			LatencyThresholdMs:  threshold,
+			DominantErrorType:   et,
+			ConsecutiveFailures: 1,
+		})
+		status = StatusFromScore(score, true, false)
+		mainIssue = MainIssue(et, p95, threshold, 0)
+		recommendation = RecommendationForIssue(mainIssue)
+	}
+
+	cur := store.ProviderHealthCurrent{
+		ID:                uuid.NewString(),
+		Provider:          res.Provider,
+		ProviderAccountID: res.ProviderAccountID,
+		Model:             res.Model,
+		Capability:        res.Capability,
+		HealthStatus:      status,
+		HealthScore:       score,
+		LastProbeAt:       &now,
+		LastUpdatedAt:     now,
+	}
+	if res.Status == "success" {
+		cur.LastSuccessAt = &now
+	} else {
+		cur.LastFailureAt = &now
+	}
+	if mainIssue != "" {
+		cur.MainIssue = &mainIssue
+	}
+	if recommendation != "" {
+		cur.Recommendation = &recommendation
+	}
+	if err := r.repo.UpsertCurrent(ctx, cur); err != nil {
+		r.log.Warn("probe current upsert failed", "err", err, "provider", res.Provider, "model", res.Model)
+	}
+}
+
+// drainProbeStream consumes a probe stream channel into a synthetic response,
+// merging any usage chunks. A ChunkError is surfaced as an error.
+func drainProbeStream(ch <-chan core.StreamChunk) (*core.ChatResponse, error) {
+	resp := &core.ChatResponse{}
+	for chunk := range ch {
+		switch chunk.Type {
+		case core.ChunkError:
+			if chunk.Err != nil {
+				return resp, chunk.Err
+			}
+		case core.ChunkUsage:
+			if chunk.Usage != nil {
+				resp.Usage = mergeUsage(resp.Usage, *chunk.Usage)
+			}
+		case core.ChunkFinish:
+			resp.FinishReason = chunk.FinishReason
+			if chunk.Usage != nil {
+				resp.Usage = mergeUsage(resp.Usage, *chunk.Usage)
+			}
+		}
+	}
+	return resp, nil
+}
+
+func mergeUsage(a, b core.Usage) core.Usage {
+	if b.PromptTokens > 0 {
+		a.PromptTokens = b.PromptTokens
+	}
+	if b.CompletionTokens > 0 {
+		a.CompletionTokens = b.CompletionTokens
+	}
+	if b.CachedTokens > 0 {
+		a.CachedTokens = b.CachedTokens
+	}
+	return a
+}
+
+func toStored(res ProbeResult, triggeredBy string) store.ProviderProbeResult {
+	return store.ProviderProbeResult{
+		ID:                  uuid.NewString(),
+		Provider:            res.Provider,
+		ProviderAccountID:   res.ProviderAccountID,
+		Model:               res.Model,
+		Capability:          res.Capability,
+		Status:              res.Status,
+		HTTPStatus:          res.HTTPStatus,
+		LatencyMs:           res.LatencyMs,
+		TTFTMs:              res.TTFTMs,
+		ErrorType:           res.ErrorType,
+		ErrorMessage:        res.ErrorMessage,
+		PromptTokens:        res.PromptTokens,
+		CompletionTokens:    res.CompletionTokens,
+		EstimatedCostMicros: res.CostMicroUSD,
+		TriggeredBy:         triggeredBy,
+		CreatedAt:           time.Now(),
+	}
+}

--- a/backend/internal/health/recommendation.go
+++ b/backend/internal/health/recommendation.go
@@ -1,0 +1,44 @@
+package health
+
+// RecommendationFor returns an actionable recommendation for a given main issue
+// / error type. The dashboard surfaces this so a degraded/unhealthy status
+// always comes with a next step.
+func RecommendationFor(errType ProviderErrorType) string {
+	switch errType {
+	case ProviderErrorAuth:
+		return "Re-check the API key or OAuth connection for this provider account."
+	case ProviderErrorRateLimited:
+		return "Lower concurrency, reduce chain priority, or add another account/provider fallback."
+	case ProviderErrorQuotaExceeded:
+		return "Check provider billing/quota or disable this account temporarily."
+	case ProviderErrorTimeout:
+		return "Increase the timeout if acceptable, or move this model lower in the fallback chain."
+	case ProviderErrorProvider5xx:
+		return "Likely upstream instability. Keep fallback enabled and monitor recovery."
+	case ProviderErrorUnsupported:
+		return "Verify the model name, refresh the model list, or check capability support."
+	case ProviderErrorNetwork:
+		return "Check network connectivity, DNS, proxy, or the provider base URL."
+	case ProviderErrorBadRequest:
+		return "Review the request shape; a 4xx indicates a client-side issue."
+	case ProviderErrorUnknown:
+		return "Check provider logs and run a manual probe."
+	default:
+		return ""
+	}
+}
+
+// RecommendationForIssue maps a derived main_issue label (e.g. high_latency) to
+// a recommendation when there is no single dominant error type.
+func RecommendationForIssue(issue string) string {
+	switch issue {
+	case "high_latency":
+		return "Move a lower-latency model earlier in the chain or reduce request size."
+	case "fallback_spike":
+		return "Fallback is absorbing failures; investigate the primary provider or add capacity."
+	case "":
+		return ""
+	default:
+		return RecommendationFor(ProviderErrorType(issue))
+	}
+}

--- a/backend/internal/health/score.go
+++ b/backend/internal/health/score.go
@@ -1,0 +1,157 @@
+package health
+
+import "sort"
+
+// Health status values used across the dashboard, store, and API.
+const (
+	StatusHealthy   = "healthy"
+	StatusDegraded  = "degraded"
+	StatusUnhealthy = "unhealthy"
+	StatusUnknown   = "unknown"
+	StatusDisabled  = "disabled"
+)
+
+// ScoreInput captures the raw signals needed to compute a 0-100 health score.
+type ScoreInput struct {
+	// SuccessRate is the fraction of successful requests in the window (0-1).
+	SuccessRate float64
+	// P95LatencyMs is the 95th percentile latency, or 0 if no latency samples.
+	P95LatencyMs int
+	// LatencyThresholdMs is the capability-specific p95 threshold. 0 disables
+	// the latency component (treated as a perfect score).
+	LatencyThresholdMs int
+	// DominantErrorType is the most frequent error type in the window, or
+	// ProviderErrorNone when there were no failures.
+	DominantErrorType ProviderErrorType
+	// ConsecutiveFailures is the current streak of failures.
+	ConsecutiveFailures int
+}
+
+// ComputeScore returns a 0-100 health score from the weighted sum of success,
+// latency, error-quality, and stability sub-scores.
+//
+//	success_score      0.40  = success_rate * 100
+//	latency_score      0.25  = 100 if p95 <= threshold else linear decay
+//	error_quality      0.20  = severity score of the dominant error type
+//	stability_score    0.15  = based on consecutive failures
+func ComputeScore(in ScoreInput) int {
+	successScore := in.SuccessRate * 100
+
+	latencyScore := 100.0
+	if in.LatencyThresholdMs > 0 && in.P95LatencyMs > in.LatencyThresholdMs {
+		over := float64(in.P95LatencyMs - in.LatencyThresholdMs)
+		latencyScore = 100 - (over/float64(in.LatencyThresholdMs))*100
+		if latencyScore < 0 {
+			latencyScore = 0
+		}
+	}
+
+	errorQuality := float64(ErrorSeverityScore(in.DominantErrorType))
+
+	stability := stabilityScore(in.ConsecutiveFailures)
+
+	score := successScore*0.40 + latencyScore*0.25 + errorQuality*0.20 + stability*0.15
+	return clampInt(int(score))
+}
+
+func stabilityScore(consecutiveFailures int) float64 {
+	switch {
+	case consecutiveFailures <= 0:
+		return 100
+	case consecutiveFailures == 1:
+		return 80
+	case consecutiveFailures == 2:
+		return 60
+	case consecutiveFailures == 3:
+		return 30
+	default:
+		return 0
+	}
+}
+
+// StatusFromScore derives a health status from a score. When there is no data
+// (hasData false) the status is unknown; disabled overrides everything.
+func StatusFromScore(score int, hasData, disabled bool) string {
+	if disabled {
+		return StatusDisabled
+	}
+	if !hasData {
+		return StatusUnknown
+	}
+	switch {
+	case score >= 90:
+		return StatusHealthy
+	case score >= 65:
+		return StatusDegraded
+	default:
+		return StatusUnhealthy
+	}
+}
+
+// MainIssue derives a short human-readable main issue string from the dominant
+// error type and signals, so a degraded/unhealthy row always explains itself.
+func MainIssue(errType ProviderErrorType, p95LatencyMs, latencyThresholdMs int, fallbackCount int64) string {
+	switch errType {
+	case ProviderErrorAuth:
+		return "auth_error"
+	case ProviderErrorRateLimited:
+		return "rate_limited"
+	case ProviderErrorQuotaExceeded:
+		return "quota_exceeded"
+	case ProviderErrorTimeout:
+		return "timeout"
+	case ProviderErrorProvider5xx:
+		return "provider_5xx"
+	case ProviderErrorNetwork:
+		return "network_error"
+	case ProviderErrorUnsupported:
+		return "unsupported_model_or_capability"
+	case ProviderErrorBadRequest:
+		return "bad_request"
+	case ProviderErrorUnknown:
+		return "unknown_error"
+	}
+	// No dominant error: check latency then fallbacks.
+	if latencyThresholdMs > 0 && p95LatencyMs > latencyThresholdMs {
+		return "high_latency"
+	}
+	if fallbackCount > 0 {
+		return "fallback_spike"
+	}
+	return ""
+}
+
+// Percentile returns the q-th percentile (0-100) of a sorted-ascending sample
+// slice. For small per-key windows exact percentiles are cheap and accurate.
+func Percentile(sorted []int, q float64) int {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if q <= 0 {
+		return sorted[0]
+	}
+	if q >= 100 {
+		return sorted[len(sorted)-1]
+	}
+	// Nearest-rank method.
+	idx := int(float64(len(sorted)-1) * q / 100)
+	return sorted[idx]
+}
+
+// SortInts returns a sorted copy of in ascending. Used before Percentile.
+func SortInts(in []int) []int {
+	out := make([]int, len(in))
+	copy(out, in)
+	sort.Ints(out)
+	return out
+}
+
+func clampInt(v int) int {
+	if v < 0 {
+		return 0
+	}
+	if v > 100 {
+		return 100
+	}
+	return v
+}

--- a/backend/internal/health/telemetry.go
+++ b/backend/internal/health/telemetry.go
@@ -1,0 +1,643 @@
+package health
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+// ProviderTelemetryEvent captures one completed provider attempt for health
+// aggregation. It mirrors the spec telemetry event; sensitive request/response
+// bodies are never included.
+type ProviderTelemetryEvent struct {
+	Timestamp         time.Time
+	Provider          string
+	ProviderAccountID string
+	Model             string
+	Capability        string
+
+	Status string // "success" | "failed"
+	// HTTPStatus is the upstream HTTP status code (0 when not applicable).
+	HTTPStatus int
+	LatencyMs  int
+	TTFTMs     int
+
+	InputTokens  int
+	OutputTokens int
+	CostMicroUSD int64
+
+	ErrorType    ProviderErrorType
+	ErrorMessage string
+
+	ChainID           string
+	FallbackTriggered bool
+	FallbackToProvider string
+	FallbackToModel    string
+	FinalFailure      bool
+}
+
+// LatencyThresholds maps a capability to its p95 latency threshold in ms.
+type LatencyThresholds map[string]int
+
+// DefaultLatencyThresholds returns the spec's default per-capability p95
+// thresholds used when none are configured.
+func DefaultLatencyThresholds() LatencyThresholds {
+	return LatencyThresholds{
+		"chat_completions": 10_000,
+		"embeddings":       5_000,
+		"image_generation": 60_000,
+		"audio":            60_000,
+		"search":           15_000,
+	}
+}
+
+// ThresholdFor resolves the p95 latency threshold for a capability, falling
+// back to the chat default when unknown.
+func (lt LatencyThresholds) ThresholdFor(capability string) int {
+	if v, ok := lt[capability]; ok && v > 0 {
+		return v
+	}
+	if v, ok := lt["chat_completions"]; ok && v > 0 {
+		return v
+	}
+	return 10_000
+}
+
+// Config controls the health telemetry service.
+type Config struct {
+	// Enabled gates telemetry recording. When false, Record is a no-op.
+	Enabled bool
+	// QueueSize is the async event channel capacity. Full queues drop events.
+	QueueSize int
+	// CurrentFlushInterval is how often provider_health_current is recomputed.
+	CurrentFlushInterval time.Duration
+	// SnapshotInterval is how often 1-minute snapshot rows are written.
+	SnapshotInterval time.Duration
+	// RollingWindow is the lookback for current-state aggregation.
+	RollingWindow time.Duration
+	// MaxSamplesPerBucket caps latency/TTFT samples kept per minute bucket.
+	MaxSamplesPerBucket int
+	// LatencyThresholds per capability (ms).
+	LatencyThresholds LatencyThresholds
+}
+
+// Service records provider telemetry events asynchronously and aggregates them
+// into provider_health_current (fast dashboard load) and
+// provider_health_snapshots (historical charts).
+//
+// All recording is best-effort: a full queue or a DB write failure logs a
+// warning and continues. The gateway request path never blocks on telemetry.
+type Service struct {
+	cfg Config
+	log *slog.Logger
+	repo *store.ProviderHealthRepo
+
+	ch      chan ProviderTelemetryEvent
+	once    sync.Once
+	done    chan struct{}
+	started bool
+
+	mu     sync.Mutex // guards states + chains maps
+	states map[string]*keyState
+	chains map[string]*chainState // key = chain_id
+}
+
+// chainState rolls up telemetry across all providers in one chain so the
+// dashboard can show fallback rate and final-failure count per chain.
+type chainState struct {
+	chainID      string
+	buckets      map[int64]*chainBucket // key = unix minute
+	lastUpdated  time.Time
+}
+
+type chainBucket struct {
+	minute      time.Time
+	requests    int64
+	successes   int64
+	failures    int64
+	fallbacks   int64
+	finalFails  int64
+}
+
+type keyState struct {
+	provider          string
+	account           string
+	model             string
+	capability        string
+	buckets           map[int64]*minuteBucket // key = unix minute
+	consecutiveFailures int
+	lastSuccess       *time.Time
+	lastFailure       *time.Time
+}
+
+type minuteBucket struct {
+	minute      time.Time
+	requests    int64
+	successes   int64
+	failures    int64
+	fallbacks   int64
+	finalFails  int64
+	inputTokens int64
+	outputTokens int64
+	costMicros  int64
+	latencies   []int
+	ttfts       []int
+	errCounts   map[ProviderErrorType]int64
+}
+
+// New builds a health telemetry Service. The caller must call Start to launch
+// the background aggregator and Close on shutdown.
+func New(cfg Config, log *slog.Logger, repo *store.ProviderHealthRepo) *Service {
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = 5000
+	}
+	if cfg.CurrentFlushInterval <= 0 {
+		cfg.CurrentFlushInterval = 30 * time.Second
+	}
+	if cfg.SnapshotInterval <= 0 {
+		cfg.SnapshotInterval = 60 * time.Second
+	}
+	if cfg.RollingWindow <= 0 {
+		cfg.RollingWindow = 15 * time.Minute
+	}
+	if cfg.MaxSamplesPerBucket <= 0 {
+		cfg.MaxSamplesPerBucket = 500
+	}
+	if cfg.LatencyThresholds == nil {
+		cfg.LatencyThresholds = DefaultLatencyThresholds()
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Service{
+		cfg:    cfg,
+		log:    log,
+		repo:   repo,
+		ch:     make(chan ProviderTelemetryEvent, cfg.QueueSize),
+		done:   make(chan struct{}),
+		states: make(map[string]*keyState),
+		chains: make(map[string]*chainState),
+	}
+}
+
+// Record enqueues a telemetry event. Non-blocking: when the queue is full the
+// event is dropped with a debug log so the request path is never delayed.
+func (s *Service) Record(ev ProviderTelemetryEvent) {
+	if s == nil || !s.cfg.Enabled {
+		return
+	}
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now()
+	}
+	select {
+	case s.ch <- ev:
+	default:
+		s.log.Debug("health telemetry queue full; dropping event",
+			"provider", ev.Provider, "model", ev.Model)
+	}
+}
+
+// ChainStat is the rolled-up health of one routing chain over the rolling
+// window, used by the chain-impact view.
+type ChainStat struct {
+	ChainID         string
+	Requests        int64
+	Successes       int64
+	Failures        int64
+	Fallbacks       int64
+	FinalFailures   int64
+	FallbackRate    float64 // 0-1
+	FinalFailureRate float64 // 0-1
+	LastUpdated     time.Time
+}
+
+// ChainStats returns rolled-up per-chain stats over the rolling window. Chains
+// with no recent telemetry are omitted.
+func (s *Service) ChainStats() []ChainStat {
+	if s == nil {
+		return nil
+	}
+	windowStart := time.Now().UTC().Add(-s.cfg.RollingWindow).Truncate(time.Minute)
+	s.mu.Lock()
+	out := make([]ChainStat, 0, len(s.chains))
+	for id, cs := range s.chains {
+		var agg ChainStat
+		agg.ChainID = id
+		for m, b := range cs.buckets {
+			if b.minute.Before(windowStart) {
+				continue
+			}
+			_ = m
+			agg.Requests += b.requests
+			agg.Successes += b.successes
+			agg.Failures += b.failures
+			agg.Fallbacks += b.fallbacks
+			agg.FinalFailures += b.finalFails
+		}
+		if agg.Requests > 0 {
+			agg.FallbackRate = float64(agg.Fallbacks) / float64(agg.Requests)
+			agg.FinalFailureRate = float64(agg.FinalFailures) / float64(agg.Requests)
+		}
+		agg.LastUpdated = cs.lastUpdated
+		if agg.Requests > 0 || agg.Fallbacks > 0 {
+			out = append(out, agg)
+		}
+	}
+	s.mu.Unlock()
+	return out
+}
+
+// Start launches the drain + aggregator goroutine once.
+func (s *Service) Start(ctx context.Context) {
+	if s == nil || !s.cfg.Enabled {
+		return
+	}
+	s.once.Do(func() {
+		s.started = true
+		go s.run(ctx)
+	})
+}
+
+// Close stops the service and waits for the aggregator to exit. No-op when the
+// service was never started or is disabled.
+func (s *Service) Close(timeout time.Duration) {
+	if s == nil {
+		return
+	}
+	if !s.cfg.Enabled || !s.started {
+		return
+	}
+	close(s.ch)
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-s.done:
+	case <-timer.C:
+	}
+}
+
+func (s *Service) run(ctx context.Context) {
+	defer close(s.done)
+	currentTick := time.NewTicker(s.cfg.CurrentFlushInterval)
+	snapTick := time.NewTicker(s.cfg.SnapshotInterval)
+	defer currentTick.Stop()
+	defer snapTick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.flushCurrent(context.Background())
+			s.flushSnapshots(context.Background(), true)
+			return
+		case ev, ok := <-s.ch:
+			if !ok {
+				s.flushCurrent(context.Background())
+				s.flushSnapshots(context.Background(), true)
+				return
+			}
+			s.ingest(ev)
+		case <-currentTick.C:
+			s.flushCurrent(context.Background())
+		case <-snapTick.C:
+			s.flushSnapshots(context.Background(), false)
+		}
+	}
+}
+
+func (s *Service) ingest(ev ProviderTelemetryEvent) {
+	key := store.HealthKey(ev.Provider, ev.ProviderAccountID, ev.Model, ev.Capability)
+	s.mu.Lock()
+	ks, ok := s.states[key]
+	if !ok {
+		ks = &keyState{
+			provider:   ev.Provider,
+			account:    ev.ProviderAccountID,
+			model:      ev.Model,
+			capability: ev.Capability,
+			buckets:    make(map[int64]*minuteBucket),
+		}
+		s.states[key] = ks
+	}
+	min := ev.Timestamp.UTC().Truncate(time.Minute)
+	bucket, ok := ks.buckets[min.Unix()]
+	if !ok {
+		bucket = &minuteBucket{minute: min, errCounts: make(map[ProviderErrorType]int64)}
+		ks.buckets[min.Unix()] = bucket
+	}
+	bucket.requests++
+	bucket.inputTokens += int64(ev.InputTokens)
+	bucket.outputTokens += int64(ev.OutputTokens)
+	bucket.costMicros += ev.CostMicroUSD
+	if ev.Status == "success" {
+		bucket.successes++
+		ks.consecutiveFailures = 0
+		now := ev.Timestamp
+		ks.lastSuccess = &now
+	} else {
+		bucket.failures++
+		bucket.errCounts[ev.ErrorType]++
+		ks.consecutiveFailures++
+		now := ev.Timestamp
+		ks.lastFailure = &now
+	}
+	if ev.FallbackTriggered && ev.Status == "failed" && !ev.FinalFailure {
+		bucket.fallbacks++
+	}
+	if ev.FinalFailure {
+		bucket.finalFails++
+	}
+	if ev.LatencyMs > 0 && len(bucket.latencies) < s.cfg.MaxSamplesPerBucket {
+		bucket.latencies = append(bucket.latencies, ev.LatencyMs)
+	}
+	if ev.TTFTMs > 0 && len(bucket.ttfts) < s.cfg.MaxSamplesPerBucket {
+		bucket.ttfts = append(bucket.ttfts, ev.TTFTMs)
+	}
+
+	// Chain-level rollup: only terminal events (success or FinalFailure)
+	// count as requests. FallbackTriggered on a terminal event means the
+	// request fell back ≥1 time before completing. Non-terminal per-attempt
+	// failure events are ignored at chain level (they're not requests).
+	if ev.ChainID != "" {
+		cs, ok := s.chains[ev.ChainID]
+		if !ok {
+			cs = &chainState{chainID: ev.ChainID, buckets: make(map[int64]*chainBucket)}
+			s.chains[ev.ChainID] = cs
+		}
+		cb, ok := cs.buckets[min.Unix()]
+		if !ok {
+			cb = &chainBucket{minute: min}
+			cs.buckets[min.Unix()] = cb
+		}
+		if ev.Status == "success" || ev.FinalFailure {
+			cb.requests++
+			if ev.Status == "success" {
+				cb.successes++
+			} else {
+				cb.failures++
+				cb.finalFails++
+			}
+			if ev.FallbackTriggered {
+				cb.fallbacks++
+			}
+		}
+		cs.lastUpdated = ev.Timestamp
+	}
+	s.mu.Unlock()
+}
+
+// flushCurrent recomputes provider_health_current for every active key from its
+// rolling window of minute buckets.
+func (s *Service) flushCurrent(ctx context.Context) {
+	s.mu.Lock()
+	now := time.Now().UTC()
+	windowStart := now.Add(-s.cfg.RollingWindow).Truncate(time.Minute)
+	keys := make([]*keyState, 0, len(s.states))
+	for _, ks := range s.states {
+		keys = append(keys, ks)
+	}
+	s.mu.Unlock()
+
+	for _, ks := range keys {
+		agg := s.aggregate(ks, windowStart, now)
+		if agg.requests == 0 {
+			continue
+		}
+		s.upsertCurrent(ctx, ks, agg, now)
+	}
+}
+
+// flushSnapshots writes completed (elapsed) minute buckets as snapshot rows and
+// removes them from memory. When flushAll is true (shutdown), the current
+// in-progress minute is also written.
+func (s *Service) flushSnapshots(ctx context.Context, flushAll bool) {
+	s.mu.Lock()
+	currentMinute := time.Now().UTC().Truncate(time.Minute).Unix()
+	type pending struct {
+		ks     *keyState
+		minute int64
+		bucket *minuteBucket
+	}
+	var toWrite []pending
+	for _, ks := range s.states {
+		for m, b := range ks.buckets {
+			if m < currentMinute || flushAll {
+				toWrite = append(toWrite, pending{ks, m, b})
+			}
+		}
+	}
+	s.mu.Unlock()
+
+	for _, p := range toWrite {
+		if err := s.writeSnapshot(ctx, p.ks, p.bucket); err != nil {
+			s.log.Warn("health snapshot write failed", "err", err,
+				"provider", p.ks.provider, "model", p.ks.model)
+			continue
+		}
+		s.mu.Lock()
+		// Re-fetch: the bucket may have been re-created since snapshot; only
+		// delete if it is the same pointer we wrote.
+		if cur, ok := p.ks.buckets[p.minute]; ok && cur == p.bucket {
+			delete(p.ks.buckets, p.minute)
+		}
+		s.mu.Unlock()
+	}
+}
+
+type windowAgg struct {
+	requests, successes, failures int64
+	fallbacks, finalFails         int64
+	inputTokens, outputTokens     int64
+	costMicros                    int64
+	errCounts                     map[ProviderErrorType]int64
+	latencies                     []int
+	ttfts                         []int
+}
+
+func (s *Service) aggregate(ks *keyState, windowStart, _ time.Time) windowAgg {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var a windowAgg
+	a.errCounts = make(map[ProviderErrorType]int64)
+	for _, b := range ks.buckets {
+		if b.minute.Before(windowStart) {
+			continue
+		}
+		a.requests += b.requests
+		a.successes += b.successes
+		a.failures += b.failures
+		a.fallbacks += b.fallbacks
+		a.finalFails += b.finalFails
+		a.inputTokens += b.inputTokens
+		a.outputTokens += b.outputTokens
+		a.costMicros += b.costMicros
+		for t, c := range b.errCounts {
+			a.errCounts[t] += c
+		}
+		a.latencies = append(a.latencies, b.latencies...)
+		a.ttfts = append(a.ttfts, b.ttfts...)
+	}
+	return a
+}
+
+func (s *Service) upsertCurrent(ctx context.Context, ks *keyState, a windowAgg, now time.Time) {
+	successRate := 0.0
+	if a.requests > 0 {
+		successRate = float64(a.successes) / float64(a.requests)
+	}
+	errorRate := 0.0
+	if a.requests > 0 {
+		errorRate = float64(a.failures) / float64(a.requests)
+	}
+	dominant := dominantErrorType(a.errCounts)
+	p95Lat := percentileOf(a.latencies, 95)
+	p95TTFT := percentileOf(a.ttfts, 95)
+	threshold := s.cfg.LatencyThresholds.ThresholdFor(ks.capability)
+
+	score := ComputeScore(ScoreInput{
+		SuccessRate:         successRate,
+		P95LatencyMs:        p95Lat,
+		LatencyThresholdMs:  threshold,
+		DominantErrorType:   dominant,
+		ConsecutiveFailures: ks.consecutiveFailures,
+	})
+	status := StatusFromScore(score, a.requests > 0, false)
+	mainIssue := MainIssue(dominant, p95Lat, threshold, a.fallbacks)
+	var recommendation string
+	if mainIssue != "" {
+		recommendation = RecommendationForIssue(mainIssue)
+	}
+
+	cur := store.ProviderHealthCurrent{
+		ID:                  uuid.NewString(),
+		Provider:            ks.provider,
+		ProviderAccountID:   ks.account,
+		Model:               ks.model,
+		Capability:          ks.capability,
+		HealthStatus:        status,
+		HealthScore:         score,
+		SuccessRate:         successRate,
+		ErrorRate:           errorRate,
+		RequestCount:        a.requests,
+		FallbackCount:       a.fallbacks,
+		LatencyP95Ms:        intPtr(p95Lat),
+		TTFTP95Ms:           intPtr(p95TTFT),
+		ConsecutiveFailures: ks.consecutiveFailures,
+		LastSuccessAt:       ks.lastSuccess,
+		LastFailureAt:       ks.lastFailure,
+		LastUpdatedAt:       now,
+	}
+	if mainIssue != "" {
+		cur.MainIssue = &mainIssue
+	}
+	if recommendation != "" {
+		cur.Recommendation = &recommendation
+	}
+	if err := s.repo.UpsertCurrent(ctx, cur); err != nil {
+		s.log.Warn("health current upsert failed", "err", err,
+			"provider", ks.provider, "model", ks.model)
+	}
+}
+
+func (s *Service) writeSnapshot(ctx context.Context, ks *keyState, b *minuteBucket) error {
+	successRate := 0.0
+	if b.requests > 0 {
+		successRate = float64(b.successes) / float64(b.requests)
+	}
+	dominant := dominantErrorType(b.errCounts)
+	p50Lat := percentileOf(b.latencies, 50)
+	p95Lat := percentileOf(b.latencies, 95)
+	p99Lat := percentileOf(b.latencies, 99)
+	p50TTFT := percentileOf(b.ttfts, 50)
+	p95TTFT := percentileOf(b.ttfts, 95)
+	p99TTFT := percentileOf(b.ttfts, 99)
+	threshold := s.cfg.LatencyThresholds.ThresholdFor(ks.capability)
+
+	score := ComputeScore(ScoreInput{
+		SuccessRate:        successRate,
+		P95LatencyMs:       p95Lat,
+		LatencyThresholdMs: threshold,
+		DominantErrorType:  dominant,
+	})
+	status := StatusFromScore(score, b.requests > 0, false)
+	mainIssue := MainIssue(dominant, p95Lat, threshold, b.fallbacks)
+
+	snap := store.ProviderHealthSnapshot{
+		ID:                  uuid.NewString(),
+		BucketStart:         b.minute,
+		BucketSizeSeconds:   60,
+		Provider:            ks.provider,
+		ProviderAccountID:   ks.account,
+		Model:               ks.model,
+		Capability:          ks.capability,
+		RequestCount:        b.requests,
+		SuccessCount:        b.successes,
+		FailureCount:        b.failures,
+		FallbackCount:       b.fallbacks,
+		FinalFailureCount:   b.finalFails,
+		InputTokens:         b.inputTokens,
+		OutputTokens:        b.outputTokens,
+		EstimatedCostMicros: b.costMicros,
+		LatencyP50Ms:        intPtr(p50Lat),
+		LatencyP95Ms:        intPtr(p95Lat),
+		LatencyP99Ms:        intPtr(p99Lat),
+		TTFTP50Ms:           intPtr(p50TTFT),
+		TTFTP95Ms:           intPtr(p95TTFT),
+		TTFTP99Ms:           intPtr(p99TTFT),
+		RateLimitedCount:    b.errCounts[ProviderErrorRateLimited],
+		AuthErrorCount:      b.errCounts[ProviderErrorAuth],
+		QuotaExceededCount:  b.errCounts[ProviderErrorQuotaExceeded],
+		TimeoutCount:        b.errCounts[ProviderErrorTimeout],
+		Provider5xxCount:    b.errCounts[ProviderErrorProvider5xx],
+		BadRequestCount:     b.errCounts[ProviderErrorBadRequest],
+		NetworkErrorCount:   b.errCounts[ProviderErrorNetwork],
+		UnsupportedCount:    b.errCounts[ProviderErrorUnsupported],
+		UnknownErrorCount:   b.errCounts[ProviderErrorUnknown],
+		HealthScore:         score,
+		HealthStatus:        status,
+		CreatedAt:           time.Now(),
+	}
+	if mainIssue != "" {
+		snap.MainIssue = &mainIssue
+	}
+	return s.repo.InsertSnapshot(ctx, snap)
+}
+
+func dominantErrorType(counts map[ProviderErrorType]int64) ProviderErrorType {
+	var best ProviderErrorType
+	var bestCount int64
+	for t, c := range counts {
+		if t == ProviderErrorNone {
+			continue
+		}
+		if c > bestCount {
+			best = t
+			bestCount = c
+		}
+	}
+	if bestCount == 0 {
+		return ProviderErrorNone
+	}
+	return best
+}
+
+func percentileOf(samples []int, q float64) int {
+	if len(samples) == 0 {
+		return 0
+	}
+	return Percentile(SortInts(samples), q)
+}
+
+func intPtr(v int) *int {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}

--- a/backend/internal/health/telemetry_bench_test.go
+++ b/backend/internal/health/telemetry_bench_test.go
@@ -1,0 +1,21 @@
+package health
+
+import (
+	"testing"
+)
+
+// BenchmarkRecord measures the per-event cost of telemetry recording on the
+// request hot path. It is non-blocking (channel send); the aggregator goroutine
+// is not started so this isolates the producer cost only.
+func BenchmarkRecord(b *testing.B) {
+	svc := New(Config{Enabled: true, QueueSize: 100_000}, nil, nil)
+	ev := ProviderTelemetryEvent{
+		Provider: "openai", Model: "gpt-4o", Capability: "chat_completions",
+		Status: "success", LatencyMs: 1200, InputTokens: 100, OutputTokens: 50,
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		svc.Record(ev)
+	}
+}

--- a/backend/internal/meter/meter.go
+++ b/backend/internal/meter/meter.go
@@ -111,6 +111,7 @@ type Event struct {
 
 	// Token-saving analytics.
 	SlimStats      *SlimSnapshot     // nil when RTK did not fire
+	SlimActive     bool              // RTK slimmer was enabled for this request
 	CavemanActive  bool              // caveman output compression was active
 	TerseActive    bool              // terse output compression was active
 	HeadroomStats  *HeadroomSnapshot // nil when Headroom did not yield non-phantom savings
@@ -202,6 +203,7 @@ func (m *Meter) Record(ctx context.Context, ev Event) (int64, error) {
 		LatencyMS:        int(ev.Latency.Milliseconds()),
 		TTFTMS:           int(ev.TTFT.Milliseconds()),
 		CavemanActive:    ev.CavemanActive,
+		SlimActive:       ev.SlimActive,
 		TerseActive:      ev.TerseActive,
 		PonytailActive:   ev.PonytailActive,
 		CreatedAt:        time.Now(),

--- a/backend/internal/pipeline/headroom_e2e_test.go
+++ b/backend/internal/pipeline/headroom_e2e_test.go
@@ -180,7 +180,7 @@ func TestHeadroomEndToEnd_PipelineMeterStore(t *testing.T) {
 				Account: store.Account{ID: "acc-1"},
 			}
 			usage := core.Usage{PromptTokens: 100, CompletionTokens: 50}
-			p.record(ctx, req.Metadata, attempt, usage, false, 5*time.Millisecond, save)
+			p.record(ctx, req.Metadata, attempt, usage, false, 5*time.Millisecond, save, false)
 
 			// Read the persisted record back from the store.
 			recent, err := db.Usage().Recent(ctx, store.DefaultTenantID, 10)

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
 	"github.com/mydisha/keirouter/backend/internal/guardrails"
 	"github.com/mydisha/keirouter/backend/internal/headroom"
+	"github.com/mydisha/keirouter/backend/internal/health"
 	"github.com/mydisha/keirouter/backend/internal/limits"
 	"github.com/mydisha/keirouter/backend/internal/meter"
 	"github.com/mydisha/keirouter/backend/internal/normalizer"
@@ -60,6 +61,7 @@ type Pipeline struct {
 	guardrails *guardrails.Engine
 	limiter    limits.Limiter
 	log        *slog.Logger
+	telemetry  *health.Service
 
 	requestTimeout     time.Duration // upper bound on non-streaming upstream calls
 	streamStallTimeout time.Duration // aborts a stream with no bytes for this long
@@ -87,6 +89,8 @@ type Deps struct {
 	// TimeoutReader provides dynamic timeout values from dashboard settings.
 	// When set, it overrides RequestTimeout and StreamStallTimeout.
 	TimeoutReader TimeoutReader
+	// Telemetry records provider health events. Best-effort, never blocks.
+	Telemetry *health.Service
 }
 
 // New builds a Pipeline.
@@ -107,6 +111,7 @@ func New(d Deps) *Pipeline {
 		guardrails: d.Guardrails,
 		limiter:    d.Limiter,
 		log:        log,
+		telemetry:  d.Telemetry,
 
 		requestTimeout:     d.RequestTimeout,
 		streamStallTimeout: d.StreamStallTimeout,
@@ -244,6 +249,7 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 
 	scope := budget.Scope{TenantID: req.Metadata.TenantID, ProjectID: req.Metadata.ProjectID, APIKeyID: req.Metadata.APIKeyID}
 	var lastErr error
+	fellBack := false // tracks whether the current request triggered ≥1 fallback
 	for i, attempt := range attempts {
 		started := time.Now()
 		p.log.Debug("attempt start", "i", i, "provider", attempt.Target.Provider,
@@ -316,6 +322,7 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 			if p.metrics != nil {
 				p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
 			}
+			p.recordFailureTelemetry(req.Metadata, attempt, pe, latency, pe.Fallbackable())
 			if !pe.Fallbackable() {
 				p.log.Debug("attempt not fallbackable, aborting", "kind", pe.Kind)
 				p.budgetRelease(scope)
@@ -324,6 +331,7 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 			if p.metrics != nil {
 				p.metrics.RecordFallback(string(pe.Kind))
 			}
+			fellBack = true
 			p.log.Warn("chat attempt failed, falling back",
 				"provider", attempt.Target.Provider, "model", attempt.Target.Model, "kind", pe.Kind)
 			continue
@@ -337,12 +345,12 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 		// still costs the user but never returns the leaked content.
 		if gres := p.guardrails.Outbound(ctx, req, resp); gres.Action == guardrails.ActionBlock {
 			p.log.Debug("guardrails blocked outbound", "reason", gres.Reason)
-			cost := p.record(ctx, req.Metadata, attempt, resp.Usage, false, latency, save)
+			cost := p.record(ctx, req.Metadata, attempt, resp.Usage, false, latency, save, fellBack)
 			p.budgetConfirm(scope, cost)
 			return nil, &core.ProviderError{Kind: core.ErrPolicyBlocked, Message: gres.Reason}
 		}
 
-		cost := p.record(ctx, req.Metadata, attempt, resp.Usage, false, latency, save)
+		cost := p.record(ctx, req.Metadata, attempt, resp.Usage, false, latency, save, fellBack)
 		p.cacheStore(ctx, vec, resp)
 		// Confirm budget reservation — usage is now recorded in DB.
 		p.budgetConfirm(scope, cost)
@@ -363,6 +371,7 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 	if lastErr == nil {
 		lastErr = &core.ProviderError{Kind: core.ErrInternal, Message: "pipeline: no attempts executed"}
 	}
+	p.recordFinalFailureTelemetry(req.Metadata, lastErr, fellBack)
 	p.budgetRelease(scope)
 	return nil, lastErr
 }
@@ -498,6 +507,7 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 	required core.CapabilitySet, scope budget.Scope, release limits.ReleaseFunc) (*StreamResult, error, bool) {
 
 	var lastErr error
+	fellBack := false // tracks whether the current request triggered ≥1 fallback
 	for i, attempt := range attempts {
 		attemptReq := cloneForAttempt(req, attempt.Target.Model)
 		started := time.Now()
@@ -552,23 +562,25 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 				body, _, rawErr := ds.StreamRaw(callCtx, attemptReq, attempt.Creds, streamCfg)
 				if rawErr != nil {
 
-					pe := core.AsProviderError(rawErr)
-					lastErr = pe
-					p.dispatcher.NoteFailure(ctx, attempt.Account.ID, pe)
-					if p.metrics != nil {
-						p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
-					}
-					if !pe.Fallbackable() {
-						release(0)
-						p.budgetRelease(scope)
-						return nil, pe, true
-					}
-					if p.metrics != nil {
-						p.metrics.RecordFallback(string(pe.Kind))
-					}
-					p.log.Warn("direct stream attempt failed, falling back",
-						"provider", attempt.Target.Provider, "model", attempt.Target.Model, "kind", pe.Kind)
-					continue
+				pe := core.AsProviderError(rawErr)
+				lastErr = pe
+				p.dispatcher.NoteFailure(ctx, attempt.Account.ID, pe)
+				if p.metrics != nil {
+					p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
+				}
+				p.recordFailureTelemetry(req.Metadata, attempt, pe, time.Since(started), pe.Fallbackable())
+				if !pe.Fallbackable() {
+					release(0)
+					p.budgetRelease(scope)
+					return nil, pe, true
+				}
+			if p.metrics != nil {
+				p.metrics.RecordFallback(string(pe.Kind))
+			}
+			fellBack = true
+			p.log.Warn("direct stream attempt failed, falling back",
+				"provider", attempt.Target.Provider, "model", attempt.Target.Model, "kind", pe.Kind)
+			continue
 				}
 				p.log.Debug("direct stream connected (zero-copy)", "provider", attempt.Target.Provider,
 					"model", attempt.Target.Model)
@@ -592,7 +604,7 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 					defer release(0)
 					usage := extractUsageFromStream(capture.Bytes())
 					totalLatency := time.Since(started)
-					cost := p.recordWithTTFT(ctx, meta, acc, usage, false, totalLatency, ttft, saveCopy)
+					cost := p.recordWithTTFT(ctx, meta, acc, usage, false, totalLatency, ttft, saveCopy, fellBack)
 					p.budgetConfirm(budgetScope, cost)
 				}
 				return &StreamResult{
@@ -615,18 +627,20 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 			if p.metrics != nil {
 				p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
 			}
+			p.recordFailureTelemetry(req.Metadata, attempt, pe, time.Since(started), pe.Fallbackable())
 			if !pe.Fallbackable() {
 				p.log.Debug("stream attempt not fallbackable, aborting", "kind", pe.Kind)
 				release(0)
 				p.budgetRelease(scope)
 				return nil, pe, true
 			}
-			if p.metrics != nil {
-				p.metrics.RecordFallback(string(pe.Kind))
-			}
-			p.log.Warn("stream attempt failed, falling back",
-				"provider", attempt.Target.Provider, "model", attempt.Target.Model, "kind", pe.Kind)
-			continue
+		if p.metrics != nil {
+			p.metrics.RecordFallback(string(pe.Kind))
+		}
+		fellBack = true
+		p.log.Warn("stream attempt failed, falling back",
+			"provider", attempt.Target.Provider, "model", attempt.Target.Model, "kind", pe.Kind)
+		continue
 		}
 
 		p.log.Debug("stream connected", "provider", attempt.Target.Provider,
@@ -638,7 +652,7 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 		out := make(chan core.StreamChunk, 16)
 		meta := req.Metadata
 		acc := attempt
-		go p.pumpStream(ctx, req, upstream, out, meta, acc, started, &ttft, save, scope, release)
+		go p.pumpStream(ctx, req, upstream, out, meta, acc, started, &ttft, save, scope, release, fellBack)
 
 		return &StreamResult{
 			Chunks:    out,
@@ -651,6 +665,7 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 	if lastErr == nil {
 		lastErr = &core.ProviderError{Kind: core.ErrInternal, Message: "pipeline: no attempts executed"}
 	}
+	p.recordFinalFailureTelemetry(req.Metadata, lastErr, fellBack)
 	release(0)
 	p.budgetRelease(scope)
 	return nil, lastErr, true
@@ -670,7 +685,7 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 // tail before forwarding; on a Block decision the stream is cancelled and an
 // error chunk is delivered to the client.
 func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-chan core.StreamChunk, out chan<- core.StreamChunk,
-	meta core.RequestMetadata, attempt dispatch.Attempt, started time.Time, ttft *time.Duration, save *saveState, scope budget.Scope, release limits.ReleaseFunc) {
+	meta core.RequestMetadata, attempt dispatch.Attempt, started time.Time, ttft *time.Duration, save *saveState, scope budget.Scope, release limits.ReleaseFunc, fellBack bool) {
 	defer close(out)
 	defer release(0)
 
@@ -737,10 +752,10 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 		case chunk, ok := <-in:
 			if !ok {
 				// Upstream closed — stream complete.
-				// If the client opted into a usage event (stream_options.
-				// include_usage) but the provider never sent one, synthesize an
-				// estimate so the client still receives a final usage event.
-				// Mirrors 9router's estimateUsage/addBufferToUsage behavior.
+			// If the client opted into a usage event (stream_options.
+			// include_usage) but the provider never sent one, synthesize an
+			// estimate so the client still receives a final usage event.
+			// Mirrors the estimateUsage/addBufferToUsage behavior.
 				if req.IncludeUsage && !sawUsage {
 					est := estimateStreamUsage(req, completionChars)
 					if est.TotalTokens > 0 {
@@ -754,7 +769,7 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 				// Record actual total upstream duration as latency; TTFT is
 				// stored separately in ttft_ms by recordWithTTFT.
 				totalLatency := time.Since(started)
-				cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, totalLatency, *ttft, save)
+				cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, totalLatency, *ttft, save, fellBack)
 				p.budgetConfirm(scope, cost)
 				return
 			}
@@ -793,7 +808,7 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 						for range in {
 						}
 						totalLatency := time.Since(started)
-						cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, totalLatency, *ttft, save)
+				cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, totalLatency, *ttft, save, fellBack)
 						p.budgetConfirm(scope, cost)
 						return
 					}
@@ -829,7 +844,7 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 			for range in {
 			}
 			totalLatency := time.Since(started)
-			cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, totalLatency, *ttft, save)
+			cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, totalLatency, *ttft, save, fellBack)
 			p.budgetConfirm(scope, cost)
 			return
 		}
@@ -1062,6 +1077,7 @@ func (p *Pipeline) applyTokenSaving(ctx context.Context, req *core.ChatRequest, 
 type saveState struct {
 	slimSnap     *meter.SlimSnapshot
 	headroomSnap *meter.HeadroomSnapshot
+	slim         bool
 	caveman      bool
 	terse        bool
 	ponytail     bool
@@ -1094,6 +1110,7 @@ func splitRuleNames(s string) []string {
 // flag mirrors opts.Ponytail.Enabled.
 func buildSaveState(stats *slimmer.Stats, hr *headroom.Stats, opts Options) *saveState {
 	save := &saveState{
+		slim:      opts.Slimmer.Enabled,
 		caveman:  opts.Caveman.Enabled,
 		terse:    opts.Terse.Enabled,
 		ponytail: opts.Ponytail.Enabled,
@@ -1134,13 +1151,100 @@ func buildSaveState(stats *slimmer.Stats, hr *headroom.Stats, opts Options) *sav
 
 // record meters a completed attempt; failures to record are logged, not fatal.
 func (p *Pipeline) record(ctx context.Context, meta core.RequestMetadata, attempt dispatch.Attempt,
-	usage core.Usage, cacheHit bool, latency time.Duration, save *saveState) int64 {
-	return p.recordWithTTFT(ctx, meta, attempt, usage, cacheHit, latency, 0, save)
+	usage core.Usage, cacheHit bool, latency time.Duration, save *saveState, fellBack bool) int64 {
+	return p.recordWithTTFT(ctx, meta, attempt, usage, cacheHit, latency, 0, save, fellBack)
+}
+
+// recordSuccessTelemetry emits a best-effort health telemetry event for a
+// successful upstream attempt. fellBack reports whether the request triggered
+// at least one fallback before succeeding, so the chain-impact view computes
+// an accurate fallback rate per request (not per attempt).
+func (p *Pipeline) recordSuccessTelemetry(meta core.RequestMetadata, attempt dispatch.Attempt,
+	usage core.Usage, latency, ttft time.Duration, fellBack bool) {
+	if p.telemetry == nil {
+		return
+	}
+	ev := health.ProviderTelemetryEvent{
+		Timestamp:         time.Now(),
+		Provider:          attempt.Target.Provider,
+		ProviderAccountID: attempt.Account.ID,
+		Model:             attempt.Target.Model,
+		Capability:        capabilityOf(attempt.Target.Provider, attempt.Target.Model),
+		Status:            "success",
+		LatencyMs:         int(latency.Milliseconds()),
+		TTFTMs:            int(ttft.Milliseconds()),
+		InputTokens:       usage.PromptTokens,
+		OutputTokens:      usage.CompletionTokens,
+		ChainID:           meta.ChainID,
+		FallbackTriggered: fellBack,
+	}
+	p.telemetry.Record(ev)
+}
+
+// recordFailureTelemetry emits a best-effort health telemetry event for a
+// failed upstream attempt. fallbackable reports whether the dispatcher
+// advanced to the next candidate (i.e. fallback was triggered).
+func (p *Pipeline) recordFailureTelemetry(meta core.RequestMetadata, attempt dispatch.Attempt,
+	pe *core.ProviderError, latency time.Duration, fallbackable bool) {
+	if p.telemetry == nil || pe == nil {
+		return
+	}
+	ev := health.ProviderTelemetryEvent{
+		Timestamp:         time.Now(),
+		Provider:          attempt.Target.Provider,
+		ProviderAccountID: attempt.Account.ID,
+		Model:             attempt.Target.Model,
+		Capability:        capabilityOf(attempt.Target.Provider, attempt.Target.Model),
+		Status:            "failed",
+		HTTPStatus:        pe.StatusCode,
+		LatencyMs:         int(latency.Milliseconds()),
+		ErrorType:         health.ClassifyError(pe),
+		ErrorMessage:      pe.Message,
+		ChainID:           meta.ChainID,
+		FallbackTriggered: fallbackable,
+	}
+	p.telemetry.Record(ev)
+}
+
+// recordFinalFailureTelemetry emits a best-effort health telemetry event when
+// all attempts in a chain have failed, so the chain-impact view can count
+// final failures (requests lost after every fallback).
+func (p *Pipeline) recordFinalFailureTelemetry(meta core.RequestMetadata, lastErr error, fellBack bool) {
+	if p.telemetry == nil || lastErr == nil {
+		return
+	}
+	pe, _ := lastErr.(*core.ProviderError)
+	if pe == nil {
+		pe = core.AsProviderError(lastErr)
+	}
+	ev := health.ProviderTelemetryEvent{
+		Timestamp:         time.Now(),
+		Provider:          pe.Provider,
+		Model:             pe.Model,
+		Capability:        capabilityOf(pe.Provider, pe.Model),
+		Status:            "failed",
+		HTTPStatus:        pe.StatusCode,
+		ErrorType:         health.ClassifyError(pe),
+		ErrorMessage:      pe.Message,
+		ChainID:           meta.ChainID,
+		FinalFailure:      true,
+		FallbackTriggered: fellBack,
+	}
+	p.telemetry.Record(ev)
+}
+
+// capabilityOf derives the capability label for a target. KeiRouter routes by
+// service kind, but telemetry keys on a stable capability string; default to
+// chat_completions for LLM models.
+func capabilityOf(provider, model string) string {
+	_ = provider
+	_ = model
+	return "chat_completions"
 }
 
 // recordWithTTFT is like record but also records time-to-first-token.
 func (p *Pipeline) recordWithTTFT(ctx context.Context, meta core.RequestMetadata, attempt dispatch.Attempt,
-	usage core.Usage, cacheHit bool, latency, ttft time.Duration, save *saveState) int64 {
+	usage core.Usage, cacheHit bool, latency, ttft time.Duration, save *saveState, fellBack bool) int64 {
 	if p.meter == nil {
 		return 0
 	}
@@ -1159,6 +1263,7 @@ func (p *Pipeline) recordWithTTFT(ctx context.Context, meta core.RequestMetadata
 	}
 	if save != nil {
 		ev.SlimStats = save.slimSnap
+		ev.SlimActive = save.slim
 		ev.CavemanActive = save.caveman
 		ev.TerseActive = save.terse
 		ev.HeadroomStats = save.headroomSnap
@@ -1167,6 +1272,10 @@ func (p *Pipeline) recordWithTTFT(ctx context.Context, meta core.RequestMetadata
 	cost, err := p.meter.Record(ctx, ev)
 	if err != nil {
 		p.log.Error("failed to record usage", "err", err)
+	}
+	// Best-effort provider health telemetry (non-blocking, never fails).
+	if !cacheHit {
+		p.recordSuccessTelemetry(meta, attempt, usage, latency, ttft, fellBack)
 	}
 
 	if p.metrics != nil {

--- a/backend/internal/store/migrations/0023_custom_model_source.sql
+++ b/backend/internal/store/migrations/0023_custom_model_source.sql
@@ -1,0 +1,4 @@
+-- Distinguish user-entered custom models from models imported via the
+-- /models discovery endpoint. Imported models populate the "Available Models"
+-- catalog only; the "Custom Models" section shows manual entries exclusively.
+ALTER TABLE custom_models ADD COLUMN source TEXT NOT NULL DEFAULT 'manual';

--- a/backend/internal/store/migrations/0024_slim_active.sql
+++ b/backend/internal/store/migrations/0024_slim_active.sql
@@ -1,0 +1,5 @@
+-- Add slim_active flag to usage_records so the RTK badge reflects whether the
+-- slimmer was enabled for the request, independent of bytes saved (matches the
+-- caveman_active / terse_active semantics). DEFAULT0 keeps old records backward
+-- compatible (they read as inactive).
+ALTER TABLE usage_records ADD COLUMN slim_active INTEGER NOT NULL DEFAULT 0;

--- a/backend/internal/store/migrations/0025_provider_health.sql
+++ b/backend/internal/store/migrations/0025_provider_health.sql
@@ -1,0 +1,104 @@
+-- Actionable provider health dashboard: current state, historical snapshots,
+-- and synthetic probe results. See docs/spec provider-health-dashboard.
+--
+-- Portable across SQLite and PostgreSQL: TEXT ids/timestamps (RFC3339),
+-- INTEGER counters, REAL rates. Nullable dimensions use '' (empty string)
+-- rather than NULL so UNIQUE constraints behave identically across engines.
+
+-- Current rolled-up health per provider/account/model/capability key.
+-- Updated by both the telemetry aggregator (real traffic) and the probe
+-- worker (synthetic probes). Fast lookup for the dashboard overview.
+CREATE TABLE IF NOT EXISTS provider_health_current (
+    id TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    provider_account_id TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL DEFAULT '',
+    capability TEXT NOT NULL DEFAULT '',
+    health_status TEXT NOT NULL DEFAULT 'unknown',
+    health_score INTEGER NOT NULL DEFAULT 100,
+    success_rate REAL NOT NULL DEFAULT 0,
+    error_rate REAL NOT NULL DEFAULT 0,
+    request_count INTEGER NOT NULL DEFAULT 0,
+    fallback_count INTEGER NOT NULL DEFAULT 0,
+    latency_p95_ms INTEGER,
+    ttft_p95_ms INTEGER,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    main_issue TEXT,
+    recommendation TEXT,
+    last_success_at TEXT,
+    last_failure_at TEXT,
+    last_probe_at TEXT,
+    last_updated_at TEXT NOT NULL,
+    health_key TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_health_current_status ON provider_health_current(health_status);
+CREATE INDEX IF NOT EXISTS idx_provider_health_current_provider ON provider_health_current(provider);
+
+-- Aggregated health buckets for historical charts and trend analysis.
+-- One row per (bucket_start, provider, account, model, capability).
+CREATE TABLE IF NOT EXISTS provider_health_snapshots (
+    id TEXT PRIMARY KEY,
+    bucket_start TEXT NOT NULL,
+    bucket_size_seconds INTEGER NOT NULL,
+    provider TEXT NOT NULL,
+    provider_account_id TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL DEFAULT '',
+    capability TEXT NOT NULL DEFAULT '',
+    request_count INTEGER NOT NULL DEFAULT 0,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    failure_count INTEGER NOT NULL DEFAULT 0,
+    fallback_count INTEGER NOT NULL DEFAULT 0,
+    final_failure_count INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_microusd INTEGER NOT NULL DEFAULT 0,
+    latency_p50_ms INTEGER,
+    latency_p95_ms INTEGER,
+    latency_p99_ms INTEGER,
+    ttft_p50_ms INTEGER,
+    ttft_p95_ms INTEGER,
+    ttft_p99_ms INTEGER,
+    rate_limited_count INTEGER NOT NULL DEFAULT 0,
+    auth_error_count INTEGER NOT NULL DEFAULT 0,
+    quota_exceeded_count INTEGER NOT NULL DEFAULT 0,
+    timeout_count INTEGER NOT NULL DEFAULT 0,
+    provider_5xx_count INTEGER NOT NULL DEFAULT 0,
+    bad_request_count INTEGER NOT NULL DEFAULT 0,
+    network_error_count INTEGER NOT NULL DEFAULT 0,
+    unsupported_count INTEGER NOT NULL DEFAULT 0,
+    unknown_error_count INTEGER NOT NULL DEFAULT 0,
+    health_score INTEGER NOT NULL DEFAULT 100,
+    health_status TEXT NOT NULL DEFAULT 'unknown',
+    main_issue TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_health_snapshots_lookup
+    ON provider_health_snapshots(bucket_start, provider, provider_account_id, model, capability);
+CREATE INDEX IF NOT EXISTS idx_provider_health_snapshots_status
+    ON provider_health_snapshots(health_status, bucket_start);
+
+-- Synthetic probe results (scheduled + manual). Drives the probe history page
+-- and feeds provider_health_current when no real traffic exists.
+CREATE TABLE IF NOT EXISTS provider_probe_results (
+    id TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    provider_account_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    capability TEXT NOT NULL,
+    status TEXT NOT NULL,
+    http_status INTEGER,
+    latency_ms INTEGER,
+    ttft_ms INTEGER,
+    error_type TEXT,
+    error_message TEXT,
+    prompt_tokens INTEGER,
+    completion_tokens INTEGER,
+    estimated_cost_microusd INTEGER,
+    triggered_by TEXT NOT NULL DEFAULT 'scheduled',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_probe_results_lookup
+    ON provider_probe_results(created_at, provider, provider_account_id, model, capability);

--- a/backend/internal/store/models.go
+++ b/backend/internal/store/models.go
@@ -141,6 +141,7 @@ type UsageRecord struct {
 	SlimBytesSaved   int    // bytes removed by RTK slimmer (input-side compression)
 	SlimTokensSaved  int    // estimated tokens saved by RTK (bytes/4)
 	SlimRules        string // comma-separated rule names that fired (e.g. "git-diff,grep")
+	SlimActive       bool   // RTK slimmer was enabled for this request
 	CavemanActive    bool   // caveman output compression was active
 	TerseActive      bool   // terse output compression was active
 
@@ -359,4 +360,89 @@ type ResourceBucket struct {
 
 	InflightAvg float64
 	InflightMax int64
+}
+
+// ProviderHealthCurrent is the rolled-up current health state for one
+// provider/account/model/capability key. It is updated by both real-traffic
+// telemetry aggregation and synthetic probes for fast dashboard loading.
+type ProviderHealthCurrent struct {
+	ID                  string     `json:"id"`
+	Provider            string     `json:"provider"`
+	ProviderAccountID   string     `json:"provider_account_id"`
+	Model               string     `json:"model"`
+	Capability          string     `json:"capability"`
+	HealthStatus        string     `json:"health_status"` // healthy | degraded | unhealthy | unknown | disabled
+	HealthScore         int        `json:"health_score"`
+	SuccessRate         float64    `json:"success_rate"`  // 0-1
+	ErrorRate           float64    `json:"error_rate"`    // 0-1
+	RequestCount        int64      `json:"request_count"`
+	FallbackCount       int64      `json:"fallback_count"`
+	LatencyP95Ms        *int       `json:"latency_p95_ms"`
+	TTFTP95Ms           *int       `json:"ttft_p95_ms"`
+	ConsecutiveFailures int        `json:"consecutive_failures"`
+	MainIssue           *string    `json:"main_issue"`
+	Recommendation      *string    `json:"recommendation"`
+	LastSuccessAt       *time.Time `json:"last_success_at"`
+	LastFailureAt       *time.Time `json:"last_failure_at"`
+	LastProbeAt         *time.Time `json:"last_probe_at"`
+	LastUpdatedAt       time.Time  `json:"last_updated_at"`
+}
+
+// ProviderHealthSnapshot is one aggregated time bucket of provider health,
+// stored for historical charts and trend analysis.
+type ProviderHealthSnapshot struct {
+	ID                  string     `json:"id"`
+	BucketStart         time.Time  `json:"bucket_start"`
+	BucketSizeSeconds   int        `json:"bucket_size_seconds"`
+	Provider            string     `json:"provider"`
+	ProviderAccountID   string     `json:"provider_account_id"`
+	Model               string     `json:"model"`
+	Capability          string     `json:"capability"`
+	RequestCount        int64      `json:"request_count"`
+	SuccessCount        int64      `json:"success_count"`
+	FailureCount        int64      `json:"failure_count"`
+	FallbackCount       int64      `json:"fallback_count"`
+	FinalFailureCount   int64      `json:"final_failure_count"`
+	InputTokens         int64      `json:"input_tokens"`
+	OutputTokens        int64      `json:"output_tokens"`
+	EstimatedCostMicros int64      `json:"estimated_cost_microusd"`
+	LatencyP50Ms        *int       `json:"latency_p50_ms"`
+	LatencyP95Ms        *int       `json:"latency_p95_ms"`
+	LatencyP99Ms        *int       `json:"latency_p99_ms"`
+	TTFTP50Ms           *int       `json:"ttft_p50_ms"`
+	TTFTP95Ms           *int       `json:"ttft_p95_ms"`
+	TTFTP99Ms           *int       `json:"ttft_p99_ms"`
+	RateLimitedCount    int64      `json:"rate_limited_count"`
+	AuthErrorCount      int64      `json:"auth_error_count"`
+	QuotaExceededCount  int64      `json:"quota_exceeded_count"`
+	TimeoutCount        int64      `json:"timeout_count"`
+	Provider5xxCount    int64      `json:"provider_5xx_count"`
+	BadRequestCount     int64      `json:"bad_request_count"`
+	NetworkErrorCount   int64      `json:"network_error_count"`
+	UnsupportedCount    int64      `json:"unsupported_count"`
+	UnknownErrorCount   int64      `json:"unknown_error_count"`
+	HealthScore         int        `json:"health_score"`
+	HealthStatus        string     `json:"health_status"`
+	MainIssue           *string    `json:"main_issue"`
+	CreatedAt           time.Time  `json:"created_at"`
+}
+
+// ProviderProbeResult is one synthetic probe outcome (scheduled or manual).
+type ProviderProbeResult struct {
+	ID                  string     `json:"id"`
+	Provider            string     `json:"provider"`
+	ProviderAccountID   string     `json:"provider_account_id"`
+	Model               string     `json:"model"`
+	Capability          string     `json:"capability"`
+	Status              string     `json:"status"` // success | failed
+	HTTPStatus          *int       `json:"http_status"`
+	LatencyMs           *int       `json:"latency_ms"`
+	TTFTMs              *int       `json:"ttft_ms"`
+	ErrorType           *string    `json:"error_type"`
+	ErrorMessage        *string    `json:"error_message"`
+	PromptTokens        *int       `json:"prompt_tokens"`
+	CompletionTokens    *int       `json:"completion_tokens"`
+	EstimatedCostMicros *int64     `json:"estimated_cost_microusd"`
+	TriggeredBy         string     `json:"triggered_by"` // scheduled | manual | after_failure | startup
+	CreatedAt           time.Time  `json:"created_at"`
 }

--- a/backend/internal/store/repo_custom_providers.go
+++ b/backend/internal/store/repo_custom_providers.go
@@ -40,6 +40,7 @@ type CustomModel struct {
 	ContextWindow int
 	InputPerM     float64
 	OutputPerM    float64
+	Source        string // "manual" (user-entered) | "imported" (from /models)
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }
@@ -125,7 +126,7 @@ func (r *CustomProviderRepo) DeleteProvider(ctx context.Context, id string) erro
 	return tx.Commit()
 }
 
-const customModelColumns = `id, tenant_id, provider_id, model_id, display_name, kind, context_window, input_per_m, output_per_m, created_at, updated_at`
+const customModelColumns = `id, tenant_id, provider_id, model_id, display_name, kind, context_window, input_per_m, output_per_m, source, created_at, updated_at`
 
 // ListModels returns all custom models for a tenant.
 func (r *CustomProviderRepo) ListModels(ctx context.Context, tenantID string) ([]CustomModel, error) {
@@ -167,14 +168,42 @@ func (r *CustomProviderRepo) ListModelsByProvider(ctx context.Context, providerI
 	return out, rows.Err()
 }
 
+// ListManualModelsByProvider returns only user-entered custom models (source =
+// "manual") for a provider. Imported models from /models are excluded — they
+// surface in the Available Models catalog, not the editable Custom Models list.
+func (r *CustomProviderRepo) ListManualModelsByProvider(ctx context.Context, providerID string) ([]CustomModel, error) {
+	q := r.db.rebind(`SELECT ` + customModelColumns + ` FROM custom_models
+		WHERE provider_id = ? AND (source = 'manual' OR source = '')
+		ORDER BY model_id`)
+	rows, err := r.db.sql.QueryContext(ctx, q, providerID)
+	if err != nil {
+		return nil, fmt.Errorf("store: list manual custom models by provider: %w", err)
+	}
+	defer rows.Close()
+
+	var out[]CustomModel
+	for rows.Next() {
+		m, err := scanCustomModel(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
 // CreateModel inserts a custom model.
 func (r *CustomProviderRepo) CreateModel(ctx context.Context, m CustomModel) error {
 	now := formatTime(time.Now())
+	source := m.Source
+	if source == "" {
+		source = "manual"
+	}
 	q := r.db.rebind(`INSERT INTO custom_models (` + customModelColumns + `)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	_, err := r.db.sql.ExecContext(ctx, q,
 		m.ID, m.TenantID, m.ProviderID, m.ModelID, m.DisplayName, m.Kind,
-		m.ContextWindow, m.InputPerM, m.OutputPerM, now, now)
+		m.ContextWindow, m.InputPerM, m.OutputPerM, source, now, now)
 	if err != nil {
 		return fmt.Errorf("store: create custom model: %w", err)
 	}
@@ -244,7 +273,7 @@ func scanCustomModel(s scanner) (CustomModel, error) {
 	var m CustomModel
 	var created, updated string
 	if err := s.Scan(&m.ID, &m.TenantID, &m.ProviderID, &m.ModelID, &m.DisplayName, &m.Kind,
-		&m.ContextWindow, &m.InputPerM, &m.OutputPerM, &created, &updated); err != nil {
+		&m.ContextWindow, &m.InputPerM, &m.OutputPerM, &m.Source, &created, &updated); err != nil {
 		return CustomModel{}, err
 	}
 	m.CreatedAt = parseTime(created)

--- a/backend/internal/store/repo_provider_health.go
+++ b/backend/internal/store/repo_provider_health.go
@@ -1,0 +1,441 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// ProviderHealthRepo persists actionable provider health state: current
+// rolled-up status, historical snapshots, and synthetic probe results.
+type ProviderHealthRepo struct{ db *DB }
+
+// ProviderHealth returns the actionable provider health repository.
+func (db *DB) ProviderHealth() *ProviderHealthRepo { return &ProviderHealthRepo{db: db} }
+
+const providerHealthCurrentColumns = `id, provider, provider_account_id, model, capability,
+	health_status, health_score, success_rate, error_rate, request_count,
+	fallback_count, latency_p95_ms, ttft_p95_ms, consecutive_failures,
+	main_issue, recommendation, last_success_at, last_failure_at,
+	last_probe_at, last_updated_at`
+
+// HealthKey builds the deterministic unique key for a health dimension tuple.
+// Empty dimensions collapse to '' so SQLite and PostgreSQL treat NULLs
+// identically under the UNIQUE constraint.
+func HealthKey(provider, account, model, capability string) string {
+	return provider + ":" + account + ":" + model + ":" + capability
+}
+
+// UpsertCurrent inserts or replaces a current health row keyed by health_key.
+func (r *ProviderHealthRepo) UpsertCurrent(ctx context.Context, c ProviderHealthCurrent) error {
+	if c.ID == "" {
+		return fmt.Errorf("store: provider health current: missing id")
+	}
+	key := HealthKey(c.Provider, c.ProviderAccountID, c.Model, c.Capability)
+	q := r.db.rebind(`INSERT INTO provider_health_current (` + providerHealthCurrentColumns + `, health_key)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(health_key) DO UPDATE SET
+			id = excluded.id,
+			provider = excluded.provider,
+			provider_account_id = excluded.provider_account_id,
+			model = excluded.model,
+			capability = excluded.capability,
+			health_status = excluded.health_status,
+			health_score = excluded.health_score,
+			success_rate = excluded.success_rate,
+			error_rate = excluded.error_rate,
+			request_count = excluded.request_count,
+			fallback_count = excluded.fallback_count,
+			latency_p95_ms = excluded.latency_p95_ms,
+			ttft_p95_ms = excluded.ttft_p95_ms,
+			consecutive_failures = excluded.consecutive_failures,
+			main_issue = excluded.main_issue,
+			recommendation = excluded.recommendation,
+			last_success_at = excluded.last_success_at,
+			last_failure_at = excluded.last_failure_at,
+			last_probe_at = excluded.last_probe_at,
+			last_updated_at = excluded.last_updated_at`)
+	_, err := r.db.sql.ExecContext(ctx, q,
+		c.ID, c.Provider, c.ProviderAccountID, c.Model, c.Capability,
+		c.HealthStatus, c.HealthScore, c.SuccessRate, c.ErrorRate, c.RequestCount,
+		c.FallbackCount, nullIntPtr(c.LatencyP95Ms), nullIntPtr(c.TTFTP95Ms), c.ConsecutiveFailures,
+		nullStringPtr(c.MainIssue), nullStringPtr(c.Recommendation),
+		nullTime(c.LastSuccessAt), nullTime(c.LastFailureAt), nullTime(c.LastProbeAt),
+		formatTime(c.LastUpdatedAt), key)
+	if err != nil {
+		return fmt.Errorf("store: upsert provider health current: %w", err)
+	}
+	return nil
+}
+
+// GetCurrent fetches one current health row by dimension tuple.
+func (r *ProviderHealthRepo) GetCurrent(ctx context.Context, provider, account, model, capability string) (ProviderHealthCurrent, error) {
+	q := r.db.rebind(`SELECT ` + providerHealthCurrentColumns + ` FROM provider_health_current WHERE health_key = ?`)
+	key := HealthKey(provider, account, model, capability)
+	row, err := scanProviderHealthCurrent(r.db.sql.QueryRowContext(ctx, q, key).Scan)
+	if err == sql.ErrNoRows {
+		return ProviderHealthCurrent{}, ErrNotFound
+	}
+	if err != nil {
+		return ProviderHealthCurrent{}, fmt.Errorf("store: get provider health current: %w", err)
+	}
+	return row, nil
+}
+
+// ListCurrent returns all current health rows, optionally filtered by status.
+func (r *ProviderHealthRepo) ListCurrent(ctx context.Context, status string) ([]ProviderHealthCurrent, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if status != "" {
+		q := r.db.rebind(`SELECT ` + providerHealthCurrentColumns + ` FROM provider_health_current WHERE health_status = ? ORDER BY provider, model`)
+		rows, err = r.db.sql.QueryContext(ctx, q, status)
+	} else {
+		q := r.db.rebind(`SELECT ` + providerHealthCurrentColumns + ` FROM provider_health_current ORDER BY provider, model`)
+		rows, err = r.db.sql.QueryContext(ctx, q)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("store: list provider health current: %w", err)
+	}
+	defer rows.Close()
+	var out []ProviderHealthCurrent
+	for rows.Next() {
+		h, err := scanProviderHealthCurrent(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
+// ListCurrentByProvider returns current health rows for one provider.
+func (r *ProviderHealthRepo) ListCurrentByProvider(ctx context.Context, provider string) ([]ProviderHealthCurrent, error) {
+	q := r.db.rebind(`SELECT ` + providerHealthCurrentColumns + ` FROM provider_health_current WHERE provider = ? ORDER BY model, provider_account_id`)
+	rows, err := r.db.sql.QueryContext(ctx, q, provider)
+	if err != nil {
+		return nil, fmt.Errorf("store: list provider health current by provider: %w", err)
+	}
+	defer rows.Close()
+	var out []ProviderHealthCurrent
+	for rows.Next() {
+		h, err := scanProviderHealthCurrent(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
+// UpdateProbeTimestamp marks the last probe time for a health key without
+// clobbering traffic-derived fields. Used when real traffic already populates
+// the row and a probe merely refreshes last_probe_at.
+func (r *ProviderHealthRepo) UpdateProbeTimestamp(ctx context.Context, provider, account, model, capability string, at time.Time) error {
+	key := HealthKey(provider, account, model, capability)
+	q := r.db.rebind(`UPDATE provider_health_current SET last_probe_at = ?, last_updated_at = ? WHERE health_key = ?`)
+	_, err := r.db.sql.ExecContext(ctx, q, formatTime(at), formatTime(at), key)
+	if err != nil {
+		return fmt.Errorf("store: update probe timestamp: %w", err)
+	}
+	return nil
+}
+
+// InsertSnapshot writes one aggregated historical bucket.
+func (r *ProviderHealthRepo) InsertSnapshot(ctx context.Context, s ProviderHealthSnapshot) error {
+	if s.ID == "" {
+		return fmt.Errorf("store: provider health snapshot: missing id")
+	}
+	q := r.db.rebind(`INSERT INTO provider_health_snapshots (id, bucket_start, bucket_size_seconds,
+		provider, provider_account_id, model, capability,
+		request_count, success_count, failure_count, fallback_count, final_failure_count,
+		input_tokens, output_tokens, estimated_cost_microusd,
+		latency_p50_ms, latency_p95_ms, latency_p99_ms,
+		ttft_p50_ms, ttft_p95_ms, ttft_p99_ms,
+		rate_limited_count, auth_error_count, quota_exceeded_count, timeout_count,
+		provider_5xx_count, bad_request_count, network_error_count, unsupported_count, unknown_error_count,
+		health_score, health_status, main_issue, created_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
+	_, err := r.db.sql.ExecContext(ctx, q,
+		s.ID, formatTime(s.BucketStart), s.BucketSizeSeconds,
+		s.Provider, s.ProviderAccountID, s.Model, s.Capability,
+		s.RequestCount, s.SuccessCount, s.FailureCount, s.FallbackCount, s.FinalFailureCount,
+		s.InputTokens, s.OutputTokens, s.EstimatedCostMicros,
+		nullIntPtr(s.LatencyP50Ms), nullIntPtr(s.LatencyP95Ms), nullIntPtr(s.LatencyP99Ms),
+		nullIntPtr(s.TTFTP50Ms), nullIntPtr(s.TTFTP95Ms), nullIntPtr(s.TTFTP99Ms),
+		s.RateLimitedCount, s.AuthErrorCount, s.QuotaExceededCount, s.TimeoutCount,
+		s.Provider5xxCount, s.BadRequestCount, s.NetworkErrorCount, s.UnsupportedCount, s.UnknownErrorCount,
+		s.HealthScore, s.HealthStatus, nullStringPtr(s.MainIssue), formatTime(s.CreatedAt))
+	if err != nil {
+		return fmt.Errorf("store: insert provider health snapshot: %w", err)
+	}
+	return nil
+}
+
+// ListSnapshots returns aggregated buckets within [since, now] for a dimension
+// tuple. Empty provider/model/capability match any (wildcard via COALESCE).
+func (r *ProviderHealthRepo) ListSnapshots(ctx context.Context, provider, account, model, capability string, since time.Time) ([]ProviderHealthSnapshot, error) {
+	q := r.db.rebind(`SELECT id, bucket_start, bucket_size_seconds,
+		provider, provider_account_id, model, capability,
+		request_count, success_count, failure_count, fallback_count, final_failure_count,
+		input_tokens, output_tokens, estimated_cost_microusd,
+		latency_p50_ms, latency_p95_ms, latency_p99_ms,
+		ttft_p50_ms, ttft_p95_ms, ttft_p99_ms,
+		rate_limited_count, auth_error_count, quota_exceeded_count, timeout_count,
+		provider_5xx_count, bad_request_count, network_error_count, unsupported_count, unknown_error_count,
+		health_score, health_status, main_issue, created_at
+		FROM provider_health_snapshots
+		WHERE bucket_start >= ? AND provider = ?
+		ORDER BY bucket_start ASC`)
+	rows, err := r.db.sql.QueryContext(ctx, q, formatTime(since), provider)
+	if err != nil {
+		return nil, fmt.Errorf("store: list provider health snapshots: %w", err)
+	}
+	defer rows.Close()
+	var out []ProviderHealthSnapshot
+	for rows.Next() {
+		s, err := scanProviderHealthSnapshot(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		if account != "" && s.ProviderAccountID != account {
+			continue
+		}
+		if model != "" && s.Model != model {
+			continue
+		}
+		if capability != "" && s.Capability != capability {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// InsertProbeResult records one synthetic probe outcome.
+func (r *ProviderHealthRepo) InsertProbeResult(ctx context.Context, p ProviderProbeResult) error {
+	if p.ID == "" {
+		return fmt.Errorf("store: provider probe result: missing id")
+	}
+	q := r.db.rebind(`INSERT INTO provider_probe_results (id, provider, provider_account_id, model, capability,
+		status, http_status, latency_ms, ttft_ms, error_type, error_message,
+		prompt_tokens, completion_tokens, estimated_cost_microusd, triggered_by, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	_, err := r.db.sql.ExecContext(ctx, q,
+		p.ID, p.Provider, p.ProviderAccountID, p.Model, p.Capability,
+		p.Status, nullIntPtr(p.HTTPStatus), nullIntPtr(p.LatencyMs), nullIntPtr(p.TTFTMs),
+		nullStringPtr(p.ErrorType), nullStringPtr(p.ErrorMessage),
+		nullIntPtr(p.PromptTokens), nullIntPtr(p.CompletionTokens), nullInt64Ptr(p.EstimatedCostMicros),
+		p.TriggeredBy, formatTime(p.CreatedAt))
+	if err != nil {
+		return fmt.Errorf("store: insert provider probe result: %w", err)
+	}
+	return nil
+}
+
+// ListProbeResults returns probe results ordered newest-first, filtered by
+// provider and a time window. Pagination via limit/offset.
+func (r *ProviderHealthRepo) ListProbeResults(ctx context.Context, provider string, since time.Time, limit, offset int) ([]ProviderProbeResult, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if provider != "" {
+		q := r.db.rebind(`SELECT id, provider, provider_account_id, model, capability,
+			status, http_status, latency_ms, ttft_ms, error_type, error_message,
+			prompt_tokens, completion_tokens, estimated_cost_microusd, triggered_by, created_at
+			FROM provider_probe_results
+			WHERE created_at >= ? AND provider = ?
+			ORDER BY created_at DESC LIMIT ? OFFSET ?`)
+		rows, err = r.db.sql.QueryContext(ctx, q, formatTime(since), provider, limit, offset)
+	} else {
+		q := r.db.rebind(`SELECT id, provider, provider_account_id, model, capability,
+			status, http_status, latency_ms, ttft_ms, error_type, error_message,
+			prompt_tokens, completion_tokens, estimated_cost_microusd, triggered_by, created_at
+			FROM provider_probe_results
+			WHERE created_at >= ?
+			ORDER BY created_at DESC LIMIT ? OFFSET ?`)
+		rows, err = r.db.sql.QueryContext(ctx, q, formatTime(since), limit, offset)
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("store: list provider probe results: %w", err)
+	}
+	defer rows.Close()
+	var out []ProviderProbeResult
+	for rows.Next() {
+		p, err := scanProviderProbeResult(rows.Scan)
+		if err != nil {
+			return nil, 0, err
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	// Total count for pagination.
+	var total int
+	countQ := r.db.rebind(`SELECT COUNT(*) FROM provider_probe_results WHERE created_at >= ?`)
+	countArgs := []any{formatTime(since)}
+	if provider != "" {
+		countQ = r.db.rebind(`SELECT COUNT(*) FROM provider_probe_results WHERE created_at >= ? AND provider = ?`)
+		countArgs = append(countArgs, provider)
+	}
+	if err := r.db.sql.QueryRowContext(ctx, countQ, countArgs...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("store: count provider probe results: %w", err)
+	}
+	return out, total, nil
+}
+
+// --- scanners ---------------------------------------------------------------
+
+func scanProviderHealthCurrent(scan func(dest ...any) error) (ProviderHealthCurrent, error) {
+	var (
+		c                                   ProviderHealthCurrent
+		latencyP95, ttftP95                 sql.NullInt64
+		mainIssue, recommendation           sql.NullString
+		lastSuccess, lastFailure, lastProbe sql.NullString
+		lastUpdated                          string
+	)
+	if err := scan(
+		&c.ID, &c.Provider, &c.ProviderAccountID, &c.Model, &c.Capability,
+		&c.HealthStatus, &c.HealthScore, &c.SuccessRate, &c.ErrorRate, &c.RequestCount,
+		&c.FallbackCount, &latencyP95, &ttftP95, &c.ConsecutiveFailures,
+		&mainIssue, &recommendation, &lastSuccess, &lastFailure, &lastProbe, &lastUpdated,
+	); err != nil {
+		return ProviderHealthCurrent{}, err
+	}
+	if latencyP95.Valid {
+		v := int(latencyP95.Int64)
+		c.LatencyP95Ms = &v
+	}
+	if ttftP95.Valid {
+		v := int(ttftP95.Int64)
+		c.TTFTP95Ms = &v
+	}
+	if mainIssue.Valid {
+		s := mainIssue.String
+		c.MainIssue = &s
+	}
+	if recommendation.Valid {
+		s := recommendation.String
+		c.Recommendation = &s
+	}
+	if lastSuccess.Valid {
+		t := parseTime(lastSuccess.String)
+		c.LastSuccessAt = &t
+	}
+	if lastFailure.Valid {
+		t := parseTime(lastFailure.String)
+		c.LastFailureAt = &t
+	}
+	if lastProbe.Valid {
+		t := parseTime(lastProbe.String)
+		c.LastProbeAt = &t
+	}
+	c.LastUpdatedAt = parseTime(lastUpdated)
+	return c, nil
+}
+
+func scanProviderHealthSnapshot(scan func(dest ...any) error) (ProviderHealthSnapshot, error) {
+	var (
+		s                            ProviderHealthSnapshot
+		bucketStart, createdAt       string
+		mainIssue                    sql.NullString
+		lp50, lp95, lp99, tp50, tp95, tp99 sql.NullInt64
+	)
+	if err := scan(
+		&s.ID, &bucketStart, &s.BucketSizeSeconds,
+		&s.Provider, &s.ProviderAccountID, &s.Model, &s.Capability,
+		&s.RequestCount, &s.SuccessCount, &s.FailureCount, &s.FallbackCount, &s.FinalFailureCount,
+		&s.InputTokens, &s.OutputTokens, &s.EstimatedCostMicros,
+		&lp50, &lp95, &lp99, &tp50, &tp95, &tp99,
+		&s.RateLimitedCount, &s.AuthErrorCount, &s.QuotaExceededCount, &s.TimeoutCount,
+		&s.Provider5xxCount, &s.BadRequestCount, &s.NetworkErrorCount, &s.UnsupportedCount, &s.UnknownErrorCount,
+		&s.HealthScore, &s.HealthStatus, &mainIssue, &createdAt,
+	); err != nil {
+		return ProviderHealthSnapshot{}, err
+	}
+	s.BucketStart = parseTime(bucketStart)
+	s.CreatedAt = parseTime(createdAt)
+	if mainIssue.Valid {
+		v := mainIssue.String
+		s.MainIssue = &v
+	}
+	assignIntPtr(lp50, &s.LatencyP50Ms)
+	assignIntPtr(lp95, &s.LatencyP95Ms)
+	assignIntPtr(lp99, &s.LatencyP99Ms)
+	assignIntPtr(tp50, &s.TTFTP50Ms)
+	assignIntPtr(tp95, &s.TTFTP95Ms)
+	assignIntPtr(tp99, &s.TTFTP99Ms)
+	return s, nil
+}
+
+func scanProviderProbeResult(scan func(dest ...any) error) (ProviderProbeResult, error) {
+	var (
+		p                                                  ProviderProbeResult
+		httpStatus, latencyMs, ttftMs, promptTok, compTok  sql.NullInt64
+		costMicros                                         sql.NullInt64
+		errType, errMsg                                    sql.NullString
+		createdAt                                          string
+	)
+	if err := scan(
+		&p.ID, &p.Provider, &p.ProviderAccountID, &p.Model, &p.Capability,
+		&p.Status, &httpStatus, &latencyMs, &ttftMs, &errType, &errMsg,
+		&promptTok, &compTok, &costMicros, &p.TriggeredBy, &createdAt,
+	); err != nil {
+		return ProviderProbeResult{}, err
+	}
+	assignIntPtr(httpStatus, &p.HTTPStatus)
+	assignIntPtr(latencyMs, &p.LatencyMs)
+	assignIntPtr(ttftMs, &p.TTFTMs)
+	assignIntPtr(promptTok, &p.PromptTokens)
+	assignIntPtr(compTok, &p.CompletionTokens)
+	if costMicros.Valid {
+		v := costMicros.Int64
+		p.EstimatedCostMicros = &v
+	}
+	if errType.Valid {
+		v := errType.String
+		p.ErrorType = &v
+	}
+	if errMsg.Valid {
+		v := errMsg.String
+		p.ErrorMessage = &v
+	}
+	p.CreatedAt = parseTime(createdAt)
+	return p, nil
+}
+
+func nullIntPtr(p *int) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullStringPtr(p *string) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullInt64Ptr(p *int64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func assignIntPtr(n sql.NullInt64, dst **int) {
+	if n.Valid {
+		v := int(n.Int64)
+		*dst = &v
+	}
+}

--- a/backend/internal/store/repo_provider_health_test.go
+++ b/backend/internal/store/repo_provider_health_test.go
@@ -1,0 +1,147 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderHealthCurrent_UpsertAndGet(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t)
+	repo := db.ProviderHealth()
+
+	now := time.Now().UTC()
+	cur := ProviderHealthCurrent{
+		ID:                "h1",
+		Provider:          "openai",
+		ProviderAccountID: "acc_1",
+		Model:             "gpt-4o",
+		Capability:        "chat_completions",
+		HealthStatus:      "degraded",
+		HealthScore:       72,
+		SuccessRate:       0.912,
+		ErrorRate:         0.088,
+		RequestCount:      1000,
+		FallbackCount:     37,
+		LatencyP95Ms:      intPtr9400(),
+		ConsecutiveFailures: 2,
+		MainIssue:         strPtr("rate_limited"),
+		Recommendation:    strPtr("lower concurrency"),
+		LastSuccessAt:     &now,
+		LastFailureAt:     &now,
+		LastUpdatedAt:     now,
+	}
+	require.NoError(t, repo.UpsertCurrent(ctx, cur))
+
+	got, err := repo.GetCurrent(ctx, "openai", "acc_1", "gpt-4o", "chat_completions")
+	require.NoError(t, err)
+	require.Equal(t, "degraded", got.HealthStatus)
+	require.Equal(t, 72, got.HealthScore)
+	require.NotNil(t, got.LatencyP95Ms)
+	require.Equal(t, 9400, *got.LatencyP95Ms)
+	require.NotNil(t, got.MainIssue)
+	require.Equal(t, "rate_limited", *got.MainIssue)
+
+	// Upsert again (same key) replaces the row.
+	cur.HealthScore = 50
+	cur.HealthStatus = "unhealthy"
+	require.NoError(t, repo.UpsertCurrent(ctx, cur))
+	got2, err := repo.GetCurrent(ctx, "openai", "acc_1", "gpt-4o", "chat_completions")
+	require.NoError(t, err)
+	require.Equal(t, "unhealthy", got2.HealthStatus)
+	require.Equal(t, 50, got2.HealthScore)
+}
+
+func TestProviderHealthCurrent_ListByStatus(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t)
+	repo := db.ProviderHealth()
+
+	upsert := func(id, provider, status string) {
+		require.NoError(t, repo.UpsertCurrent(ctx, ProviderHealthCurrent{
+			ID: id, Provider: provider, HealthStatus: status, HealthScore: 80, LastUpdatedAt: time.Now(),
+		}))
+	}
+	upsert("a", "openai", "healthy")
+	upsert("b", "anthropic", "degraded")
+	upsert("c", "gemini", "unhealthy")
+
+	all, err := repo.ListCurrent(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+
+	degraded, err := repo.ListCurrent(ctx, "degraded")
+	require.NoError(t, err)
+	require.Len(t, degraded, 1)
+	require.Equal(t, "anthropic", degraded[0].Provider)
+
+	byProv, err := repo.ListCurrentByProvider(ctx, "openai")
+	require.NoError(t, err)
+	require.Len(t, byProv, 1)
+}
+
+func TestProviderProbeResult_InsertAndList(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t)
+	repo := db.ProviderHealth()
+
+	p := ProviderProbeResult{
+		ID:                "p1",
+		Provider:          "openai",
+		ProviderAccountID: "acc_1",
+		Model:             "gpt-4o-mini",
+		Capability:        "chat_completions",
+		Status:            "success",
+		HTTPStatus:        intPtr200(),
+		LatencyMs:         intPtr1200(),
+		TriggeredBy:       "manual",
+		CreatedAt:         time.Now(),
+	}
+	require.NoError(t, repo.InsertProbeResult(ctx, p))
+
+	items, total, err := repo.ListProbeResults(ctx, "openai", time.Now().Add(-time.Hour), 10, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, items, 1)
+	require.Equal(t, "success", items[0].Status)
+	require.NotNil(t, items[0].HTTPStatus)
+	require.Equal(t, 200, *items[0].HTTPStatus)
+}
+
+func TestProviderHealthSnapshot_InsertAndList(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t)
+	repo := db.ProviderHealth()
+
+	now := time.Now().UTC()
+	snap := ProviderHealthSnapshot{
+		ID:                "s1",
+		BucketStart:       now.Add(-time.Minute),
+		BucketSizeSeconds: 60,
+		Provider:          "openai",
+		Model:             "gpt-4o",
+		Capability:        "chat_completions",
+		RequestCount:      100,
+		SuccessCount:      92,
+		FailureCount:      8,
+		FallbackCount:     3,
+		HealthScore:       72,
+		HealthStatus:      "degraded",
+		CreatedAt:         now,
+	}
+	require.NoError(t, repo.InsertSnapshot(ctx, snap))
+
+	snaps, err := repo.ListSnapshots(ctx, "openai", "", "gpt-4o", "", now.Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, snaps, 1)
+	require.Equal(t, int64(100), snaps[0].RequestCount)
+}
+
+// helpers local to this test file to avoid touching repo helpers.
+func intPtr9400() *int   { v := 9400; return &v }
+func intPtr200() *int    { v := 200; return &v }
+func intPtr1200() *int   { v := 1200; return &v }
+func strPtr(s string) *string { return &s }

--- a/backend/internal/store/repo_usage.go
+++ b/backend/internal/store/repo_usage.go
@@ -35,13 +35,13 @@ func (r *UsageRepo) RecordBatch(ctx context.Context, records []UsageRecord) erro
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	const cols = 26
+	const cols = 27
 	var b strings.Builder
 	b.WriteString(`INSERT INTO usage_records
 		(id, tenant_id, project_id, api_key_id, provider, model, account_id, client,
 		 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
 		 cost_micros, cache_hit, latency_ms, ttft_ms,
-		 slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+		 slim_bytes_saved, slim_tokens_saved, slim_rules, slim_active, caveman_active, terse_active,
 		 headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active,
 		 created_at) VALUES `)
 	args := make([]any, 0, len(records)*cols)
@@ -49,7 +49,7 @@ func (r *UsageRepo) RecordBatch(ctx context.Context, records []UsageRecord) erro
 		if i > 0 {
 			b.WriteString(",")
 		}
-		b.WriteString("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+		b.WriteString("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 		args = append(args, usageArgs(u)...)
 	}
 	q := r.db.rebind(b.String())
@@ -70,10 +70,10 @@ func insertUsage(ctx context.Context, exec interface {
 			(id, tenant_id, project_id, api_key_id, provider, model, account_id, client,
 			 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
 			 cost_micros, cache_hit, latency_ms, ttft_ms,
-			 slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+			 slim_bytes_saved, slim_tokens_saved, slim_rules, slim_active, caveman_active, terse_active,
 			 headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active,
 			 created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	_, err := exec.ExecContext(ctx, q, usageArgs(u)...)
 	return err
 }
@@ -84,7 +84,7 @@ func usageArgs(u UsageRecord) []any {
 		u.Provider, u.Model, nullString(u.AccountID), u.Client,
 		u.PromptTokens, u.CompletionTokens, u.CachedTokens, u.CacheWriteTokens,
 		u.CostMicros, boolToInt(u.CacheHit), u.LatencyMS, u.TTFTMS,
-		u.SlimBytesSaved, u.SlimTokensSaved, u.SlimRules, boolToInt(u.CavemanActive), boolToInt(u.TerseActive),
+		u.SlimBytesSaved, u.SlimTokensSaved, u.SlimRules, boolToInt(u.SlimActive), boolToInt(u.CavemanActive), boolToInt(u.TerseActive),
 		u.HeadroomTokensSaved, u.HeadroomBytesSaved, boolToInt(u.HeadroomActive), boolToInt(u.PonytailActive),
 		formatTime(u.CreatedAt),
 	}
@@ -349,6 +349,7 @@ type RecentRecord struct {
 	SlimBytesSaved   int    // bytes saved by RTK slimmer
 	SlimTokensSaved  int    // estimated tokens saved by RTK
 	SlimRules        string // comma-separated rule names that fired
+	SlimActive       bool   // RTK slimmer was enabled for this request
 	CavemanActive    bool
 	TerseActive      bool
 
@@ -368,7 +369,7 @@ func (r *UsageRepo) Recent(ctx context.Context, tenantID string, limit int) ([]R
 	q := r.db.rebind(`
 		SELECT id, provider, model, prompt_tokens, completion_tokens, cached_tokens,
 		       cache_write_tokens, cost_micros, cache_hit, latency_ms, ttft_ms,
-		       slim_bytes_saved, slim_tokens_saved, slim_rules, caveman_active, terse_active,
+		       slim_bytes_saved, slim_tokens_saved, slim_rules, slim_active, caveman_active, terse_active,
 		       headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active,
 		       created_at
 		FROM usage_records
@@ -387,17 +388,19 @@ func (r *UsageRepo) Recent(ctx context.Context, tenantID string, limit int) ([]R
 			rec                            RecentRecord
 			cacheHit, caveman, terse       int
 			headroomActive, ponytailActive int
+			slimActive                     int
 			createdAt                      string
 		)
 		if err := rows.Scan(&rec.ID, &rec.Provider, &rec.Model, &rec.PromptTokens,
 			&rec.CompletionTokens, &rec.CachedTokens, &rec.CacheWriteTokens,
 			&rec.CostMicros, &cacheHit, &rec.LatencyMS, &rec.TTFTMS,
-			&rec.SlimBytesSaved, &rec.SlimTokensSaved, &rec.SlimRules, &caveman, &terse,
+			&rec.SlimBytesSaved, &rec.SlimTokensSaved, &rec.SlimRules, &slimActive, &caveman, &terse,
 			&rec.HeadroomTokensSaved, &rec.HeadroomBytesSaved, &headroomActive, &ponytailActive,
 			&createdAt); err != nil {
 			return nil, err
 		}
 		rec.CacheHit = cacheHit != 0
+		rec.SlimActive = slimActive != 0
 		rec.CavemanActive = caveman != 0
 		rec.TerseActive = terse != 0
 		rec.HeadroomActive = headroomActive != 0
@@ -730,6 +733,57 @@ func (r *UsageRepo) SavingsByClient(ctx context.Context, tenantID string, since 
 			return nil, err
 		}
 		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// RecentByKey returns the most recent usage records for a specific API key
+// since the given time, newest first. Used by the customer portal to show
+// per-request details including token in/out and optimization flags.
+func (r *UsageRepo) RecentByKey(ctx context.Context, keyID string, since time.Time, limit int) ([]RecentRecord, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	q := r.db.rebind(`
+		SELECT id, provider, model, prompt_tokens, completion_tokens, cached_tokens,
+		       cache_write_tokens, cost_micros, cache_hit, latency_ms, ttft_ms,
+		       slim_bytes_saved, slim_tokens_saved, slim_rules, slim_active, caveman_active, terse_active,
+		       headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active,
+		       created_at
+		FROM usage_records
+		WHERE api_key_id = ? AND created_at >= ?
+		ORDER BY created_at DESC
+		LIMIT ?`)
+	rows, err := r.db.sql.QueryContext(ctx, q, keyID, formatTime(since), limit)
+	if err != nil {
+		return nil, fmt.Errorf("store: recent usage by key: %w", err)
+	}
+	defer rows.Close()
+	var out []RecentRecord
+	for rows.Next() {
+		var (
+			rec                            RecentRecord
+			cacheHit, caveman, terse       int
+			headroomActive, ponytailActive int
+			slimActive                     int
+			createdAt                      string
+		)
+		if err := rows.Scan(&rec.ID, &rec.Provider, &rec.Model, &rec.PromptTokens,
+			&rec.CompletionTokens, &rec.CachedTokens, &rec.CacheWriteTokens,
+			&rec.CostMicros, &cacheHit, &rec.LatencyMS, &rec.TTFTMS,
+			&rec.SlimBytesSaved, &rec.SlimTokensSaved, &rec.SlimRules, &slimActive, &caveman, &terse,
+			&rec.HeadroomTokensSaved, &rec.HeadroomBytesSaved, &headroomActive, &ponytailActive,
+			&createdAt); err != nil {
+			return nil, err
+		}
+		rec.CacheHit = cacheHit != 0
+		rec.SlimActive = slimActive != 0
+		rec.CavemanActive = caveman != 0
+		rec.TerseActive = terse != 0
+		rec.HeadroomActive = headroomActive != 0
+		rec.PonytailActive = ponytailActive != 0
+		rec.CreatedAt = parseTime(createdAt)
+		out = append(out, rec)
 	}
 	return out, rows.Err()
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,6 +82,38 @@ health:
   recent_model_window: 24h
   max_models_per_provider: 8
 
+# Actionable provider health dashboard: real-traffic telemetry aggregation +
+# synthetic probes. All optional — sensible defaults apply when omitted.
+provider_health:
+  enabled: true
+  probe_interval: 60s
+  probe_timeout: 15s
+  failure_threshold: 3
+  queue_size: 5000
+  current_flush_interval: 30s
+  snapshot_interval: 60s
+  rolling_window: 15m
+  latency_thresholds:
+    chat_completions: 10000
+    embeddings: 5000
+    image_generation: 60000
+    audio: 60000
+    search: 15000
+  capabilities:
+    chat_completions:
+      enabled: true
+      max_tokens: 5
+      prompt: "Reply with OK only."
+    embeddings:
+      enabled: true
+      input: "health check"
+    image_generation:
+      enabled: false
+    audio:
+      enabled: false
+    search:
+      enabled: false
+
 cache:
   # Semantic response cache. Off by default. When enabled, repeated or
   # near-identical prompts are served from cache for zero upstream cost.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ const OAuthCallbackPage = lazy(routeLoaders["/oauth-callback"]);
 const KeyPortalPage = lazy(routeLoaders["/portal"]);
 const KeyDetailPage = lazy(routeLoaders["/key-detail"]);
 const GuardrailsPage = lazy(routeLoaders["/guardrails"]);
+const ProviderHealthPage = lazy(routeLoaders["/provider-health"]);
 
 function PageFallback() {
   return (
@@ -72,6 +73,8 @@ export function App() {
                 <Route path="keys" element={<KeysPage />} />
                 <Route path="keys/:id" element={<KeyDetailPage />} />
                 <Route path="guardrails" element={<GuardrailsPage />} />
+                <Route path="provider-health" element={<ProviderHealthPage />} />
+                <Route path="provider-health/:provider" element={<ProviderHealthPage />} />
                 <Route path="plans" element={<PlansPage />} />
                 <Route path="budgets" element={<PlansPage />} />
                 <Route path="system" element={<SystemPage />} />

--- a/frontend/src/components/CustomModelsSection.tsx
+++ b/frontend/src/components/CustomModelsSection.tsx
@@ -77,7 +77,7 @@ export function CustomModelsSection({ provider }: { provider: Provider }) {
     <Card>
       <CardHeader
         title="Custom Models"
-        description="Models you register yourself, beyond the predefined catalog. Useful for endpoints that don't expose a /models list."
+        description="Models you register yourself, beyond the predefined catalog. Use Fetch from /models to import the upstream listing, or add entries manually."
         action={
 
           <Button variant="ghost" className="h-8 px-3 text-xs" onClick={openAdd}>

--- a/frontend/src/components/HealthBadge.tsx
+++ b/frontend/src/components/HealthBadge.tsx
@@ -1,0 +1,102 @@
+import type { HealthStatus } from "../lib/api";
+
+const STATUS_LABEL: Record<HealthStatus, string> = {
+  healthy: "Healthy",
+  degraded: "Degraded",
+  unhealthy: "Unhealthy",
+  unknown: "Unknown",
+  disabled: "Disabled",
+};
+
+// fmtIssue converts a snake_case issue/error-type label to a human-readable
+// phrase. Known issues get explicit friendly names; unknown ones fall back to
+// Title Case with spaces.
+const ISSUE_LABELS: Record<string, string> = {
+  rate_limited: "Rate Limited",
+  auth_error: "Auth Error",
+  quota_exceeded: "Quota Exceeded",
+  timeout: "Timeout",
+  provider_5xx: "Provider 5xx",
+  bad_request: "Bad Request",
+  network_error: "Network Error",
+  unsupported_model_or_capability: "Unsupported Model",
+  unknown_error: "Unknown Error",
+  high_latency: "High Latency",
+  fallback_spike: "Fallback Spike",
+};
+
+export function fmtIssue(issue?: string): string {
+  if (!issue) return "";
+  if (ISSUE_LABELS[issue]) return ISSUE_LABELS[issue];
+  return issue
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+const STATUS_TONE: Record<HealthStatus, string> = {
+  healthy: "bg-accent-100 text-accent-700 dark:bg-accent-800/40 dark:text-accent-200",
+  degraded: "bg-[color:var(--color-warning)]/15 text-[color:var(--color-warning)]",
+  unhealthy: "bg-[color:var(--color-danger)]/15 text-[color:var(--color-danger)]",
+  unknown: "bg-ink-100 text-ink-500 dark:bg-ink-800 dark:text-ink-400",
+  disabled: "bg-ink-100 text-ink-500 dark:bg-ink-800 dark:text-ink-400",
+};
+
+const STATUS_DOT: Record<HealthStatus, string> = {
+  healthy: "bg-accent-500",
+  degraded: "bg-[color:var(--color-warning)]",
+  unhealthy: "bg-[color:var(--color-danger)]",
+  unknown: "bg-ink-400",
+  disabled: "bg-ink-400",
+};
+
+export function HealthStatusBadge({ status, issue }: { status: HealthStatus; issue?: string }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${STATUS_TONE[status]}`}
+      title={issue || STATUS_LABEL[status]}
+    >
+      <span className={`inline-block h-1.5 w-1.5 rounded-full ${STATUS_DOT[status]}`} />
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+// HealthScoreRing renders a compact circular gauge for the 0-100 score.
+export function HealthScoreRing({ score, size = 44 }: { score: number; size?: number }) {
+  const stroke = 4;
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  const pct = Math.max(0, Math.min(100, score));
+  const offset = c - (pct / 100) * c;
+  const color =
+    score >= 90 ? "var(--color-accent-500)" : score >= 65 ? "var(--color-warning)" : "var(--color-danger)";
+  return (
+    <svg width={size} height={size} className="shrink-0" role="img" aria-label={`Health score ${score}`}>
+      <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="var(--border)" strokeWidth={stroke} />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        stroke={color}
+        strokeWidth={stroke}
+        strokeDasharray={c}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        style={{ transition: "stroke-dashoffset 0.4s ease" }}
+      />
+      <text
+        x="50%"
+        y="50%"
+        dy="0.35em"
+        textAnchor="middle"
+        className="fill-[var(--text)]"
+        style={{ fontSize: size * 0.3, fontWeight: 600 }}
+      >
+        {score}
+      </text>
+    </svg>
+  );
+}

--- a/frontend/src/components/HealthCharts.tsx
+++ b/frontend/src/components/HealthCharts.tsx
@@ -1,0 +1,181 @@
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { HealthSnapshot } from "../lib/api";
+import { fmtIssue } from "./HealthBadge";
+
+const tooltipStyle = {
+  fontSize: 12,
+  background: "var(--bg-elevated)",
+  border: "1px solid var(--border)",
+  borderRadius: 6,
+  boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)",
+};
+const axisTick = { fontSize: 10, fill: "var(--text-muted)", fontWeight: 500 };
+
+function fmtTime(t: string) {
+  const d = new Date(t);
+  if (isNaN(d.getTime())) return t;
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function fmtMs(v?: number) {
+  if (v == null) return "0";
+  if (v < 1000) return `${v}ms`;
+  return `${(v / 1000).toFixed(1)}s`;
+}
+
+function emptyState() {
+  return (
+    <div className="flex h-full items-center justify-center text-xs font-medium uppercase tracking-wider text-[var(--text-muted)]">
+      No data
+    </div>
+  );
+}
+
+export function RequestVolumeChart({ data }: { data: HealthSnapshot[] }) {
+  if (!data.length) return emptyState();
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <AreaChart data={data} margin={{ top: 10, right: 0, left: -20, bottom: 0 }}>
+        <defs>
+          <linearGradient id="reqFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--color-chart-1)" stopOpacity={0.2} />
+            <stop offset="95%" stopColor="var(--color-chart-1)" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid vertical={false} stroke="var(--border)" opacity={0.3} />
+        <XAxis dataKey="bucket_start" tickFormatter={fmtTime} tick={axisTick} tickLine={false} axisLine={false} dy={10} />
+        <YAxis tick={axisTick} tickLine={false} axisLine={false} width={50} />
+        <Tooltip contentStyle={tooltipStyle} labelFormatter={fmtTime} />
+        <Area type="monotone" dataKey="request_count" name="Requests" stroke="var(--color-chart-1)" strokeWidth={2} fill="url(#reqFill)" />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function ErrorRateChart({ data }: { data: HealthSnapshot[] }) {
+  if (!data.length) return emptyState();
+  const series = data.map((d) => ({
+    bucket_start: d.bucket_start,
+    error_rate: d.request_count > 0 ? (d.failure_count / d.request_count) * 100 : 0,
+  }));
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <AreaChart data={series} margin={{ top: 10, right: 0, left: -20, bottom: 0 }}>
+        <defs>
+          <linearGradient id="errFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--color-danger)" stopOpacity={0.2} />
+            <stop offset="95%" stopColor="var(--color-danger)" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid vertical={false} stroke="var(--border)" opacity={0.3} />
+        <XAxis dataKey="bucket_start" tickFormatter={fmtTime} tick={axisTick} tickLine={false} axisLine={false} dy={10} />
+        <YAxis tick={axisTick} tickLine={false} axisLine={false} width={40} tickFormatter={(v: number) => `${v}%`} />
+        <Tooltip contentStyle={tooltipStyle} labelFormatter={fmtTime} formatter={(v: number) => [`${v.toFixed(1)}%`, "Error rate"]} />
+        <Area type="monotone" dataKey="error_rate" stroke="var(--color-danger)" strokeWidth={2} fill="url(#errFill)" />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function LatencyChart({ data }: { data: HealthSnapshot[] }) {
+  if (!data.length) return emptyState();
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={data} margin={{ top: 10, right: 0, left: -20, bottom: 0 }}>
+        <CartesianGrid vertical={false} stroke="var(--border)" opacity={0.3} />
+        <XAxis dataKey="bucket_start" tickFormatter={fmtTime} tick={axisTick} tickLine={false} axisLine={false} dy={10} />
+        <YAxis tick={axisTick} tickLine={false} axisLine={false} width={50} tickFormatter={fmtMs} />
+        <Tooltip contentStyle={tooltipStyle} labelFormatter={fmtTime} formatter={(v: number) => [fmtMs(v), ""]} />
+        <Line type="monotone" dataKey="latency_p50_ms" name="p50" stroke="var(--color-chart-3)" strokeWidth={1.5} dot={false} />
+        <Line type="monotone" dataKey="latency_p95_ms" name="p95" stroke="var(--color-warning)" strokeWidth={2} dot={false} />
+        <Line type="monotone" dataKey="latency_p99_ms" name="p99" stroke="var(--color-danger)" strokeWidth={1.5} dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function TTFTChart({ data }: { data: HealthSnapshot[] }) {
+  if (!data.length) return emptyState();
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <AreaChart data={data} margin={{ top: 10, right: 0, left: -20, bottom: 0 }}>
+        <defs>
+          <linearGradient id="ttftFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--color-chart-2)" stopOpacity={0.2} />
+            <stop offset="95%" stopColor="var(--color-chart-2)" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid vertical={false} stroke="var(--border)" opacity={0.3} />
+        <XAxis dataKey="bucket_start" tickFormatter={fmtTime} tick={axisTick} tickLine={false} axisLine={false} dy={10} />
+        <YAxis tick={axisTick} tickLine={false} axisLine={false} width={50} tickFormatter={fmtMs} />
+        <Tooltip contentStyle={tooltipStyle} labelFormatter={fmtTime} formatter={(v: number) => [fmtMs(v), "TTFT p95"]} />
+        <Area type="monotone" dataKey="ttft_p95_ms" stroke="var(--color-chart-2)" strokeWidth={2} fill="url(#ttftFill)" />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function FallbackChart({ data }: { data: HealthSnapshot[] }) {
+  if (!data.length) return emptyState();
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} margin={{ top: 10, right: 0, left: -20, bottom: 0 }}>
+        <CartesianGrid vertical={false} stroke="var(--border)" opacity={0.3} />
+        <XAxis dataKey="bucket_start" tickFormatter={fmtTime} tick={axisTick} tickLine={false} axisLine={false} dy={10} />
+        <YAxis tick={axisTick} tickLine={false} axisLine={false} width={40} />
+        <Tooltip contentStyle={tooltipStyle} labelFormatter={fmtTime} />
+        <Bar dataKey="fallback_count" name="Fallbacks" fill="var(--color-secondary-500)" radius={[3, 3, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function ErrorBreakdownChart({ data }: { data: HealthSnapshot[] }) {
+  if (!data.length) return emptyState();
+  const totals = data.reduce(
+    (acc, d) => {
+      acc.rate_limited += d.rate_limited_count;
+      acc.auth += d.auth_error_count;
+      acc.quota += d.quota_exceeded_count;
+      acc.timeout += d.timeout_count;
+      acc.five_xx += d.provider_5xx_count;
+      acc.bad_request += d.bad_request_count;
+      acc.network += d.network_error_count;
+      return acc;
+    },
+    { rate_limited: 0, auth: 0, quota: 0, timeout: 0, five_xx: 0, bad_request: 0, network: 0 },
+  );
+  const series = [
+    { name: fmtIssue("rate_limited"), value: totals.rate_limited, fill: "var(--color-warning)" },
+    { name: fmtIssue("auth_error"), value: totals.auth, fill: "var(--color-danger)" },
+    { name: fmtIssue("quota_exceeded"), value: totals.quota, fill: "var(--color-secondary-500)" },
+    { name: fmtIssue("timeout"), value: totals.timeout, fill: "var(--color-chart-3)" },
+    { name: "Provider 5xx", value: totals.five_xx, fill: "var(--color-chart-4)" },
+    { name: fmtIssue("bad_request"), value: totals.bad_request, fill: "var(--color-chart-5)" },
+    { name: fmtIssue("network_error"), value: totals.network, fill: "var(--color-chart-2)" },
+  ].filter((s) => s.value > 0);
+  if (!series.length) return emptyState();
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={series} layout="vertical" margin={{ top: 5, right: 10, left: 20, bottom: 5 }}>
+        <CartesianGrid horizontal={false} stroke="var(--border)" opacity={0.3} />
+        <XAxis type="number" tick={axisTick} tickLine={false} axisLine={false} />
+        <YAxis type="category" dataKey="name" tick={axisTick} tickLine={false} axisLine={false} width={80} />
+        <Tooltip contentStyle={tooltipStyle} />
+        <Bar dataKey="value" radius={[0, 3, 3, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/src/components/KiroConnectModal.tsx
+++ b/frontend/src/components/KiroConnectModal.tsx
@@ -8,7 +8,7 @@ import { useToast } from "./Toast";
 type Method = "builder-id" | "idc" | "import" | "api-key";
 
 
-// KiroConnectModal mirrors 9router's "Connect Kiro" flow: pick an auth method,
+// KiroConnectModal implements the "Connect Kiro" flow: pick an auth method,
 // then either run an AWS SSO OIDC device authorization (Builder ID / IAM
 // Identity Center) or paste a refresh token exported from the Kiro IDE.
 export function KiroConnectModal({ onClose }: { onClose: () => void }) {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -23,6 +23,7 @@ import {
   Key,
   Activity,
   Shield,
+  HeartPulse,
   type LucideIcon,
 } from "lucide-react";
 import { api } from "../lib/api";
@@ -72,6 +73,7 @@ const navGroups: NavGroup[] = [
     heading: "Safety",
     items: [
       { to: "/guardrails", label: "Guardrails", icon: Shield, preload: "/guardrails" },
+      { to: "/provider-health", label: "Provider Health", icon: HeartPulse, preload: "/provider-health" },
     ],
   },
   {
@@ -108,6 +110,7 @@ const TITLE_BY_PATH: Record<string, string> = {
   "/settings": "Settings",
   "/keys": "API Keys",
   "/guardrails": "Guardrails",
+  "/provider-health": "Provider Health",
   "/console": "Console Log",
   "/cli-tools": "CLI Tools",
   "/system": "System",

--- a/frontend/src/components/ui.tsx
+++ b/frontend/src/components/ui.tsx
@@ -1,6 +1,6 @@
 // Reusable UI primitives styled with the KeiRouter design system. Calm,
 // generously spaced, soft shadows and rounded surfaces — no gradients or neon.
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import type {
   ButtonHTMLAttributes,
   InputHTMLAttributes,
@@ -456,4 +456,56 @@ export function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: 
       />
     </button>
   );
+}
+
+// TablePagination is the footer row shown below a paginated table. It renders
+// a total count on the left and Prev / page-indicator / Next on the right.
+export function TablePagination({
+  page,
+  pages,
+  total,
+  onPage,
+}: {
+  page: number;
+  pages: number;
+  total: number;
+  onPage: (p: number) => void;
+}) {
+  if (pages <= 1) return null;
+  return (
+    <div className="flex items-center justify-between border-t border-[var(--border)] px-4 py-2 text-xs">
+      <span className="text-[var(--text-muted)]">{total.toLocaleString()} total</span>
+      <div className="flex items-center gap-1">
+        <button
+          disabled={page <= 1}
+          onClick={() => onPage(page - 1)}
+          className="rounded px-2 py-1 hover:bg-[var(--bg-subtle)] disabled:opacity-40"
+        >
+          Prev
+        </button>
+        <span className="px-2 py-1 tabular-nums">{page}/{pages}</span>
+        <button
+          disabled={page >= pages}
+          onClick={() => onPage(page + 1)}
+          className="rounded px-2 py-1 hover:bg-[var(--bg-subtle)] disabled:opacity-40"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// useClientPagination splits a client-side array into pages. Returns the
+// current page slice, page number, total pages, and a setter. Pass `pageSize`
+// to control how many rows appear per page.
+export function useClientPagination<T>(items: T[], pageSize = 10) {
+  const [page, setPage] = useState(1);
+  const pages = Math.max(1, Math.ceil(items.length / pageSize));
+  const clampedPage = Math.min(page, pages);
+  const paged = useMemo(
+    () => items.slice((clampedPage - 1) * pageSize, clampedPage * pageSize),
+    [items, clampedPage, pageSize],
+  );
+  return { page: clampedPage, pages, paged, setPage, total: items.length };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -922,6 +922,26 @@ export interface KeyUsageData {
     completion_tokens: number;
     cost_usd: number;
   }[];
+  recent?: PortalRecentRequest[];
+  days?: number;
+}
+
+export interface PortalRecentRequest {
+  id: string;
+  provider: string;
+  model: string;
+  prompt_tokens: number;
+  completion_tokens: number;
+  cost_usd: number;
+  cache_hit: boolean;
+  latency_ms: number;
+  created_at: string;
+  optimizations: string[];
+  ttft_ms?: number;
+  slim_bytes_saved?: number;
+  slim_tokens_saved?: number;
+  slim_rules?: string;
+  headroom_tokens_saved?: number;
 }
 
 /**
@@ -938,8 +958,9 @@ export async function fetchPortalBranding(): Promise<BrandingSettings> {
 /**
  * Fetch usage stats for an API Key, authenticated via the key itself (public portal)
  */
-export async function fetchKeyUsage(key: string): Promise<KeyUsageData> {
-  const resp = await fetch("/v1/keys/me/usage", {
+export async function fetchKeyUsage(key: string, days?: number): Promise<KeyUsageData> {
+  const qs = days ? `?days=${days}` : "";
+  const resp = await fetch(`/v1/keys/me/usage${qs}`, {
     headers: { Authorization: `Bearer ${key}` },
   });
   if (!resp.ok) {
@@ -952,8 +973,9 @@ export async function fetchKeyUsage(key: string): Promise<KeyUsageData> {
 /**
  * Fetch usage stats for an API Key using its database ID (public portal link sharing)
  */
-export async function fetchKeyUsageById(id: string): Promise<KeyUsageData> {
-  const resp = await fetch(`/v1/portal/keys/${id}/usage`);
+export async function fetchKeyUsageById(id: string, days?: number): Promise<KeyUsageData> {
+  const qs = days ? `?days=${days}` : "";
+  const resp = await fetch(`/v1/portal/keys/${id}/usage${qs}`);
   if (!resp.ok) {
     const data = await resp.json().catch(() => ({}));
     throw new Error(data.error || "Invalid key ID or server error");
@@ -989,12 +1011,18 @@ export const api = {
   // Custom provider instances (dynamic OpenAI-/Anthropic-compatible providers).
   listCustomProviders: () =>
     request<{ providers: CustomProvider[] }>("GET", "/custom-providers"),
-  createCustomProvider: (input: { display_name: string; dialect: string; base_url: string }) =>
+  createCustomProvider: (input: { display_name: string; dialect: string; base_url: string; alias?: string }) =>
     request<CustomProvider>("POST", "/custom-providers", input),
   updateCustomProvider: (id: string, patch: { display_name?: string; alias?: string; base_url?: string }) =>
     request<CustomProvider>("PATCH", `/custom-providers/${id}`, patch),
   deleteCustomProvider: (id: string) =>
     request<{ id: string; deleted: boolean }>("DELETE", `/custom-providers/${id}`),
+
+  importModels: (id: string) =>
+    request<{ provider_id: string; imported: number; skipped: number; total: number }>(
+      "POST",
+      `/providers/${id}/import-models`,
+    ),
 
   // Custom models, attachable to any provider id (custom or built-in).
   listCustomModels: (providerId: string) =>
@@ -1348,7 +1376,207 @@ export const api = {
       "/guardrails/tenant-flags",
       flags,
     ),
+
+  // ---- Actionable provider health dashboard ----
+
+  healthOverview: (range = "1h", status?: string) =>
+    request<HealthOverview>(
+      "GET",
+      `/health/overview?range=${encodeURIComponent(range)}${status ? `&status=${encodeURIComponent(status)}` : ""}`,
+    ),
+
+  healthProviderDetail: (provider: string, range = "24h") =>
+    request<HealthProviderDetail>(
+      "GET",
+      `/health/providers/${encodeURIComponent(provider)}?range=${encodeURIComponent(range)}`,
+    ),
+
+  healthModels: (range = "1h", status?: string) =>
+    request<{ models: HealthModelRow[] }>(
+      "GET",
+      `/health/models?range=${encodeURIComponent(range)}${status ? `&status=${encodeURIComponent(status)}` : ""}`,
+    ),
+
+  healthChains: (range = "1h") =>
+    request<{ chains: HealthChainRow[] }>(
+      "GET",
+      `/health/chains?range=${encodeURIComponent(range)}`,
+    ),
+
+  healthChainDetail: (id: string) =>
+    request<HealthChainDetail>("GET", `/health/chains/${encodeURIComponent(id)}`),
+
+  healthProbeHistory: (params: { provider?: string; range?: string; page?: number; limit?: number } = {}) => {
+    const qs = new URLSearchParams();
+    if (params.provider) qs.set("provider", params.provider);
+    qs.set("range", params.range ?? "24h");
+    qs.set("page", String(params.page ?? 1));
+    qs.set("limit", String(params.limit ?? 50));
+    return request<{ items: HealthProbeRow[]; pagination: { page: number; limit: number; total: number } }>(
+      "GET",
+      `/health/probes?${qs.toString()}`,
+    );
+  },
+
+  runHealthProbe: (input: { provider: string; provider_account_id?: string; model: string; capability?: string }) =>
+    request<HealthProbeResult>("POST", "/health/probes/run", input),
 };
+
+// ---- Provider health types ----
+
+export type HealthStatus = "healthy" | "degraded" | "unhealthy" | "unknown" | "disabled";
+
+export interface HealthSummary {
+  healthy: number;
+  degraded: number;
+  unhealthy: number;
+  unknown: number;
+  disabled: number;
+  fallbacks: number;
+  avg_p95_latency_ms: number;
+}
+
+export interface HealthProviderRow {
+  provider: string;
+  status: HealthStatus;
+  score: number;
+  accounts: number;
+  models_monitored: number;
+  success_rate: number;
+  error_rate: number;
+  latency_p95_ms: number;
+  ttft_p95_ms: number;
+  fallback_count: number;
+  last_probe_at?: string;
+  main_issue?: string;
+  recommendation?: string;
+}
+
+export interface HealthOverview {
+  summary: HealthSummary;
+  providers: HealthProviderRow[];
+}
+
+export interface HealthSnapshot {
+  bucket_start: string;
+  request_count: number;
+  success_count: number;
+  failure_count: number;
+  fallback_count: number;
+  latency_p50_ms?: number;
+  latency_p95_ms?: number;
+  latency_p99_ms?: number;
+  ttft_p50_ms?: number;
+  ttft_p95_ms?: number;
+  ttft_p99_ms?: number;
+  rate_limited_count: number;
+  auth_error_count: number;
+  quota_exceeded_count: number;
+  timeout_count: number;
+  provider_5xx_count: number;
+  bad_request_count: number;
+  network_error_count: number;
+  health_score: number;
+  health_status: HealthStatus;
+}
+
+export interface HealthProviderDetail {
+  provider: string;
+  status: HealthStatus;
+  score: number;
+  main_issue: string;
+  recommendation: string;
+  metrics: {
+    requests: number;
+    success_rate: number;
+    error_rate: number;
+    latency_p95_ms: number;
+    ttft_p95_ms: number;
+    fallback_count: number;
+  };
+  error_breakdown: Record<string, number>;
+  models: HealthModelRow[];
+  snapshots: HealthSnapshot[];
+}
+
+export interface HealthModelRow {
+  provider?: string;
+  provider_account_id?: string;
+  model: string;
+  capability?: string;
+  status: HealthStatus;
+  score: number;
+  success_rate: number;
+  error_rate: number;
+  latency_p95_ms?: number;
+  ttft_p95_ms?: number;
+  fallback_count: number;
+  main_issue?: string;
+  last_updated_at?: string;
+}
+
+export interface HealthChainRow {
+  chain_id: string;
+  name: string;
+  status: HealthStatus;
+  affected_provider: string;
+  affected_model: string;
+  main_issue?: string;
+  step_count?: number;
+  requests: number;
+  fallback_rate: number;
+  fallback_count: number;
+  final_failure_count: number;
+  recommendation: string;
+}
+
+export interface HealthChainStep {
+  position: number;
+  provider: string;
+  model: string;
+  status: HealthStatus;
+  score: number;
+  main_issue: string;
+}
+
+export interface HealthChainDetail {
+  chain_id: string;
+  name: string;
+  strategy: string;
+  steps: HealthChainStep[];
+  requests?: number;
+  fallback_rate?: number;
+  fallback_count?: number;
+  final_failure_count?: number;
+  fallback_provider?: string;
+  fallback_model?: string;
+}
+
+export interface HealthProbeRow {
+  time: string;
+  provider: string;
+  provider_account_id: string;
+  model: string;
+  capability: string;
+  status: string;
+  http_status?: number;
+  latency_ms?: number;
+  ttft_ms?: number;
+  error_type?: string;
+  error_message?: string;
+  triggered_by: string;
+}
+
+export interface HealthProbeResult {
+  status: string;
+  provider: string;
+  model: string;
+  http_status?: number;
+  latency_ms?: number;
+  ttft_ms?: number;
+  error_type?: string;
+  message: string;
+}
 
 export interface GuardrailTemplate {
   id: string;

--- a/frontend/src/pages/ConsoleLog.tsx
+++ b/frontend/src/pages/ConsoleLog.tsx
@@ -255,6 +255,12 @@ export function ConsoleLogPage() {
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: () => ROW_HEIGHT,
     overscan: 20,
+    // Key measurements by the stable log seq, not the array index. The log
+    // list mutates constantly (SSE appends + slice(-MAX_LINES) shifts every
+    // index), so an index-keyed cache would attach an expanded row's tall
+    // height to whatever entry later lands on that index, leaving neighboring
+    // rows with stale offsets and causing overlapping "glitch" rows.
+    getItemKey: (index) => filtered[index].seq,
   });
 
   // ── Auto-scroll ──────────────────────────────────────────────────────────

--- a/frontend/src/pages/KeyPortal.tsx
+++ b/frontend/src/pages/KeyPortal.tsx
@@ -2,15 +2,15 @@ import { useState, useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
-  AreaChart, Area, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,
-  CartesianGrid, PieChart, Pie, Cell,
+  AreaChart, Area, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,
+  CartesianGrid, PieChart, Pie, Cell, ComposedChart, Line,
 } from "recharts";
-import { fetchKeyUsage, fetchKeyUsageById, APIError, type KeyUsageData } from "../lib/api";
+import { fetchKeyUsage, fetchKeyUsageById, APIError, type KeyUsageData, type PortalRecentRequest } from "../lib/api";
 import { useBranding } from "../contexts/BrandingContext";
 import {
   AlertTriangle, CheckCircle2, Activity, ArrowDownRight, ArrowUpRight, DollarSign,
   LogOut, Layers, Key, Zap, Send, ChevronDown, Radio, TrendingUp, Coins, Calendar,
-  Trophy, Infinity as InfinityIcon,
+  Trophy, Infinity as InfinityIcon, Clock, ChevronLeft, ChevronRight,
 } from "lucide-react";
 import { Card, Button, Input, Spinner, ErrorCard, Badge, SegmentedControl } from "../components/ui";
 
@@ -20,6 +20,13 @@ const C_INPUT = "var(--color-chart-1)";
 const C_OUTPUT = "var(--color-chart-2)";
 const C_COST = "var(--color-chart-3)";
 const C_REQ = "var(--color-chart-5)";
+
+const DATE_RANGES = [
+  { value: 7, label: "7D" },
+  { value: 14, label: "14D" },
+  { value: 30, label: "30D" },
+  { value: 90, label: "90D" },
+];
 
 export function KeyPortalPage() {
   const { branding, logoSrc } = useBranding();
@@ -31,6 +38,7 @@ export function KeyPortalPage() {
   const [testPrompt, setTestPrompt] = useState("Say hello in one sentence");
   const [testResponse, setTestResponse] = useState<any>(null);
   const [isTesting, setIsTesting] = useState(false);
+  const [days, setDays] = useState(30);
 
   const authValue = activeId || activeKey;
   const isIdMode = !!activeId;
@@ -50,8 +58,8 @@ export function KeyPortalPage() {
   };
 
   const { data, isLoading, isError, error, dataUpdatedAt } = useQuery({
-    queryKey: ["key-usage", authValue, isIdMode],
-    queryFn: () => (isIdMode ? fetchKeyUsageById(authValue) : fetchKeyUsage(authValue)),
+    queryKey: ["key-usage", authValue, isIdMode, days],
+    queryFn: () => (isIdMode ? fetchKeyUsageById(authValue, days) : fetchKeyUsage(authValue, days)),
     enabled: !!authValue,
     retry: false,
     refetchInterval: 30000,
@@ -161,11 +169,14 @@ export function KeyPortalPage() {
           </div>
         </header>
 
-        {/* ── Overview: Allocations + 30-day KPIs ────────────────────── */}
+        {/* ── Date filter ────────────────────────────────────────────── */}
+        <DateFilter days={days} onChange={setDays} />
+
+        {/* ── Overview: Allocations + KPIs ───────────────────────────── */}
         <OverviewSection d={d} />
 
-        {/* ── Usage Trend (multi-metric) ─────────────────────────────── */}
-        {d.daily && d.daily.length > 0 && <TrendSection daily={d.daily} />}
+        {/* ── Usage Trend (multi-metric, condensed) ──────────────────── */}
+        {d.daily && d.daily.length > 0 && <TrendSection daily={d.daily} days={days} />}
 
         {/* ── Composition + Highlights ───────────────────────────────── */}
         {d.daily && d.daily.length > 0 && <InsightsSection d={d} />}
@@ -206,15 +217,41 @@ export function KeyPortalPage() {
           />
         )}
 
+        {/* ── Recent Requests table ──────────────────────────────────── */}
+        {d.recent && d.recent.length > 0 && <RecentRequestsSection recent={d.recent} days={days} />}
+
         <footer className="pt-2 pb-8 text-center text-xs text-[var(--text-muted)]">
-          Metrics reflect the last 30 days · refreshed automatically every 30 seconds
+          Metrics reflect the last {days} days · refreshed automatically every 30 seconds
         </footer>
       </div>
     </div>
   );
 }
 
-// ─── Overview: budget allocations + 30-day KPI cards ──────────────────────
+// ─── Date Filter ───────────────────────────────────────────────────────────
+function DateFilter({ days, onChange }: { days: number; onChange: (v: number) => void }) {
+  return (
+    <div className="flex items-center justify-center sm:justify-end">
+      <div className="flex items-center gap-1 rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] p-1 shadow-sm">
+        {DATE_RANGES.map((r) => (
+          <button
+            key={r.value}
+            onClick={() => onChange(r.value)}
+            className={`rounded-lg px-4 py-2 text-xs font-semibold transition-all ${
+              days === r.value
+                ? "bg-accent-600 text-white shadow-sm"
+                : "text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-subtle)]"
+            }`}
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Overview: budget allocations + KPI cards ──────────────────────────────
 function OverviewSection({ d }: { d: KeyUsageData }) {
   const daily = d.daily ?? [];
   const t = useMemo(() => aggregate(daily), [daily]);
@@ -278,10 +315,10 @@ function OverviewSection({ d }: { d: KeyUsageData }) {
           </Card>
         </div>
 
-        {/* 30-day KPI cards */}
+        {/* KPI cards */}
         <div className="lg:col-span-7">
           <div className="mb-3 flex items-center justify-between px-1">
-            <h2 className="text-xs font-semibold tracking-widest text-[var(--text-muted)] uppercase">Last 30 Days</h2>
+            <h2 className="text-xs font-semibold tracking-widest text-[var(--text-muted)] uppercase">Period Summary</h2>
             <span className="text-xs text-[var(--text-muted)]">{activeDays} active day{activeDays === 1 ? "" : "s"}</span>
           </div>
           <div className="grid grid-cols-2 gap-4">
@@ -305,7 +342,7 @@ function OverviewSection({ d }: { d: KeyUsageData }) {
 // ─── Usage trend chart with metric toggle ─────────────────────────────────
 type Metric = "tokens" | "requests" | "cost";
 
-function TrendSection({ daily }: { daily: NonNullable<KeyUsageData["daily"]> }) {
+function TrendSection({ daily, days }: { daily: NonNullable<KeyUsageData["daily"]>; days: number }) {
   const [metric, setMetric] = useState<Metric>("tokens");
   const chartData = useMemo(() => daily.map((dp) => ({ ...dp, label: dp.date.slice(5) })), [daily]);
   const t = useMemo(() => aggregate(daily), [daily]);
@@ -333,29 +370,44 @@ function TrendSection({ daily }: { daily: NonNullable<KeyUsageData["daily"]> }) 
       <Card className="p-6 md:p-7">
         <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
           <div>
-            <p className="text-xs font-medium uppercase tracking-widest text-[var(--text-muted)]">30-day total</p>
+            <p className="text-xs font-medium uppercase tracking-widest text-[var(--text-muted)]">{days}-day total</p>
             <p className="mt-1 text-2xl font-display font-semibold tabular-nums tracking-tight text-[var(--text)]">{headline}</p>
           </div>
           {metric === "tokens" && (
             <div className="flex items-center gap-4 text-xs">
               <LegendDot color={C_INPUT} label="Input" />
               <LegendDot color={C_OUTPUT} label="Output" />
+              <LegendDot color={C_REQ} label="Requests" />
+            </div>
+          )}
+          {metric === "requests" && (
+            <div className="flex items-center gap-4 text-xs">
+              <LegendDot color={C_REQ} label="Requests" />
+              <LegendDot color={C_COST} label="Cost" />
+            </div>
+          )}
+          {metric === "cost" && (
+            <div className="flex items-center gap-4 text-xs">
+              <LegendDot color={C_COST} label="Cost" />
+              <LegendDot color={C_REQ} label="Requests" />
             </div>
           )}
         </div>
 
-        <div className="h-[300px] w-full">
+        <div className="h-[260px] w-full">
           <ResponsiveContainer width="100%" height="100%">
             {metric === "requests" ? (
-              <BarChart data={chartData} margin={{ top: 10, right: 8, left: -18, bottom: 0 }}>
+              <ComposedChart data={chartData} margin={{ top: 10, right: 8, left: -18, bottom: 0 }}>
                 <CartesianGrid vertical={false} stroke="var(--border)" strokeDasharray="4 4" opacity={0.6} />
                 <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={false} dy={12} minTickGap={24} />
-                <YAxis tick={axisTick} tickLine={false} axisLine={false} tickFormatter={formatNumber} width={56} />
+                <YAxis yAxisId="left" tick={axisTick} tickLine={false} axisLine={false} tickFormatter={formatNumber} width={56} />
+                <YAxis yAxisId="right" orientation="right" tick={axisTick} tickLine={false} axisLine={false} tickFormatter={(v) => `$${v}`} width={52} />
                 <Tooltip cursor={{ fill: "var(--bg-subtle)", opacity: 0.5 }} content={<ChartTooltip metric={metric} />} />
-                <Bar dataKey="requests" fill={C_REQ} radius={[6, 6, 0, 0]} maxBarSize={38} name="Requests" />
-              </BarChart>
+                <Bar yAxisId="left" dataKey="requests" fill={C_REQ} fillOpacity={0.85} radius={[6, 6, 0, 0]} maxBarSize={38} name="Requests" />
+                <Line yAxisId="right" type="monotone" dataKey="cost_usd" stroke={C_COST} strokeWidth={2.5} dot={false} name="Cost" />
+              </ComposedChart>
             ) : metric === "cost" ? (
-              <AreaChart data={chartData} margin={{ top: 10, right: 8, left: -8, bottom: 0 }}>
+              <ComposedChart data={chartData} margin={{ top: 10, right: 8, left: -8, bottom: 0 }}>
                 <defs>
                   <linearGradient id="costFill" x1="0" y1="0" x2="0" y2="1">
                     <stop offset="5%" stopColor={C_COST} stopOpacity={0.3} />
@@ -364,35 +416,185 @@ function TrendSection({ daily }: { daily: NonNullable<KeyUsageData["daily"]> }) 
                 </defs>
                 <CartesianGrid vertical={false} stroke="var(--border)" strokeDasharray="4 4" opacity={0.6} />
                 <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={false} dy={12} minTickGap={24} />
-                <YAxis tick={axisTick} tickLine={false} axisLine={false} tickFormatter={(v) => `$${v}`} width={56} />
+                <YAxis yAxisId="left" tick={axisTick} tickLine={false} axisLine={false} tickFormatter={(v) => `$${v}`} width={56} />
+                <YAxis yAxisId="right" orientation="right" tick={axisTick} tickLine={false} axisLine={false} tickFormatter={formatNumber} width={52} />
                 <Tooltip content={<ChartTooltip metric={metric} />} />
-                <Area type="monotone" dataKey="cost_usd" stroke={C_COST} strokeWidth={2.5} fill="url(#costFill)" name="Cost" />
-              </AreaChart>
+                <Area yAxisId="left" type="monotone" dataKey="cost_usd" stroke={C_COST} strokeWidth={2.5} fill="url(#costFill)" name="Cost" />
+                <Line yAxisId="right" type="monotone" dataKey="requests" stroke={C_REQ} strokeWidth={2} strokeDasharray="4 3" dot={false} name="Requests" />
+              </ComposedChart>
             ) : (
-              <AreaChart data={chartData} margin={{ top: 10, right: 8, left: -18, bottom: 0 }}>
-                <defs>
-                  <linearGradient id="inFill" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor={C_INPUT} stopOpacity={0.28} />
-                    <stop offset="95%" stopColor={C_INPUT} stopOpacity={0} />
-                  </linearGradient>
-                  <linearGradient id="outFill" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor={C_OUTPUT} stopOpacity={0.28} />
-                    <stop offset="95%" stopColor={C_OUTPUT} stopOpacity={0} />
-                  </linearGradient>
-                </defs>
+              <ComposedChart data={chartData} margin={{ top: 10, right: 8, left: -18, bottom: 0 }}>
                 <CartesianGrid vertical={false} stroke="var(--border)" strokeDasharray="4 4" opacity={0.6} />
                 <XAxis dataKey="label" tick={axisTick} tickLine={false} axisLine={false} dy={12} minTickGap={24} />
-                <YAxis tick={axisTick} tickLine={false} axisLine={false} tickFormatter={formatTokens} width={56} />
-                <Tooltip content={<ChartTooltip metric={metric} />} />
-                <Area type="monotone" dataKey="prompt_tokens" stackId="1" stroke={C_INPUT} strokeWidth={2.5} fill="url(#inFill)" name="Input" />
-                <Area type="monotone" dataKey="completion_tokens" stackId="1" stroke={C_OUTPUT} strokeWidth={2.5} fill="url(#outFill)" name="Output" />
-              </AreaChart>
+                <YAxis yAxisId="left" tick={axisTick} tickLine={false} axisLine={false} tickFormatter={formatTokens} width={56} />
+                <YAxis yAxisId="right" orientation="right" tick={axisTick} tickLine={false} axisLine={false} tickFormatter={formatNumber} width={52} />
+                <Tooltip cursor={{ fill: "var(--bg-subtle)", opacity: 0.5 }} content={<ChartTooltip metric={metric} />} />
+                <Bar yAxisId="left" dataKey="prompt_tokens" stackId="tok" fill={C_INPUT} fillOpacity={0.85} radius={[0, 0, 0, 0]} maxBarSize={38} name="Input" />
+                <Bar yAxisId="left" dataKey="completion_tokens" stackId="tok" fill={C_OUTPUT} fillOpacity={0.85} radius={[6, 6, 0, 0]} maxBarSize={38} name="Output" />
+                <Line yAxisId="right" type="monotone" dataKey="requests" stroke={C_REQ} strokeWidth={2.5} dot={false} name="Requests" />
+              </ComposedChart>
             )}
           </ResponsiveContainer>
         </div>
       </Card>
     </section>
   );
+}
+
+// ─── Recent Requests table ─────────────────────────────────────────────────
+function RecentRequestsSection({ recent, days: _days }: { recent: PortalRecentRequest[]; days: number }) {
+  const PAGE_SIZE =15;
+  const [page, setPage] = useState(0);
+  const totalPages = Math.max(1, Math.ceil(recent.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages -1);
+  const start = safePage * PAGE_SIZE;
+  const pageItems = recent.slice(start, start + PAGE_SIZE);
+
+  return (
+    <section className="space-y-4">
+      <SectionTitle title="Request Log" icon={<Clock size={17} />} count={recent.length} />
+      <Card className="overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-[var(--bg-subtle)]/50 border-b border-[var(--border)]">
+              <tr className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+                <th className="px-4 py-3 text-left font-semibold">Model</th>
+                <th className="px-4 py-3 text-right font-semibold">
+                  <span className="inline-flex items-center justify-end gap-1">
+                    <ArrowDownRight size={12} className="text-[var(--color-chart-1)]" /> In
+                  </span>
+                </th>
+                <th className="px-4 py-3 text-right font-semibold">
+                  <span className="inline-flex items-center justify-end gap-1">
+                    <ArrowUpRight size={12} className="text-[var(--color-chart-2)]" /> Out
+                  </span>
+                </th>
+                <th className="px-4 py-3 text-right font-semibold">Cost</th>
+                <th className="px-4 py-3 text-center font-semibold">Optimizations</th>
+                <th className="px-4 py-3 text-right font-semibold">Latency</th>
+                <th className="px-4 py-3 text-right font-semibold">Date</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--border)]">
+              {pageItems.map((r) => {
+                const opts = r.optimizations ?? [];
+                return (
+                  <tr key={r.id} className="group transition-colors hover:bg-[var(--bg-subtle)]/30">
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <ProviderIcon provider={r.provider} className="h-8 w-8" />
+                        <div className="flex min-w-0 flex-col">
+                          <span className="font-semibold text-[var(--text)] text-[13px] truncate">{r.model}</span>
+                          <span className="text-[11px] text-[var(--text-muted)] capitalize truncate">{r.provider}</span>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums font-mono text-[13px] text-[var(--text)]">
+                      <span className="inline-flex items-center justify-end gap-1.5">
+                        <ArrowDownRight size={12} className="text-[var(--color-chart-1)]" />
+                        {formatTokens(r.prompt_tokens)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums font-mono text-[13px] text-[var(--text)]">
+                      <span className="inline-flex items-center justify-end gap-1.5">
+                        <ArrowUpRight size={12} className="text-[var(--color-chart-2)]" />
+                        {formatTokens(r.completion_tokens)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums text-[13px] text-[var(--text-muted)]">${r.cost_usd.toFixed(4)}</td>
+                    <td className="px-4 py-3 text-center">
+                      {opts.length >0 ? (
+                        <div className="flex flex-wrap items-center justify-center gap-1">
+                          {opts.map((opt) => (
+                            <OptBadge key={opt} name={opt} detail={optDetail(r, opt)} />
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-[11px] text-[var(--text-muted)] opacity-40">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums text-[12px] text-[var(--text-muted)]">
+                      {r.latency_ms >0 ? `${r.latency_ms}ms` : r.cache_hit ? "cache" : "—"}
+                    </td>
+                    <td className="px-4 py-3 text-right whitespace-nowrap">
+                      <div className="flex flex-col items-end leading-tight">
+                        <span className="text-[12px] font-medium text-[var(--text)] tabular-nums">{formatDateTime(r.created_at)}</span>
+                        <span className="text-[10px] text-[var(--text-muted)] tabular-nums">{relTime(r.created_at)} ago</span>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        {totalPages >1 && (
+          <div className="flex items-center justify-between border-t border-[var(--border)] px-4 py-3">
+            <span className="text-[11px] text-[var(--text-muted)]">
+              Showing {start +1}–{Math.min(start + PAGE_SIZE, recent.length)} of {recent.length}
+            </span>
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => setPage((p) => Math.max(0, p -1))}
+                disabled={safePage ===0}
+                className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-subtle)] hover:text-[var(--text)] disabled:opacity-40 disabled:hover:bg-[var(--bg-elevated)] disabled:hover:text-[var(--text-muted)]"
+                aria-label="Previous page"
+              >
+                <ChevronLeft size={16} />
+              </button>
+              <span className="px-2 text-[12px] font-medium tabular-nums text-[var(--text)]">
+                {safePage +1} / {totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages -1, p +1))}
+                disabled={safePage === totalPages -1}
+                className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-subtle)] hover:text-[var(--text)] disabled:opacity-40 disabled:hover:bg-[var(--bg-elevated)] disabled:hover:text-[var(--text-muted)]"
+                aria-label="Next page"
+              >
+                <ChevronRight size={16} />
+              </button>
+            </div>
+          </div>
+        )}
+      </Card>
+    </section>
+  );
+}
+
+function OptBadge({ name, detail }: { name: string; detail?: string }) {
+  const styles: Record<string, string> = {
+    RTK: "bg-teal-500/10 text-teal-600 dark:text-teal-400",
+    Caveman: "bg-purple-500/10 text-purple-600 dark:text-purple-400",
+    Terse: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400",
+    Headroom: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+    Ponytail: "bg-pink-500/10 text-pink-600 dark:text-pink-400",
+  };
+  const style = styles[name] || "bg-[var(--bg-subtle)] text-[var(--text-muted)]";
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${style}`}
+      title={detail || name}
+    >
+      {name}
+    </span>
+  );
+}
+
+function optDetail(r: PortalRecentRequest, name: string): string {
+  switch (name) {
+    case "RTK":
+      return r.slim_rules ? `RTK rules: ${r.slim_rules}${r.slim_tokens_saved ? ` (${formatTokens(r.slim_tokens_saved)} tokens saved)` : ""}` : "RTK compression";
+    case "Caveman":
+      return "Caveman output compression";
+    case "Terse":
+      return "Terse output compression";
+    case "Headroom":
+      return r.headroom_tokens_saved ? `Headroom saved ${formatTokens(r.headroom_tokens_saved)} tokens` : "Headroom compression";
+    case "Ponytail":
+      return "Ponytail injection";
+    default:
+      return name;
+  }
 }
 
 // ─── Token composition donut + activity highlights ────────────────────────
@@ -452,7 +654,7 @@ function InsightsSection({ d }: { d: KeyUsageData }) {
         <Card className="p-6 md:p-7">
           <div className="grid grid-cols-2 gap-x-6 gap-y-6">
             <Highlight label="Busiest Day" value={busiest && busiest.requests > 0 ? busiest.date.slice(5) : "—"} sub={busiest && busiest.requests > 0 ? `${formatNumber(busiest.requests)} requests` : "no activity"} />
-            <Highlight label="Models Used" value={String(d.models?.length ?? 0)} sub="in last 30 days" />
+            <Highlight label="Models Used" value={String(d.models?.length ?? 0)} sub="in period" />
             <Highlight label="Avg / Request" value={formatTokens(avgPerReq)} sub="tokens" />
             <Highlight label="This Month" value={`$${d.current_period.cost_usd.toFixed(2)}`} sub={`${formatNumber(d.current_period.total_requests)} requests`} />
           </div>
@@ -770,9 +972,13 @@ function LegendDot({ color, label }: { color: string; label: string }) {
   );
 }
 
-function ChartTooltip({ active, payload, label, metric, simple }: any) {
+function ChartTooltip({ active, payload, label, metric: _metric, simple }: any) {
   if (!active || !payload?.length) return null;
-  const fmt = (v: number) => (metric === "cost" ? `$${v.toFixed(4)}` : metric === "requests" ? formatNumber(v) : formatTokens(v));
+  const fmtVal = (key: string, v: number) => {
+    if (key === "requests" || key === "Requests") return formatNumber(v);
+    if (key === "cost_usd" || key === "Cost") return `$${v.toFixed(4)}`;
+    return formatTokens(v);
+  };
   const nameOf = (key: string) => (key === "prompt_tokens" || key === "Input" ? "Input" : key === "completion_tokens" || key === "Output" ? "Output" : key === "requests" ? "Requests" : key === "cost_usd" ? "Cost" : key);
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] px-3.5 py-2.5 shadow-[var(--shadow-pop)]">
@@ -782,7 +988,7 @@ function ChartTooltip({ active, payload, label, metric, simple }: any) {
           <div key={i} className="flex items-center gap-2 text-sm">
             <span className="h-2 w-2 rounded-full" style={{ background: p.color || p.payload?.color }} />
             <span className="text-[var(--text-muted)]">{nameOf(p.name ?? p.dataKey)}</span>
-            <span className="ml-auto font-semibold tabular-nums text-[var(--text)]">{fmt(p.value)}</span>
+            <span className="ml-auto font-semibold tabular-nums text-[var(--text)]">{fmtVal(p.dataKey ?? p.name, p.value)}</span>
           </div>
         ))}
       </div>
@@ -841,4 +1047,24 @@ function relativeTime(ts: number): string {
   const m = Math.floor(s / 60);
   if (m < 60) return `${m}m ago`;
   return `${Math.floor(m / 60)}h ago`;
+}
+
+function relTime(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "—";
+  const diff = Date.now() - t;
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+function formatDateTime(iso: string): string {
+  const t = new Date(iso);
+  if (Number.isNaN(t.getTime())) return "—";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${t.getFullYear()}-${pad(t.getMonth() + 1)}-${pad(t.getDate())} ${pad(t.getHours())}:${pad(t.getMinutes())}`;
 }

--- a/frontend/src/pages/Keys.tsx
+++ b/frontend/src/pages/Keys.tsx
@@ -1,7 +1,7 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { KeyRound, Plus, Copy, Check, ToggleLeft, ToggleRight, ArrowLeft, ArrowRight, Trash2, Wallet, Wrench, DollarSign, Gauge, Link2, Activity, Ban, ListFilter } from "lucide-react";
+import { KeyRound, Plus, Copy, Check, ToggleLeft, ToggleRight, ArrowLeft, ArrowRight, Trash2, Wallet, Wrench, DollarSign, Gauge, Link2, Activity, Ban, ListFilter, Search, X, ArrowUpDown } from "lucide-react";
 import { api, type APIKey, type CreatedKey, type Plan } from "../lib/api";
 import { microsToUSD, formatTokens } from "../lib/format";
 import { PageHeader } from "../components/Layout";
@@ -220,6 +220,41 @@ export function KeysPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
   const [statusFilter, setStatusFilter] = useState<"all" | "active" | "inactive">("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortKey, setSortKey] = useState<"created_desc" | "created_asc" | "name_asc" | "name_desc">("created_desc");
+
+  const visibleKeys = useMemo(() => {
+    const all = keys.data?.keys ?? [];
+    return all
+      .filter((k) => {
+        if (statusFilter === "active") return !k.disabled;
+        if (statusFilter === "inactive") return k.disabled;
+        return true;
+      })
+      .filter((k) => {
+        if (!searchQuery.trim()) return true;
+        const q = searchQuery.toLowerCase();
+        return (
+          k.name.toLowerCase().includes(q) ||
+          k.id.toLowerCase().includes(q) ||
+          k.display.toLowerCase().includes(q) ||
+          (k.plan_name ?? "").toLowerCase().includes(q)
+        );
+      })
+      .sort((a, b) => {
+        switch (sortKey) {
+          case "name_asc":
+            return a.name.localeCompare(b.name);
+          case "name_desc":
+            return b.name.localeCompare(a.name);
+          case "created_asc":
+            return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+          case "created_desc":
+          default:
+            return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+        }
+      });
+  }, [keys.data, statusFilter, searchQuery, sortKey]);
 
   // Step 1 — name
   const [name, setName] = useState("");
@@ -318,12 +353,12 @@ export function KeysPage() {
   }, []);
 
   const toggleSelectAll = useCallback(() => {
-    if (!keys.data?.keys) return;
+    if (!visibleKeys.length) return;
     setSelectedIds((prev) => {
-      if (prev.size === keys.data!.keys!.length) return new Set();
-      return new Set(keys.data!.keys!.map((k) => k.id));
+      if (prev.size === visibleKeys.length && visibleKeys.every((k) => prev.has(k.id))) return new Set();
+      return new Set(visibleKeys.map((k) => k.id));
     });
-  }, [keys.data]);
+  }, [visibleKeys]);
 
   const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
 
@@ -477,20 +512,52 @@ export function KeysPage() {
           <KeyEmptyState onCreate={openModal} />
         ) : (
           <div>
-            {keys.data.keys.length > 0 && (
-              <div className="flex items-center justify-between gap-4 border-b border-[var(--border)] bg-[var(--bg-subtle)] px-5 py-3 sm:px-6">
-                <label className="flex cursor-pointer items-center gap-3">
+            <div className="flex flex-col gap-3 border-b border-[var(--border)] bg-[var(--bg-subtle)] px-5 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+              <label className="flex cursor-pointer items-center gap-3">
+                <input
+                  type="checkbox"
+                  checked={visibleKeys.length >0 && visibleKeys.every((k) => selectedIds.has(k.id))}
+                  onChange={toggleSelectAll}
+                  className="h-4 w-4 rounded border-[var(--border)] accent-[var(--color-accent)]"
+                />
+                <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  Select all
+                </span>
+              </label>
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="relative max-w-xs flex-1">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-muted)]" />
                   <input
-                    type="checkbox"
-                    checked={selectedIds.size > 0 && selectedIds.size === keys.data.keys.length}
-                    onChange={toggleSelectAll}
-                    className="h-4 w-4 rounded border-[var(--border)] accent-[var(--color-accent)]"
+                    type="text"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Search keys…"
+                    className="w-full rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] py-1.5 pl-9 pr-9 text-sm placeholder:text-[var(--text-muted)] focus:border-accent-400 focus:outline-none focus:ring-2 focus:ring-accent-400/40"
                   />
-                  <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                    Select all
-                  </span>
-                </label>
-                <div className="flex items-center gap-2 text-[11px] font-medium text-[var(--text-muted)]">
+                  {searchQuery && (
+                    <button
+                      onClick={() => setSearchQuery("")}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-[var(--text-muted)] hover:text-[var(--text)]"
+                      aria-label="Clear search"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+                <div className="flex items-center gap-1.5 text-[11px] font-medium text-[var(--text-muted)]">
+                  <ArrowUpDown className="h-3.5 w-3.5" />
+                  <select
+                    className="bg-transparent font-semibold text-[var(--text)] outline-none cursor-pointer"
+                    value={sortKey}
+                    onChange={(e) => setSortKey(e.target.value as any)}
+                  >
+                    <option value="created_desc">Newest first</option>
+                    <option value="created_asc">Oldest first</option>
+                    <option value="name_asc">Name A–Z</option>
+                    <option value="name_desc">Name Z–A</option>
+                  </select>
+                </div>
+                <div className="flex items-center gap-1.5 text-[11px] font-medium text-[var(--text-muted)]">
                   <span>Filter:</span>
                   <select
                     className="bg-transparent font-semibold text-[var(--text)] outline-none cursor-pointer"
@@ -503,27 +570,27 @@ export function KeysPage() {
                   </select>
                 </div>
               </div>
-            )}
-            <div className="divide-y divide-[var(--border)]">
-              {keys.data.keys
-                .filter(k => {
-                  if (statusFilter === "active") return !k.disabled;
-                  if (statusFilter === "inactive") return k.disabled;
-                  return true;
-                })
-                .map((k) => (
-                <KeyRow
-                  key={k.id}
-                  apiKey={k}
-                  selected={selectedIds.has(k.id)}
-                  onSelect={() => toggleSelect(k.id)}
-                  onToggle={() => toggleDisabled.mutate({ id: k.id, disabled: !k.disabled })}
-                  onConfigure={() => navigate(`/keys/${k.id}`)}
-                  onRevoke={() => remove.mutate(k.id)}
-                  togglePending={toggleDisabled.isPending}
-                />
-              ))}
             </div>
+            {visibleKeys.length ===0 ? (
+              <div className="px-6 py-10 text-center text-sm text-[var(--text-muted)]">
+                No keys match your search or filters.
+              </div>
+            ) : (
+              <div className="divide-y divide-[var(--border)]">
+                {visibleKeys.map((k) => (
+                  <KeyRow
+                    key={k.id}
+                    apiKey={k}
+                    selected={selectedIds.has(k.id)}
+                    onSelect={() => toggleSelect(k.id)}
+                    onToggle={() => toggleDisabled.mutate({ id: k.id, disabled: !k.disabled })}
+                    onConfigure={() => navigate(`/keys/${k.id}`)}
+                    onRevoke={() => remove.mutate(k.id)}
+                    togglePending={toggleDisabled.isPending}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         )}
       </Card>

--- a/frontend/src/pages/ProviderDetail.tsx
+++ b/frontend/src/pages/ProviderDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Plus, Trash2, Plug, X, Zap, ArrowUp, ArrowDown, CheckCircle, ToggleLeft, ToggleRight, Search, Route, AlertCircle, AlertTriangle, RefreshCw, Globe, Copy, Check, Upload, Loader2, XCircle, Layers, FileText } from "lucide-react";
+import { ArrowLeft, Plus, Trash2, Plug, X, Zap, ArrowUp, ArrowDown, CheckCircle, ToggleLeft, ToggleRight, Search, Route, AlertCircle, AlertTriangle, RefreshCw, Globe, Copy, Check, Upload, Loader2, XCircle, Layers, FileText, Download } from "lucide-react";
 import { api, type DeviceCode, type OAuthProvider, type Provider, type Account, type ProxyPool, type UpstreamQuota, type ProviderRoutingSettings, type BulkAccountResult, type QuotaAccount } from "../lib/api";
 import { KiroConnectModal } from "../components/KiroConnectModal";
 import { QoderConnectModal } from "../components/QoderConnectModal";
@@ -82,6 +82,22 @@ export function ProviderDetailPage() {
     staleTime: 60_000,
   });
 
+  const importModelsMut = useMutation({
+    mutationFn: () => api.importModels(id!),
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ["provider-models", id] });
+      qc.invalidateQueries({ queryKey: ["custom-models", id] });
+      const msg =
+        res.imported > 0
+          ? `Imported ${res.imported} model${res.imported === 1 ? "" : "s"} from /models${res.skipped ? ` (${res.skipped} already present)` : ""}.`
+          : res.total > 0
+            ? `No new models — all ${res.total} were already registered.`
+            : "No models returned by /models.";
+      toast.success("Import complete", msg);
+    },
+    onError: (e: Error) => toast.error("Couldn't import models", e.message),
+  });
+
   const provider = providers.data?.providers.find((p) => p.id === id);
   const oauthProvider = oauthProviders.data?.providers.find((p) => p.provider === id);
   const myAccounts = (accounts.data?.accounts ?? []).filter((a) => a.provider === id);
@@ -128,11 +144,12 @@ export function ProviderDetailPage() {
   };
 
   const filteredModels = useMemo(() => {
-    if (!models.data?.models) return [];
-    if (!modelSearchQuery.trim()) return models.data.models;
+    const all = models.data?.models ?? [];
+    if (all.length === 0) return [];
+    if (!modelSearchQuery.trim()) return all;
     const lowerQ = modelSearchQuery.toLowerCase();
-    return models.data.models.filter(m => 
-      m.id.toLowerCase().includes(lowerQ) || 
+    return all.filter(m =>
+      m.id.toLowerCase().includes(lowerQ) ||
       (m.name && m.name.toLowerCase().includes(lowerQ)) ||
       (m.kind && m.kind.toLowerCase().includes(lowerQ))
     );
@@ -144,9 +161,10 @@ export function ProviderDetailPage() {
 
   const totalModelPages = Math.ceil(filteredModels.length / MODELS_PER_PAGE);
   const paginatedModels = filteredModels.slice(
-    (modelPage - 1) * MODELS_PER_PAGE, 
+    (modelPage - 1) * MODELS_PER_PAGE,
     modelPage * MODELS_PER_PAGE
   );
+  const modelList = models.data?.models ?? [];
 
   // Set default region when provider loads.
   useEffect(() => {
@@ -619,12 +637,27 @@ export function ProviderDetailPage() {
         </Card>
 
         {/* Available Models */}
-        {models.data?.models && models.data.models.length > 0 && (
+        {models.data && (
           <Card>
             <CardHeader
               title="Available Models"
-              description={`${models.data.models.length} model${models.data.models.length === 1 ? "" : "s"} configured for this provider.`}
+              description={`${modelList.length} model${modelList.length === 1 ? "" : "s"} configured for this provider.`}
+              action={
+                provider?.custom ? (
+                  <Button
+                    variant="secondary"
+                    className="h-8 px-3 text-xs"
+                    disabled={importModelsMut.isPending}
+                    onClick={() => importModelsMut.mutate()}
+                    title="Fetch the upstream /models listing and register each model"
+                  >
+                    <Download className="h-3.5 w-3.5" />
+                    {importModelsMut.isPending ? "Fetching…" : "Fetch from /models"}
+                  </Button>
+                ) : undefined
+              }
             />
+            {modelList.length > 0 && (
             <div className="flex flex-col gap-3 border-t border-[var(--border)] bg-[var(--bg-subtle)] px-6 py-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="relative w-full max-w-sm">
                 <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-muted)]" />
@@ -694,9 +727,27 @@ export function ProviderDetailPage() {
                 )}
               </div>
             </div>
+            )}
             {filteredModels.length === 0 ? (
               <div className="px-6 py-12 text-center text-sm text-[var(--text-muted)] border-t border-[var(--border)]">
-                No models found matching "{modelSearchQuery}"
+                {modelList.length === 0 ? (
+                  <div className="flex flex-col items-center gap-3">
+                    <span>No models configured yet.</span>
+                    {provider?.custom && (
+                      <Button
+                        variant="secondary"
+                        className="h-8 px-3 text-xs"
+                        disabled={importModelsMut.isPending}
+                        onClick={() => importModelsMut.mutate()}
+                      >
+                        <Download className="h-3.5 w-3.5" />
+                        {importModelsMut.isPending ? "Fetching…" : "Fetch from /models"}
+                      </Button>
+                    )}
+                  </div>
+                ) : (
+                  <>No models found matching "{modelSearchQuery}"</>
+                )}
               </div>
             ) : (
               <div className={`grid grid-cols-1 gap-px overflow-hidden border-t border-[var(--border)] bg-[var(--border)] sm:grid-cols-2 lg:grid-cols-3 ${totalModelPages <= 1 ? "rounded-b-2xl" : ""}`}>

--- a/frontend/src/pages/ProviderHealth.tsx
+++ b/frontend/src/pages/ProviderHealth.tsx
@@ -1,0 +1,716 @@
+import { useState, type ReactNode } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { useQuery, useQueryClient, type UseQueryResult } from "@tanstack/react-query";
+import { ArrowLeft, Lightbulb, Play, RefreshCw } from "lucide-react";
+import {
+  api,
+  type HealthStatus,
+  type HealthSummary,
+  type HealthProviderRow,
+  type HealthProviderDetail,
+  type HealthModelRow,
+  type HealthChainRow,
+  type HealthProbeRow,
+} from "../lib/api";
+import { PageHeader } from "../components/Layout";
+import {
+  Badge,
+  Card,
+  EmptyState,
+  ErrorCard,
+  SegmentedControl,
+  Spinner,
+  TablePagination,
+  useClientPagination,
+} from "../components/ui";
+import { HealthStatusBadge, HealthScoreRing, fmtIssue } from "../components/HealthBadge";
+import {
+  ErrorBreakdownChart,
+  ErrorRateChart,
+  FallbackChart,
+  LatencyChart,
+  RequestVolumeChart,
+  TTFTChart,
+} from "../components/HealthCharts";
+import { useToast } from "../components/Toast";
+
+const RANGES = [
+  { value: "5m", label: "5m" },
+  { value: "15m", label: "15m" },
+  { value: "1h", label: "1h" },
+  { value: "6h", label: "6h" },
+  { value: "24h", label: "24h" },
+  { value: "7d", label: "7d" },
+];
+
+const STATUS_FILTERS = [
+  { value: "", label: "All" },
+  { value: "healthy", label: "Healthy" },
+  { value: "degraded", label: "Degraded" },
+  { value: "unhealthy", label: "Unhealthy" },
+  { value: "unknown", label: "Unknown" },
+];
+
+function fmtMs(ms?: number) {
+  if (ms == null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function fmtPct(v?: number) {
+  if (v == null) return "—";
+  return `${v.toFixed(1)}%`;
+}
+
+function fmtTime(t?: string) {
+  if (!t) return "—";
+  const d = new Date(t);
+  if (isNaN(d.getTime())) return "—";
+  const diff = Date.now() - d.getTime();
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return d.toLocaleString();
+}
+
+export function ProviderHealthPage() {
+  const { provider } = useParams();
+  if (provider) return <ProviderDetail provider={provider} />;
+  return <Overview />;
+}
+
+// ---- Overview ---------------------------------------------------------------
+
+type Tab = "providers" | "models" | "chains" | "probes";
+
+function Overview() {
+  const [params, setParams] = useSearchParams();
+  const range = params.get("range") ?? "1h";
+  const status = params.get("status") ?? "";
+  const [tab, setTab] = useState<Tab>("providers");
+
+  const setRange = (v: string) => setParams((p) => { p.set("range", v); return p; }, { replace: true });
+  const setStatus = (v: string) => setParams((p) => { if (v) p.set("status", v); else p.delete("status"); return p; }, { replace: true });
+
+  const overview = useQuery({
+    queryKey: ["health-overview", range, status],
+    queryFn: () => api.healthOverview(range, status || undefined),
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+  });
+
+  const models = useQuery({
+    queryKey: ["health-models", range, status],
+    queryFn: () => api.healthModels(range, status || undefined),
+    enabled: tab === "models",
+    staleTime: 15_000,
+  });
+
+  const chains = useQuery({
+    queryKey: ["health-chains", range],
+    queryFn: () => api.healthChains(range),
+    enabled: tab === "chains",
+    staleTime: 15_000,
+  });
+
+  return (
+    <div>
+      <PageHeader
+        title="Provider Health"
+        description="Monitor the health of every AI provider connected to KeiRouter. See which are failing or slow, why, which routing chains are affected, and what to do next."
+        action={
+          <div className="flex items-center gap-2">
+            <SegmentedControl value={range} onChange={setRange} options={RANGES} />
+            <button
+              onClick={() => overview.refetch()}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2.5 py-2 text-xs font-medium hover:bg-[var(--bg-subtle)]"
+            >
+              <RefreshCw className="h-3.5 w-3.5" /> Refresh
+            </button>
+          </div>
+        }
+      />
+
+      {overview.isLoading ? (
+        <Spinner />
+      ) : overview.isError ? (
+        <ErrorCard message="Failed to load provider health." />
+      ) : overview.data ? (
+        <>
+          <SummaryCards summary={overview.data.summary} />
+          <div className="mt-5">
+            <SegmentedControl
+              value={tab}
+              onChange={(v) => setTab(v as Tab)}
+              options={[
+                { value: "providers", label: "Providers" },
+                { value: "models", label: "Models" },
+                { value: "chains", label: "Chains" },
+                { value: "probes", label: "Probes" },
+              ]}
+            />
+          </div>
+          <div className="mt-4">
+            {tab === "providers" && (
+              <ProviderTable rows={overview.data.providers} status={status} onStatus={setStatus} />
+            )}
+            {tab === "models" && <ModelTable query={models} />}
+            {tab === "chains" && <ChainTable query={chains} />}
+            {tab === "probes" && <ProbeHistoryTable range={range} />}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function SummaryCards({ summary }: { summary: HealthSummary }) {
+  const total = summary.healthy + summary.degraded + summary.unhealthy + summary.unknown + summary.disabled;
+  const segments = [
+    { key: "healthy", label: "Healthy", count: summary.healthy, color: "var(--color-accent-500)" },
+    { key: "degraded", label: "Degraded", count: summary.degraded, color: "var(--color-warning)" },
+    { key: "unhealthy", label: "Unhealthy", count: summary.unhealthy, color: "var(--color-danger)" },
+    { key: "unknown", label: "Unknown", count: summary.unknown, color: "var(--color-ink-400)" },
+    { key: "disabled", label: "Disabled", count: summary.disabled, color: "var(--color-ink-300)" },
+  ].filter((s) => s.count > 0);
+
+  return (
+    <Card className="p-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        {/* Distribution bar + legend */}
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex items-baseline justify-between">
+            <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+              Provider Health
+            </span>
+            <span className="text-sm font-semibold tabular-nums">{total} total</span>
+          </div>
+          {total === 0 ? (
+            <div className="h-2.5 rounded-full bg-[var(--bg-subtle)]" />
+          ) : (
+            <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-[var(--bg-subtle)]">
+              {segments.map((s) => (
+                <div
+                  key={s.key}
+                  style={{ width: `${(s.count / total) * 100}%`, backgroundColor: s.color }}
+                  title={`${s.label}: ${s.count}`}
+                />
+              ))}
+            </div>
+          )}
+          <div className="mt-2.5 flex flex-wrap gap-x-4 gap-y-1">
+            {segments.map((s) => (
+              <div key={s.key} className="flex items-center gap-1.5 text-xs">
+                <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: s.color }} />
+                <span className="text-[var(--text-muted)]">{s.label}</span>
+                <span className="font-semibold tabular-nums">{s.count}</span>
+              </div>
+            ))}
+          </div>
+          <p className="mt-2 text-xs text-[var(--text-muted)]">
+            Share of providers by current health status. Green is working normally; yellow is slower or less reliable; red should be avoided.
+          </p>
+        </div>
+
+        {/* Compact key metrics */}
+        <div className="flex shrink-0 gap-5 border-t border-[var(--border)] pt-3 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0">
+          <CompactStat label="Fallbacks" value={summary.fallbacks.toLocaleString()} tone={summary.fallbacks > 0 ? "warning" : "muted"} />
+          <CompactStat label="Avg p95" value={fmtMs(summary.avg_p95_latency_ms)} tone="muted" />
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function CompactStat({ label, value, tone = "muted" }: { label: string; value: string; tone?: "muted" | "warning" | "danger" }) {
+  const color = tone === "warning" ? "text-[color:var(--color-warning)]" : tone === "danger" ? "text-[color:var(--color-danger)]" : "text-[var(--text)]";
+  return (
+    <div>
+      <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">{label}</div>
+      <div className={`mt-0.5 text-lg font-semibold tabular-nums ${color}`}>{value}</div>
+    </div>
+  );
+}
+
+function MetricPill({ label, value, tone = "muted" }: { label: string; value: string; tone?: "muted" | "good" | "warn" | "bad" }) {
+  const color =
+    tone === "good" ? "text-[color:var(--color-accent-500)]" :
+    tone === "warn" ? "text-[color:var(--color-warning)]" :
+    tone === "bad" ? "text-[color:var(--color-danger)]" :
+    "text-[var(--text)]";
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span className="text-[11px] font-medium uppercase tracking-wide text-[var(--text-muted)]">{label}</span>
+      <span className={`text-sm font-semibold tabular-nums ${color}`}>{value}</span>
+    </div>
+  );
+}
+
+function ProviderTable({
+  rows,
+  status,
+  onStatus,
+}: {
+  rows: HealthProviderRow[];
+  status: string;
+  onStatus: (v: string) => void;
+}) {
+  const { page, pages, paged, setPage, total } = useClientPagination(rows, 10);
+  return (
+    <Card>
+      <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+        <h2 className="text-sm font-semibold">Provider Status</h2>
+        <select
+          value={status}
+          onChange={(e) => onStatus(e.target.value)}
+          className="rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2 py-1 text-xs"
+        >
+          {STATUS_FILTERS.map((f) => (
+            <option key={f.value} value={f.value}>{f.label}</option>
+          ))}
+        </select>
+      </div>
+      {rows.length === 0 ? (
+        <EmptyState title="No health data yet." hint="Run a probe or send traffic through a provider." />
+      ) : (
+        <>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--border)] text-left text-xs text-[var(--text-muted)]">
+                  <th className="px-4 py-2 font-medium">Provider</th>
+                  <th className="px-4 py-2 font-medium">Status</th>
+                  <th className="px-4 py-2 font-medium">Score</th>
+                  <th className="px-4 py-2 font-medium">Success</th>
+                  <th className="px-4 py-2 font-medium">Errors</th>
+                  <th className="px-4 py-2 font-medium">p95</th>
+                  <th className="px-4 py-2 font-medium">Fallbacks</th>
+                  <th className="px-4 py-2 font-medium">Last Probe</th>
+                  <th className="px-4 py-2 font-medium">Main Issue</th>
+                </tr>
+              </thead>
+              <tbody>
+                {paged.map((r) => (
+                  <tr key={r.provider} className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-subtle)]">
+                    <td className="px-4 py-2.5 font-medium">{r.provider}</td>
+                    <td className="px-4 py-2.5"><HealthStatusBadge status={r.status as HealthStatus} issue={r.main_issue} /></td>
+                    <td className="px-4 py-2.5"><HealthScoreRing score={r.score} /></td>
+                    <td className="px-4 py-2.5 tabular-nums">{fmtPct(r.success_rate)}</td>
+                    <td className="px-4 py-2.5 tabular-nums">{fmtPct(r.error_rate)}</td>
+                    <td className="px-4 py-2.5 tabular-nums">{fmtMs(r.latency_p95_ms)}</td>
+                    <td className="px-4 py-2.5 tabular-nums">{r.fallback_count}</td>
+                    <td className="px-4 py-2.5 text-[var(--text-muted)]">{fmtTime(r.last_probe_at)}</td>
+                    <td className="px-4 py-2.5 text-[var(--text-muted)]">{fmtIssue(r.main_issue) || "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <TablePagination page={page} pages={pages} total={total} onPage={setPage} />
+        </>
+      )}
+    </Card>
+  );
+}
+
+function ModelTable({ query }: { query: UseQueryResult<{ models: HealthModelRow[] } | HealthProviderDetail> }) {
+  if (query.isLoading) return <Spinner />;
+  if (query.isError) return <ErrorCard message="Failed to load model health." />;
+  const rows = (query.data as { models?: HealthModelRow[] } | undefined)?.models ?? [];
+  if (rows.length === 0) return <Card><EmptyState title="No model health data yet." /></Card>;
+  return <ModelTableInner rows={rows} />;
+}
+
+function ModelTableInner({ rows }: { rows: HealthModelRow[] }) {
+  const { page, pages, paged, setPage, total } = useClientPagination(rows, 10);
+  return (
+    <Card>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[var(--border)] text-left text-xs text-[var(--text-muted)]">
+              <th className="px-4 py-2 font-medium">Provider / Model</th>
+              <th className="px-4 py-2 font-medium">Status</th>
+              <th className="px-4 py-2 font-medium">Score</th>
+              <th className="px-4 py-2 font-medium">Success</th>
+              <th className="px-4 py-2 font-medium">p95</th>
+              <th className="px-4 py-2 font-medium">Fallbacks</th>
+              <th className="px-4 py-2 font-medium">Main Issue</th>
+            </tr>
+          </thead>
+          <tbody>
+            {paged.map((r: HealthModelRow, i: number) => (
+              <tr key={`${r.provider}/${r.model}-${i}`} className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-subtle)]">
+                <td className="px-4 py-2.5 font-medium">{r.provider}/{r.model}</td>
+                <td className="px-4 py-2.5"><HealthStatusBadge status={r.status as HealthStatus} issue={r.main_issue} /></td>
+                <td className="px-4 py-2.5"><HealthScoreRing score={r.score} /></td>
+                <td className="px-4 py-2.5 tabular-nums">{fmtPct(r.success_rate)}</td>
+                <td className="px-4 py-2.5 tabular-nums">{fmtMs(r.latency_p95_ms)}</td>
+                <td className="px-4 py-2.5 tabular-nums">{r.fallback_count}</td>
+                <td className="px-4 py-2.5 text-[var(--text-muted)]">{fmtIssue(r.main_issue) || "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <TablePagination page={page} pages={pages} total={total} onPage={setPage} />
+    </Card>
+  );
+}
+
+function ChainTable({ query }: { query: UseQueryResult<{ chains: HealthChainRow[] }> }) {
+  const [selected, setSelected] = useState<string | null>(null);
+  if (query.isLoading) return <Spinner />;
+  if (query.isError) return <ErrorCard message="Failed to load chain impact." />;
+  const rows = query.data?.chains ?? [];
+  if (rows.length === 0) return <Card><EmptyState title="No chains configured." /></Card>;
+  return (
+    <div className="space-y-4">
+      <ChainTableInner rows={rows} onSelect={setSelected} />
+      {selected && <ChainDetail id={selected} onClose={() => setSelected(null)} />}
+    </div>
+  );
+}
+
+function ChainTableInner({ rows, onSelect }: { rows: HealthChainRow[]; onSelect: (id: string) => void }) {
+  const { page, pages, paged, setPage, total } = useClientPagination(rows, 10);
+  return (
+    <Card>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[var(--border)] text-left text-xs text-[var(--text-muted)]">
+              <th className="px-4 py-2 font-medium">Chain</th>
+              <th className="px-4 py-2 font-medium">Status</th>
+              <th className="px-4 py-2 font-medium">Requests</th>
+              <th className="px-4 py-2 font-medium">Fallback Rate</th>
+              <th className="px-4 py-2 font-medium">Final Failures</th>
+              <th className="px-4 py-2 font-medium">Affected</th>
+              <th className="px-4 py-2 font-medium">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {paged.map((r) => (
+              <tr key={r.chain_id} className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--bg-subtle)] cursor-pointer" onClick={() => onSelect(r.chain_id)}>
+                <td className="px-4 py-2.5 font-medium">{r.name}</td>
+                <td className="px-4 py-2.5"><HealthStatusBadge status={r.status} issue={r.main_issue} /></td>
+                <td className="px-4 py-2.5 tabular-nums">{r.requests.toLocaleString()}</td>
+                <td className="px-4 py-2.5 tabular-nums">{fmtPct(r.fallback_rate)}</td>
+                <td className="px-4 py-2.5 tabular-nums">
+                  {r.final_failure_count > 0 ? <span className="text-[color:var(--color-danger)] font-medium">{r.final_failure_count}</span> : "0"}
+                </td>
+                <td className="px-4 py-2.5 text-[var(--text-muted)]">{r.affected_provider ? `${r.affected_provider}/${r.affected_model}` : "—"}</td>
+                <td className="px-4 py-2.5 text-xs text-accent-600 dark:text-accent-300">View →</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <TablePagination page={page} pages={pages} total={total} onPage={setPage} />
+    </Card>
+  );
+}
+
+function ChainDetail({ id, onClose }: { id: string; onClose: () => void }) {
+  const q = useQuery({
+    queryKey: ["health-chain", id],
+    queryFn: () => api.healthChainDetail(id),
+    staleTime: 15_000,
+  });
+  return (
+    <Card>
+      <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+        <h2 className="text-sm font-semibold">Chain Detail</h2>
+        <button onClick={onClose} className="text-xs text-[var(--text-muted)] hover:text-[var(--text)]">Close</button>
+      </div>
+      {q.isLoading ? <Spinner /> : q.isError ? <EmptyState title="Failed to load chain detail." /> : q.data ? (
+        <div className="px-4 py-3">
+          <div className="mb-3 flex flex-wrap items-center gap-3 text-sm">
+            <span className="font-medium">{q.data.name}</span>
+            <Badge tone="neutral">{q.data.strategy}</Badge>
+            {q.data.requests != null && <span className="text-[var(--text-muted)]">{q.data.requests.toLocaleString()} requests</span>}
+            {q.data.fallback_rate != null && <span className="text-[var(--text-muted)]">{fmtPct(q.data.fallback_rate)} fallback rate</span>}
+            {q.data.final_failure_count != null && q.data.final_failure_count > 0 && (
+              <span className="text-[color:var(--color-danger)]">{q.data.final_failure_count} final failures</span>
+            )}
+          </div>
+          <div className="space-y-2">
+            {q.data.steps.map((step) => (
+              <div key={step.position} className="flex items-center gap-3 rounded-lg border border-[var(--border)] px-3 py-2">
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--bg-subtle)] text-xs font-medium">{step.position + 1}</span>
+                <div className="flex-1">
+                  <div className="text-sm font-medium">{step.provider}/{step.model}</div>
+                  {step.main_issue && <div className="text-xs text-[var(--text-muted)]">{fmtIssue(step.main_issue)}</div>}
+                </div>
+                <HealthStatusBadge status={step.status} />
+                <HealthScoreRing score={step.score} size={36} />
+              </div>
+            ))}
+            {q.data.fallback_provider && (
+              <div className="flex items-center gap-3 rounded-lg border border-dashed border-[var(--border)] px-3 py-2">
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--bg-subtle)] text-xs">★</span>
+                <div className="flex-1 text-sm text-[var(--text-muted)]">
+                  Fallback: {q.data.fallback_provider}/{q.data.fallback_model}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+// ---- Probe history ---------------------------------------------------------
+
+function ProbeHistoryTable({ range }: { range: string }) {
+  const [page, setPage] = useState(1);
+  const q = useQuery({
+    queryKey: ["health-probes", range, page],
+    queryFn: () => api.healthProbeHistory({ range, page, limit: 50 }),
+    staleTime: 15_000,
+  });
+  if (q.isLoading) return <Spinner />;
+  if (q.isError) return <ErrorCard message="Failed to load probe history." />;
+  const rows = q.data?.items ?? [];
+  const total = q.data?.pagination.total ?? 0;
+  const pages = Math.max(1, Math.ceil(total / 50));
+  if (rows.length === 0) return <Card><EmptyState title="No probes yet." hint="Run a manual probe to see results here." /></Card>;
+  return (
+    <Card>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[var(--border)] text-left text-xs text-[var(--text-muted)]">
+              <th className="px-4 py-2 font-medium">Time</th>
+              <th className="px-4 py-2 font-medium">Provider / Model</th>
+              <th className="px-4 py-2 font-medium">Status</th>
+              <th className="px-4 py-2 font-medium">Latency</th>
+              <th className="px-4 py-2 font-medium">HTTP</th>
+              <th className="px-4 py-2 font-medium">Error</th>
+              <th className="px-4 py-2 font-medium">Trigger</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r: HealthProbeRow, i) => (
+              <tr key={i} className="border-b border-[var(--border)] last:border-0">
+                <td className="px-4 py-2.5 text-[var(--text-muted)]">{fmtTime(r.time)}</td>
+                <td className="px-4 py-2.5 font-medium">{r.provider}/{r.model}</td>
+                <td className="px-4 py-2.5">
+                  <Badge tone={r.status === "success" ? "success" : "danger"}>{r.status}</Badge>
+                </td>
+                <td className="px-4 py-2.5 tabular-nums">{fmtMs(r.latency_ms)}</td>
+                <td className="px-4 py-2.5 tabular-nums">{r.http_status ?? "—"}</td>
+                <td className="px-4 py-2.5 text-[var(--text-muted)]">{fmtIssue(r.error_type) || "—"}</td>
+                <td className="px-4 py-2.5"><Badge tone="neutral">{r.triggered_by}</Badge></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <TablePagination page={page} pages={pages} total={total} onPage={setPage} />
+    </Card>
+  );
+}
+
+// ---- Provider detail -------------------------------------------------------
+
+function ProviderDetail({ provider }: { provider: string }) {
+  const [params, setParams] = useSearchParams();
+  const range = params.get("range") ?? "24h";
+
+  const detail = useQuery({
+    queryKey: ["health-provider", provider, range],
+    queryFn: () => api.healthProviderDetail(provider, range),
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+  });
+
+  if (detail.isLoading) return <Spinner />;
+  if (detail.isError) return (
+    <div>
+      <BackLink />
+      <ErrorCard message="Failed to load provider detail." />
+    </div>
+  );
+  const d = detail.data;
+  if (!d) return null;
+
+  return (
+    <div>
+      <Card className="mb-4 p-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-4">
+            <BackLink />
+            <HealthScoreRing score={d.score} size={56} />
+            <div>
+              <h1 className="font-display text-2xl font-semibold tracking-tight">{d.provider}</h1>
+              <div className="mt-1 flex items-center gap-2">
+              <HealthStatusBadge status={d.status as HealthStatus} issue={d.main_issue} />
+              {d.main_issue && <span className="text-xs text-[var(--text-muted)]">{fmtIssue(d.main_issue)}</span>}
+              </div>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <SegmentedControl value={range} onChange={(v) => setParams((p) => { p.set("range", v); return p; }, { replace: true })} options={RANGES} />
+          </div>
+        </div>
+
+        {/* Compact inline metric strip — replaces the old 6-card grid */}
+        <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-[var(--border)] pt-3">
+          <MetricPill label="Requests" value={d.metrics.requests.toLocaleString()} />
+          <MetricPill label="Success" value={fmtPct(d.metrics.success_rate)} tone={d.metrics.success_rate >= 95 ? "good" : "warn"} />
+          <MetricPill label="Errors" value={fmtPct(d.metrics.error_rate)} tone={d.metrics.error_rate >= 5 ? "bad" : "muted"} />
+          <MetricPill label="p95" value={fmtMs(d.metrics.latency_p95_ms)} />
+          <MetricPill label="TTFT" value={fmtMs(d.metrics.ttft_p95_ms)} />
+          <MetricPill label="Fallbacks" value={d.metrics.fallback_count.toLocaleString()} tone={d.metrics.fallback_count > 0 ? "warn" : "muted"} />
+        </div>
+      </Card>
+
+      {(d.main_issue || d.recommendation) && (
+        <RecommendationPanel issue={fmtIssue(d.main_issue)} recommendation={d.recommendation} />
+      )}
+
+
+      <TrendCharts snapshots={d.snapshots ?? []} />
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <Card>
+          <div className="border-b border-[var(--border)] px-4 py-3">
+            <h2 className="text-sm font-semibold">Error Breakdown</h2>
+          </div>
+          {Object.keys(d.error_breakdown).length === 0 ? (
+            <EmptyState title="No errors in this window." />
+          ) : (
+            <div className="px-4 py-3 space-y-2">
+              {Object.entries(d.error_breakdown)
+                .sort((a, b) => b[1] - a[1])
+                .map(([k, v]) => (
+                  <div key={k} className="flex items-center justify-between text-sm">
+                    <span className="text-[var(--text-muted)]">{fmtIssue(k)}</span>
+                    <span className="tabular-nums font-medium">{v}</span>
+                  </div>
+                ))}
+            </div>
+          )}
+        </Card>
+        <Card>
+          <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+            <h2 className="text-sm font-semibold">Manual Probe</h2>
+            <ManualProbeInline provider={provider} models={d.models.map((m) => m.model).filter(Boolean)} />
+          </div>
+          <div className="px-4 py-3 text-sm text-[var(--text-muted)]">
+            Run a synthetic probe to test this provider now. Result appears in probe history.
+          </div>
+        </Card>
+      </div>
+
+      <div className="mt-4">
+        <h2 className="mb-2 text-sm font-semibold">Models</h2>
+        <ModelTable query={detail} />
+      </div>
+    </div>
+  );
+}
+
+function TrendCharts({ snapshots }: { snapshots: import("../lib/api").HealthSnapshot[] }) {
+  if (!snapshots.length) {
+    return (
+      <Card className="mt-4">
+        <EmptyState title="No trend data yet." hint="Snapshots appear after traffic flows through this provider." />
+      </Card>
+    );
+  }
+  return (
+    <div className="mt-4 grid gap-4 lg:grid-cols-2">
+      <ChartCard title="Request Volume">
+        <RequestVolumeChart data={snapshots} />
+      </ChartCard>
+      <ChartCard title="Error Rate">
+        <ErrorRateChart data={snapshots} />
+      </ChartCard>
+      <ChartCard title="Latency p50 / p95 / p99">
+        <LatencyChart data={snapshots} />
+      </ChartCard>
+      <ChartCard title="TTFT p95">
+        <TTFTChart data={snapshots} />
+      </ChartCard>
+      <ChartCard title="Fallbacks">
+        <FallbackChart data={snapshots} />
+      </ChartCard>
+      <ChartCard title="Error Type Breakdown">
+        <ErrorBreakdownChart data={snapshots} />
+      </ChartCard>
+    </div>
+  );
+}
+
+function ChartCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <Card>
+      <div className="border-b border-[var(--border)] px-4 py-3">
+        <h2 className="text-sm font-semibold">{title}</h2>
+      </div>
+      <div className="h-56 p-3">{children}</div>
+    </Card>
+  );
+}
+
+function BackLink() {
+  return (
+    <a href="/provider-health" className="inline-flex items-center gap-1 text-sm text-[var(--text-muted)] hover:text-[var(--text)]">
+      <ArrowLeft className="h-4 w-4" /> Back
+    </a>
+  );
+}
+
+function RecommendationPanel({ issue, recommendation }: { issue: string; recommendation: string }) {
+  if (!issue && !recommendation) return null;
+  return (
+    <Card className="mt-4 border-[color:var(--color-warning)]/30 bg-[color:var(--color-warning)]/5">
+      <div className="flex items-start gap-3 px-4 py-3.5">
+        <Lightbulb className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--color-warning)]" />
+        <div className="text-sm">
+          {issue && <p className="font-medium">Main issue: <span className="text-[var(--text-muted)]">{fmtIssue(issue)}</span></p>}
+          {recommendation && <p className="mt-1 text-[var(--text-muted)]">{recommendation}</p>}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function ManualProbeInline({ provider, models }: { provider: string; models: string[] }) {
+  const [model, setModel] = useState(models[0] ?? "");
+  const [running, setRunning] = useState(false);
+  const qc = useQueryClient();
+  const toast = useToast();
+  const run = async () => {
+    if (!model) return;
+    setRunning(true);
+    try {
+      const res = await api.runHealthProbe({ provider, model });
+      toast.success(res.message);
+      qc.invalidateQueries({ queryKey: ["health-probes"] });
+      qc.invalidateQueries({ queryKey: ["health-provider", provider] });
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setRunning(false);
+    }
+  };
+  return (
+    <div className="flex items-center gap-2">
+      <select value={model} onChange={(e) => setModel(e.target.value)} className="rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2 py-1 text-xs">
+        {models.map((m) => <option key={m} value={m}>{m}</option>)}
+      </select>
+      <button
+        onClick={run}
+        disabled={running || !model}
+        className="inline-flex items-center gap-1.5 rounded-lg bg-accent-600 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-accent-700 disabled:opacity-50"
+      >
+        {running ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
+        Run Probe
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -263,18 +263,25 @@ function CreateCustomProviderModal({ open, onClose }: { open: boolean; onClose: 
   const [name, setName] = useState("");
   const [dialect, setDialect] = useState("openai");
   const [baseURL, setBaseURL] = useState("");
+  const [alias, setAlias] = useState("");
   const [error, setError] = useState("");
 
   const reset = () => {
     setName("");
     setDialect("openai");
     setBaseURL("");
+    setAlias("");
     setError("");
   };
 
   const create = useMutation({
     mutationFn: () =>
-      api.createCustomProvider({ display_name: name.trim(), dialect, base_url: baseURL.trim() }),
+      api.createCustomProvider({
+        display_name: name.trim(),
+        dialect,
+        base_url: baseURL.trim(),
+        alias: alias.trim() ? alias.trim() : undefined,
+      }),
     onSuccess: (p) => {
       qc.invalidateQueries({ queryKey: ["providers"] });
       toast.success("Custom provider created", "Add an account and models to start routing.");
@@ -321,6 +328,26 @@ function CreateCustomProviderModal({ open, onClose }: { open: boolean; onClose: 
             onChange={(e) => { setBaseURL(e.target.value); setError(""); }}
             placeholder="https://llm.example.com/v1"
           />
+        </Field>
+        <Field label="Alias / prefix (optional)">
+          <Input
+            value={alias}
+            onChange={(e) => {
+              const slug = e.target.value
+                .toLowerCase()
+                .replace(/\s+/g, "-")
+                .replace(/[^a-z0-9-]/g, "")
+                .replace(/-+/g, "-");
+              setAlias(slug);
+              setError("");
+            }}
+            placeholder="e.g. kei-ai — models route as <alias>/<model>"
+            pattern="[A-Za-z0-9-]*"
+            maxLength={32}
+          />
+          <p className="text-xs text-[var(--text-muted)]">
+            Letters, digits, hyphens only (max 32). Leave blank to derive from the name. Models route as <code>&lt;alias&gt;/&lt;model&gt;</code>.
+          </p>
         </Field>
         <p className="text-xs text-[var(--text-muted)]">
           Tip: add two separate instances for two endpoints of the same type — they will never share models or credentials.

--- a/frontend/src/pages/Skills.tsx
+++ b/frontend/src/pages/Skills.tsx
@@ -7,8 +7,8 @@ import { useToast } from "../components/Toast";
 import { Card, SectionHeader, CardHeader, Button, Input, Field, Spinner, EmptyState, Toggle, ErrorBanner } from "../components/ui";
 
 // Built-in reference skills — documentation pages that teach AI agents how to
-// call KeiRouter endpoints. These mirror 9router's skills model: static docs
-// with copyable URLs, not runtime request modifiers.
+// call KeiRouter endpoints. These are static docs with copyable URLs, not
+// runtime request modifiers.
 const REFERENCE_SKILLS = [
   { id: "keirouter", name: "KeiRouter (Entry)", endpoint: null as string | null, description: "Setup guide and index of all capabilities." },
   { id: "keirouter-chat", name: "Chat", endpoint: "/v1/chat/completions", description: "Chat and code generation via OpenAI or Anthropic format with streaming." },

--- a/frontend/src/routePreload.ts
+++ b/frontend/src/routePreload.ts
@@ -28,6 +28,7 @@ export const routeLoaders = {
   "/oauth-callback": () => named(import("./pages/OAuthCallback"), "OAuthCallbackPage"),
   "/portal": () => named(import("./pages/KeyPortal"), "KeyPortalPage"),
   "/guardrails": () => named(import("./pages/Guardrails"), "GuardrailsPage"),
+  "/provider-health": () => named(import("./pages/ProviderHealth"), "ProviderHealthPage"),
 } as const;
 
 export type RoutePreloadKey = keyof typeof routeLoaders;


### PR DESCRIPTION
## Summary
Adds a provider health dashboard with telemetry collection and active health probes.

- New provider health store repo, models, and migration (`0025_provider_health.sql`)
- Health probe pipeline integration and meter telemetry
- Frontend health dashboard page, badges, and charts
- Custom model source support and related migrations (`0023`, `0024`)
- Key portal, keys, and provider detail UI updates

## Changes
- Backend: `store/repo_provider_health.go`, `store/models.go`, `pipeline/pipeline.go`, `meter/meter.go`, migrations
- Frontend: `pages/ProviderHealth.tsx`, `components/HealthBadge.tsx`, `components/HealthCharts.tsx`, `lib/api.ts`, routing/layout wiring
- Config: `config.example.yaml` health probe options

## Tested
- `go test ./...` for backend (health, store, pipeline)
- Frontend build/type-check

## Notes
- Adds new migrations; run against a backup before applying to production.