### PR TITLE
feat(admin): import foreign router configs

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -19,17 +19,17 @@ import (
 
 // Config is the fully-resolved application configuration.
 type Config struct {
-	Server     ServerConfig     `koanf:"server"`
-	Database   DatabaseConfig   `koanf:"database"`
-	Security   SecurityConfig   `koanf:"security"`
-	Cache      CacheConfig      `koanf:"cache"`
-	Meter      MeterConfig      `koanf:"meter"`
-	Limits     LimitsConfig     `koanf:"limits"`
-	Health     HealthConfig     `koanf:"health"`
+	Server         ServerConfig         `koanf:"server"`
+	Database       DatabaseConfig       `koanf:"database"`
+	Security       SecurityConfig       `koanf:"security"`
+	Cache          CacheConfig          `koanf:"cache"`
+	Meter          MeterConfig          `koanf:"meter"`
+	Limits         LimitsConfig         `koanf:"limits"`
+	Health         HealthConfig         `koanf:"health"`
 	ProviderHealth ProviderHealthConfig `koanf:"provider_health"`
-	Log        LogConfig        `koanf:"log"`
-	Data       DataConfig       `koanf:"data"`
-	Guardrails GuardrailsConfig `koanf:"guardrails"`
+	Log            LogConfig            `koanf:"log"`
+	Data           DataConfig           `koanf:"data"`
+	Guardrails     GuardrailsConfig     `koanf:"guardrails"`
 }
 
 // ServerConfig controls the HTTP listener.
@@ -194,10 +194,10 @@ type ProviderHealthCapabilityConfig struct {
 
 // ProviderHealthProbeConfig configures one capability's probe payload.
 type ProviderHealthProbeConfig struct {
-	Enabled  bool   `koanf:"enabled"`
-	MaxTokens int   `koanf:"max_tokens"`
-	Prompt   string `koanf:"prompt"`
-	Input    string `koanf:"input"`
+	Enabled   bool   `koanf:"enabled"`
+	MaxTokens int    `koanf:"max_tokens"`
+	Prompt    string `koanf:"prompt"`
+	Input     string `koanf:"input"`
 }
 
 // LogConfig controls structured logging.
@@ -259,8 +259,8 @@ func Default() Config {
 		},
 		Database: DatabaseConfig{
 			Driver:       "sqlite",
-			MaxOpenConns: 4, // sqlite WAL permits concurrent readers; writes still serialize
-			MaxIdleConns: 4,
+			MaxOpenConns: 0,
+			MaxIdleConns: 0,
 		},
 		Security: SecurityConfig{
 			SessionTTL:       24 * time.Hour,

--- a/backend/internal/dispatch/dispatch.go
+++ b/backend/internal/dispatch/dispatch.go
@@ -94,6 +94,7 @@ type TokenRefresher interface {
 type HealthSource interface {
 	IsUnhealthy(ctx context.Context, accountID, model string) (bool, error)
 	MarkHealthy(ctx context.Context, accountID, model string) error
+	UnhealthyAccounts(ctx context.Context, accountIDs []string, model string) (map[string]bool, error)
 }
 
 // RoutingSource provides model-level cooldowns and chain rotation state.
@@ -101,6 +102,7 @@ type RoutingSource interface {
 	SetModelCooldown(ctx context.Context, accountID, model string, until time.Time) error
 	ClearModelCooldown(ctx context.Context, accountID, model string) error
 	IsModelCooldownActive(ctx context.Context, accountID, model string) (bool, error)
+	ActiveCooldowns(ctx context.Context, accountIDs []string, model string) (map[string]bool, error)
 	GetChainRotationState(ctx context.Context, chainID string) (store.ChainRotation, error)
 	SetChainRotationState(ctx context.Context, state store.ChainRotation) error
 	GetTargetRotationState(ctx context.Context, scopeKey string) (store.TargetRotation, error)
@@ -249,6 +251,20 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 		}
 		accs = d.applyAccountRouting(ctx, tenantID, target, accs, opts.accountRoutingForTarget(target.Provider))
 
+		accountIDs := make([]string, 0, len(accs))
+		for _, acc := range accs {
+			accountIDs = append(accountIDs, acc.ID)
+		}
+
+		var cooldownSet map[string]bool
+		if d.routing != nil && len(accountIDs) > 0 {
+			cooldownSet, _ = d.routing.ActiveCooldowns(ctx, accountIDs, target.Model)
+		}
+		var unhealthySet map[string]bool
+		if d.health != nil && len(accountIDs) > 0 {
+			unhealthySet, _ = d.health.UnhealthyAccounts(ctx, accountIDs, target.Model)
+		}
+
 		for _, acc := range accs {
 			// Account-level cooldown (global cooldown from NoteFailure).
 			if acc.CooldownUntil != nil && acc.CooldownUntil.After(now) {
@@ -257,27 +273,24 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 			}
 			// Skip accounts whose OAuth refresh token was permanently rejected;
 			// they need the user to re-authenticate before they can serve traffic.
+
 			if acc.NeedsReconnect {
 				lastReason = fmt.Sprintf("account %s needs reconnection (refresh token revoked)", acc.ID)
 				continue
 			}
 			// Model-level cooldown: skip this account only for this model.
-			if d.routing != nil {
-				locked, _ := d.routing.IsModelCooldownActive(ctx, acc.ID, target.Model)
-				if locked {
-					lastReason = fmt.Sprintf("account %s model %s on cooldown", acc.ID, target.Model)
-					continue
-				}
+
+			if cooldownSet != nil && cooldownSet[acc.ID] {
+				lastReason = fmt.Sprintf("account %s model %s on cooldown", acc.ID, target.Model)
+				continue
 			}
 			// Background health checker: deprioritize known-unhealthy accounts
 			// rather than hard-skipping them. They are held back as fallback
 			// candidates so that when no healthy account is available the
 			// request still reaches the provider — and a successful response
 			// lets NoteSuccess recover the health row.
-			isUnhealthy := false
-			if d.health != nil {
-				isUnhealthy, _ = d.health.IsUnhealthy(ctx, acc.ID, target.Model)
-			}
+
+			isUnhealthy := unhealthySet != nil && unhealthySet[acc.ID]
 			// Refresh an expiring OAuth access token before use, so the
 			// connector always receives a live token. A refresh failure skips
 			// this account and falls back to the next.

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -103,6 +103,7 @@ func (s *Server) mountAdmin(r chi.Router) {
 	r.Post("/settings/access", s.adminUpdateAccessSettings)
 	r.Get("/settings/database", s.adminExportDatabase)
 	r.Post("/settings/database", s.adminImportDatabase)
+	r.Post("/settings/database/import-foreign", s.adminImportForeignConfig)
 	r.Get("/settings/sqlite", s.adminSQLiteStatus)
 	r.Get("/settings/sqlite/backup", s.adminSQLiteBackup)
 	r.Post("/settings/sqlite/restore", s.adminSQLiteRestore)

--- a/backend/internal/gateway/admin_custom_providers.go
+++ b/backend/internal/gateway/admin_custom_providers.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -131,9 +132,9 @@ func (s *Server) adminListCustomProviders(w http.ResponseWriter, r *http.Request
 
 func (s *Server) adminCreateCustomProvider(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		DisplayName string `json:"display_name"`
-		Dialect     string `json:"dialect"` // "openai" | "anthropic"
-		BaseURL     string `json:"base_url"`
+		DisplayName string  `json:"display_name"`
+		Dialect     string  `json:"dialect"` // "openai" | "anthropic"
+		BaseURL     string  `json:"base_url"`
 		Alias       *string `json:"alias"` // optional routing prefix; defaults to the generated id
 	}
 	if !decodeJSON(w, r, &body) {
@@ -256,16 +257,54 @@ func (s *Server) adminUpdateCustomProvider(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) adminDeleteCustomProvider(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+
+	// The generic custom-compatible gateways ("custom-openai" /
+	// "custom-anthropic") are built-in catalog templates, not user-defined
+	// instances. They are never stored in custom_providers and must never be
+	// deleted -- only dynamic instances under the custom-openai-* /
+	// custom-anthropic-* namespaces can be.
+	if id == "custom-openai" || id == "custom-anthropic" {
+		writeError(w, http.StatusConflict, "cannot delete built-in custom provider: "+id)
+		return
+	}
+
 	if _, err := s.db.CustomProviders().GetProvider(r.Context(), id); err != nil {
 		writeError(w, http.StatusNotFound, "unknown custom provider: "+id)
 		return
 	}
 	if err := s.db.CustomProviders().DeleteProvider(r.Context(), id); err != nil {
+		// A concurrent delete may have removed the row between the GetProvider
+		// probe and now; surface it as 404 rather than a 500.
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "unknown custom provider: "+id)
+			return
+		}
 		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "delete custom provider failed"))
 		return
 	}
+
+	// Disable any accounts still bound to the deleted provider so stale
+	// credentials are not selected for routing and the dashboard reflects the
+	// severed connection. Best-effort: the provider row is already gone, so a
+	// failure here is logged but must not undo the delete.
+	var accountsDisabled int64
+	if s.accounts != nil {
+		n, derr := s.accounts.DisableByProvider(r.Context(), adminTenant, id)
+		if derr != nil {
+			s.log.Warn("disable accounts after provider delete failed", "provider", id, "err", derr)
+		} else {
+			accountsDisabled = n
+		}
+	}
+
+	// Drop the in-memory dynamic provider + its models so routing/discovery
+	// stop exposing it immediately.
 	connectors.UnregisterDynamicProvider(id)
-	writeJSON(w, http.StatusOK, map[string]any{"id": id, "deleted": true})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id":                id,
+		"deleted":           true,
+		"accounts_disabled": accountsDisabled,
+	})
 }
 
 // ---- custom models ----------------------------------------------------------

--- a/backend/internal/gateway/admin_custom_providers_test.go
+++ b/backend/internal/gateway/admin_custom_providers_test.go
@@ -1,0 +1,184 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mydisha/keirouter/backend/internal/config"
+	"github.com/mydisha/keirouter/backend/internal/connectors"
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/mydisha/keirouter/backend/internal/crypto"
+	"github.com/mydisha/keirouter/backend/internal/store"
+	"github.com/mydisha/keirouter/backend/internal/vault"
+)
+
+// newCustomProviderTestServer wires a minimal Server with an in-memory store
+// and vault, sufficient to exercise the custom-provider delete handler.
+func newCustomProviderTestServer(t *testing.T) (*Server, *store.DB) {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := store.Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: ":memory:"}, t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, db.Migrate(ctx))
+	require.NoError(t, db.Tenants().EnsureDefault(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	mk, err := crypto.GenerateMasterKey()
+	require.NoError(t, err)
+	sealer, err := crypto.NewSealer(mk)
+	require.NoError(t, err)
+
+	s := &Server{
+		db:       db,
+		accounts: db.Accounts(),
+		vault:    vault.New(sealer),
+		log:      slog.Default(),
+	}
+	return s, db
+}
+
+// withChiID builds a request whose chi URLParam "id" is set, so handlers that
+// call chi.URLParam(r, "id") work without mounting a full router.
+func withChiID(method, target, id string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	ctx := context.WithValue(context.Background(), chi.RouteCtxKey, rctx)
+	req := httptest.NewRequest(method, target, nil)
+	return req.WithContext(ctx)
+}
+
+// deleteCustomProvider invokes the handler and returns status + decoded body.
+func deleteCustomProvider(t *testing.T, s *Server, id string) (int, map[string]any) {
+	t.Helper()
+	req := withChiID(http.MethodDelete, "/custom-providers/"+id, id)
+	rec := httptest.NewRecorder()
+	s.adminDeleteCustomProvider(rec, req)
+	var out map[string]any
+	if rec.Body.Len() > 0 {
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	}
+	return rec.Code, out
+}
+
+func TestDeleteCustomProvider_BuiltinRejected(t *testing.T) {
+	s, _ := newCustomProviderTestServer(t)
+
+	for _, id := range []string{"custom-openai", "custom-anthropic"} {
+		code, body := deleteCustomProvider(t, s, id)
+		require.Equal(t, http.StatusConflict, code, "id=%s body=%v", id, body)
+		require.Nil(t, body["deleted"])
+	}
+}
+
+func TestDeleteCustomProvider_NotFound(t *testing.T) {
+	s, _ := newCustomProviderTestServer(t)
+
+	code, body := deleteCustomProvider(t, s, "custom-openai-missing")
+	require.Equal(t, http.StatusNotFound, code, body)
+
+	// Sanity: the missing id never accidentally matches a dynamic provider.
+	_, ok := connectors.DynamicProviderByID("custom-openai-missing")
+	require.False(t, ok)
+}
+
+func TestDeleteCustomProvider_SuccessDisablesAccountsAndUnregisters(t *testing.T) {
+	s, db := newCustomProviderTestServer(t)
+	ctx := context.Background()
+
+	const pid = "custom-openai-testinst"
+	now := time.Now()
+
+	// Persist a custom provider row + a custom model bound to it.
+	require.NoError(t, db.CustomProviders().CreateProvider(ctx, store.CustomProvider{
+		ID:          pid,
+		TenantID:    store.DefaultTenantID,
+		DisplayName: "Test Instance",
+		Alias:       pid,
+		Dialect:     string(core.DialectOpenAI),
+		BaseURL:     "https://example.test/v1",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}))
+	require.NoError(t, db.CustomProviders().CreateModel(ctx, store.CustomModel{
+		ID:          "cm-1",
+		TenantID:    store.DefaultTenantID,
+		ProviderID:  pid,
+		ModelID:     "gpt-test",
+		DisplayName: "gpt-test",
+		Kind:        string(core.ServiceLLM),
+		Source:      "manual",
+	}))
+
+	// Register it live so the registry mirrors runtime state.
+	connectors.RegisterDynamicProvider(connectors.DynamicProvider{
+		ID: pid, DisplayName: "Test Instance", Alias: pid,
+		Dialect: core.DialectOpenAI, BaseURL: "https://example.test/v1",
+	})
+	t.Cleanup(func() { connectors.UnregisterDynamicProvider(pid) })
+
+	// Create two accounts bound to the provider: one enabled, one disabled.
+	require.NoError(t, db.Accounts().Create(ctx, store.Account{
+		ID: "acct-enabled", TenantID: store.DefaultTenantID, Provider: pid,
+		Label: "enabled", AuthKind: store.AuthAPIKey, Priority: 10, Metadata: "{}",
+		CreatedAt: now, UpdatedAt: now,
+	}))
+	require.NoError(t, db.Accounts().Create(ctx, store.Account{
+		ID: "acct-already-off", TenantID: store.DefaultTenantID, Provider: pid,
+		Label: "off", AuthKind: store.AuthAPIKey, Priority: 10, Metadata: "{}",
+		Disabled:  true,
+		CreatedAt: now, UpdatedAt: now,
+	}))
+
+	// Precondition: dynamic provider + an enabled account exist.
+	_, ok := connectors.DynamicProviderByID(pid)
+	require.True(t, ok)
+	enabled, err := db.Accounts().ListByProvider(ctx, store.DefaultTenantID, pid)
+	require.NoError(t, err)
+	require.Len(t, enabled, 1)
+
+	code, body := deleteCustomProvider(t, s, pid)
+	require.Equal(t, http.StatusOK, code, body)
+	require.Equal(t, true, body["deleted"])
+	require.Equal(t, pid, body["id"])
+	// accounts_disabled reflects total matched rows (both accounts).
+	require.Equal(t, float64(2), body["accounts_disabled"])
+
+	// In-memory dynamic provider + its models are gone.
+	_, ok = connectors.DynamicProviderByID(pid)
+	require.False(t, ok)
+
+	// Provider row + its models are gone from the DB.
+	_, err = db.CustomProviders().GetProvider(ctx, pid)
+	require.ErrorIs(t, err, store.ErrNotFound)
+	models, err := db.CustomProviders().ListModelsByProvider(ctx, pid)
+	require.NoError(t, err)
+	require.Empty(t, models)
+
+	// No enabled accounts remain bound to the deleted provider.
+	enabled, err = db.Accounts().ListByProvider(ctx, store.DefaultTenantID, pid)
+	require.NoError(t, err)
+	require.Empty(t, enabled, "all bound accounts must be disabled after delete")
+}
+
+func TestDeleteCustomProvider_RepoReturnsNotFoundForMissing(t *testing.T) {
+	s, db := newCustomProviderTestServer(t)
+	ctx := context.Background()
+
+	// DeleteProvider itself surfaces ErrNotFound for an id that was never
+	// inserted (defence-in-depth behind the handler's GetProvider probe).
+	err := db.CustomProviders().DeleteProvider(ctx, "custom-openai-ghost")
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	// And the handler maps it to 404 when it slips past the probe.
+	code, body := deleteCustomProvider(t, s, "custom-anthropic-ghost")
+	require.Equal(t, http.StatusNotFound, code, body)
+}

--- a/backend/internal/gateway/admin_foreign_import.go
+++ b/backend/internal/gateway/admin_foreign_import.go
@@ -154,6 +154,9 @@ func (s *Server) importN9router(ctx context.Context, doc map[string]json.RawMess
 
 	// Model aliases.
 	s.importN9routerAliases(ctx, doc, res)
+
+	// Custom models (user-registered model definitions on any provider).
+	s.importN9routerCustomModels(ctx, doc, res)
 }
 
 // n9routerNode is the subset of a 9router providerNode entry we read.
@@ -355,7 +358,7 @@ func (s *Server) importN9routerConnections(ctx context.Context, doc map[string]j
 		// codex workspaceId, base_url overrides, azure details, ...). These
 		// surface as creds.Extra at request time, so they MUST transfer for
 		// connectors like Qoder that require user_id to sign requests.
-		meta := psdToMetadata(c.Data)
+		meta := psdToMetadata(provider, c.Data)
 		// Top-level email is the canonical account email for OAuth providers;
 		// ensure it lands in metadata (qoder/cursor/cloudcode read it).
 		if c.Email != "" && meta["email"] == "" {
@@ -657,6 +660,62 @@ func (s *Server) importN9routerAliases(ctx context.Context, doc map[string]json.
 	}
 }
 
+// importN9routerCustomModels imports 9router's customModels (user-registered
+// model definitions attached to a provider alias) as KeiRouter CustomModels.
+func (s *Server) importN9routerCustomModels(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	raw, ok := doc["customModels"]
+	if !ok {
+		return
+	}
+	var models []struct {
+		ProviderAlias string `json:"providerAlias"`
+		ID            string `json:"id"`
+		Type          string `json:"type"`
+		Name          string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &models); err != nil {
+		res.Errors = append(res.Errors, "customModels: "+err.Error())
+		return
+	}
+	for _, m := range models {
+		if m.ID == "" || m.ProviderAlias == "" {
+			res.Skipped++
+			continue
+		}
+		providerID := mapN9routerProvider(m.ProviderAlias, nil)
+		if providerID == "" {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("custom model %s: unknown provider %q", m.ID, m.ProviderAlias))
+			continue
+		}
+		kind := strings.TrimSpace(m.Type)
+		if kind == "" {
+			kind = "llm"
+		}
+		name := strings.TrimSpace(m.Name)
+		if name == "" {
+			name = m.ID
+		}
+		cm := store.CustomModel{
+			ID:          uuid.NewString(),
+			TenantID:    adminTenant,
+			ProviderID:  providerID,
+			ModelID:     m.ID,
+			DisplayName: name,
+			Kind:        kind,
+			Source:      "imported",
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+		}
+		if err := s.db.CustomProviders().CreateModel(ctx, cm); err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("custom model %s/%s: %v", m.ProviderAlias, m.ID, err))
+			continue
+		}
+		s.reloadCustomModels(ctx, providerID)
+	}
+}
+
 // mapN9routerProvider resolves a 9router provider id (or a node id reference)
 // to a KeiRouter provider id. Returns "" when it cannot be resolved.
 func mapN9routerProvider(provider string, nodeIDMap map[string]string) string {
@@ -864,13 +923,35 @@ func normalizeOmniPayload(doc map[string]json.RawMessage) map[string]json.RawMes
 
 // ── helpers ──────────────────────────────────────────────────────────
 
+// psdKeyRemap maps 9router providerSpecificData keys to the KeiRouter metadata
+// keys each provider's connector reads from creds.Extra. 9router and KeiRouter
+// diverge on naming for a few providers (kiro stores authMethod/region without
+// the "kiro_" prefix; cursor uses machineId). Without this remap, imported
+// kiro accounts can't refresh tokens or fetch quota because the connector
+// looks for kiro_auth_method / kiro_region and finds auth_method / region.
+var psdKeyRemap = map[string]map[string]string{
+	"kiro": {
+		"authMethod": "kiro_auth_method",
+		"region":     "kiro_region",
+		"profileArn": "profile_arn",
+	},
+	"cursor": {
+		"machineId": "machine_id",
+		"ghostMode": "ghost_mode",
+	},
+	"qoder": {
+		"userId":    "user_id",
+		"machineId": "machine_id",
+	},
+}
+
 // psdToMetadata converts a 9router providerSpecificData map into KeiRouter
 // account metadata. Keys are normalized from camelCase to snake_case so that
-// provider-specific fields land on the keys connectors read from creds.Extra
-// (e.g. qoder userId → user_id, cursor machineId → machine_id, codex
-// workspaceId → workspace_id). Proxy-related keys are dropped because
-// KeiRouter models per-account proxying via ProxyPoolID, not metadata.
-func psdToMetadata(psd map[string]any) map[string]string {
+// provider-specific fields land on the keys connectors read from creds.Extra.
+// Provider-specific overrides (psdKeyRemap) take precedence over the generic
+// camelCase conversion. Proxy-related keys are dropped because KeiRouter
+// models per-account proxying via ProxyPoolID, not metadata.
+func psdToMetadata(provider string, psd map[string]any) map[string]string {
 	meta := map[string]string{}
 	if psd == nil {
 		return meta
@@ -883,6 +964,7 @@ func psdToMetadata(psd map[string]any) map[string]string {
 		"proxyPoolId":            true,
 		"vercelRelayUrl":         true,
 	}
+	remap := psdKeyRemap[provider]
 	for k, v := range psd {
 		if skip[k] {
 			continue
@@ -890,6 +972,12 @@ func psdToMetadata(psd map[string]any) map[string]string {
 		s := strVal(v)
 		if s == "" {
 			continue
+		}
+		if remap != nil {
+			if mapped, ok := remap[k]; ok {
+				meta[mapped] = s
+				continue
+			}
 		}
 		meta[camelToSnake(k)] = s
 	}

--- a/backend/internal/gateway/admin_foreign_import.go
+++ b/backend/internal/gateway/admin_foreign_import.go
@@ -1,0 +1,964 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mydisha/keirouter/backend/internal/connectors"
+	"github.com/mydisha/keirouter/backend/internal/crypto"
+	"github.com/mydisha/keirouter/backend/internal/store"
+	"github.com/mydisha/keirouter/backend/internal/vault"
+)
+
+// Foreign config import: convert a 9router (or OmniRoute) backup JSON into
+// KeiRouter's native data model. Credentials are re-sealed under the local
+// master key, API keys are re-hashed with argon2id (the same plaintext keeps
+// working), and routing combos become chains.
+//
+// 9router and OmniRoute share the same lineage as KeiRouter, so their provider
+// ids and combo model-string format ("alias/model") are largely compatible.
+// The import is additive: existing records are left alone and conflicts are
+// skipped (best-effort), mirroring the native database import handler.
+
+// foreignImportResult is the response body for the foreign import endpoint.
+type foreignImportResult struct {
+	Source          string   `json:"source"`
+	Imported        int      `json:"imported"`
+	Skipped         int      `json:"skipped"`
+	Accounts        int      `json:"accounts"`
+	CustomProviders int      `json:"custom_providers"`
+	APIKeys         int      `json:"api_keys"`
+	Chains          int      `json:"chains"`
+	Aliases         int      `json:"aliases"`
+	ProxyPools      int      `json:"proxy_pools"`
+	Errors          []string `json:"errors,omitempty"`
+}
+
+// adminImportForeignConfig converts a foreign router backup into KeiRouter
+// records. It accepts a JSON body:
+//
+//	{ "source": "9router" | "omniroute", "config": { ...foreign payload... } }
+//
+// The handler auto-detects the source when omitted by inspecting the payload
+// shape, so callers may also POST the raw foreign payload directly.
+func (s *Server) adminImportForeignConfig(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4<<20))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "read body: "+err.Error())
+		return
+	}
+
+	source, payload, derr := decodeForeignPayload(bodyBytes)
+	if derr != nil {
+		writeError(w, http.StatusBadRequest, derr.Error())
+		return
+	}
+
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &doc); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid config JSON: "+err.Error())
+		return
+	}
+
+	if source == "" {
+		source = detectForeignSource(doc)
+	}
+
+	res := &foreignImportResult{Source: source}
+	switch source {
+	case "9router":
+		s.importN9router(ctx, doc, res)
+	case "omniroute", "omni":
+		s.importOmniRoute(ctx, doc, res)
+	default:
+		writeError(w, http.StatusBadRequest, "unknown source: "+source+" (expected '9router' or 'omniroute')")
+		return
+	}
+
+	res.Imported = res.Accounts + res.CustomProviders + res.APIKeys + res.Chains + res.Aliases + res.ProxyPools
+	writeJSON(w, http.StatusOK, res)
+}
+
+// decodeForeignPayload accepts either the wrapped form {"source":..,"config":..}
+// or a raw foreign payload posted directly. It returns the source label and the
+// config bytes.
+func decodeForeignPayload(b []byte) (string, json.RawMessage, error) {
+	var wrapped struct {
+		Source string          `json:"source"`
+		Config json.RawMessage `json:"config"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err == nil && len(wrapped.Config) > 0 {
+		return strings.ToLower(strings.TrimSpace(wrapped.Source)), wrapped.Config, nil
+	}
+	// Treat the body as a raw foreign payload.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(b, &probe); err != nil {
+		return "", nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	return "", b, nil
+}
+
+// detectForeignSource inspects the payload to guess whether it came from
+// 9router or OmniRoute. 9router exports a flat object with top-level arrays
+// keyed by table name (providerConnections, providerNodes, combos, ...).
+// OmniRoute's tar.gz sidecars use snake_case keys (provider_connections,
+// provider_nodes) or carry an "omniroute" marker in metadata.
+func detectForeignSource(doc map[string]json.RawMessage) string {
+	if _, ok := doc["providerConnections"]; ok {
+		return "9router"
+	}
+	if _, ok := doc["provider_connections"]; ok {
+		return "omniroute"
+	}
+	if raw, ok := doc["format"]; ok {
+		var format string
+		_ = json.Unmarshal(raw, &format)
+		if strings.Contains(strings.ToLower(format), "omniroute") {
+			return "omniroute"
+		}
+	}
+	// Default to 9router since the issue specifically requests it.
+	return "9router"
+}
+
+// ── 9router ──────────────────────────────────────────────────────────
+
+func (s *Server) importN9router(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	if s.vault == nil {
+		res.Errors = append(res.Errors, "vault not configured: cannot seal imported credentials")
+	}
+
+	// Custom provider nodes first so account references resolve.
+	nodeIDMap := s.importN9routerNodes(ctx, doc, res)
+
+	// Provider connections (accounts) with plaintext credentials.
+	s.importN9routerConnections(ctx, doc, res, nodeIDMap)
+
+	// API keys: re-hash the plaintext so the same key string works.
+	s.importN9routerAPIKeys(ctx, doc, res)
+
+	// Combos -> chains.
+	s.importN9routerCombos(ctx, doc, res)
+
+	// Proxy pools.
+	s.importN9routerProxyPools(ctx, doc, res)
+
+	// Model aliases.
+	s.importN9routerAliases(ctx, doc, res)
+}
+
+// n9routerNode is the subset of a 9router providerNode entry we read.
+type n9routerNode struct {
+	ID      string         `json:"id"`
+	Type    string         `json:"type"` // openai-compatible | anthropic-compatible | custom-embedding
+	Name    string         `json:"name"`
+	Prefix  string         `json:"prefix"`
+	APIType string         `json:"apiType"`
+	BaseURL string         `json:"baseUrl"`
+	Data    map[string]any `json:"-"`
+}
+
+func (s *Server) importN9routerNodes(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) map[string]string {
+	nodeIDMap := map[string]string{} // 9router node id -> keirouter provider id
+	raw, ok := doc["providerNodes"]
+	if !ok {
+		return nodeIDMap
+	}
+	var nodes []n9routerNode
+	if err := json.Unmarshal(raw, &nodes); err != nil {
+		res.Errors = append(res.Errors, "providerNodes: "+err.Error())
+		return nodeIDMap
+	}
+	// 9router may embed node fields inside a `data` JSON column. Decode each
+	// entry generically to recover baseUrl/prefix when top-level fields absent.
+	var generic []map[string]json.RawMessage
+	_ = json.Unmarshal(raw, &generic)
+
+	for i, n := range nodes {
+		if i < len(generic) {
+			if dataRaw, ok := generic[i]["data"]; ok && len(dataRaw) > 0 {
+				_ = json.Unmarshal(dataRaw, &n.Data)
+				if n.BaseURL == "" {
+					n.BaseURL = strVal(n.Data["baseUrl"])
+				}
+				if n.Prefix == "" {
+					n.Prefix = strVal(n.Data["prefix"])
+				}
+				if n.APIType == "" {
+					n.APIType = strVal(n.Data["apiType"])
+				}
+			}
+		}
+
+		dialect, prefix, ok := customDialect(nodeDialectToken(n.Type))
+		if !ok {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("node %s: unsupported type %q", n.ID, n.Type))
+			continue
+		}
+		if strings.TrimSpace(n.BaseURL) == "" {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("node %s: missing baseUrl", n.ID))
+			continue
+		}
+
+		name := strings.TrimSpace(n.Name)
+		if name == "" {
+			name = n.ID
+		}
+		id := uniqueCustomProviderID(prefix, name, func(candidate string) bool {
+			if _, exists := connectors.SpecByID(candidate); exists {
+				return true
+			}
+			if _, dup := s.db.CustomProviders().GetProvider(ctx, candidate); dup == nil {
+				return true
+			}
+			return false
+		})
+
+		alias := n.Prefix
+		if a, aerr := resolveCustomAlias(alias, name, id); aerr == nil {
+			alias = a
+		} else {
+			alias = id
+		}
+
+		p := store.CustomProvider{
+			ID:          id,
+			TenantID:    adminTenant,
+			DisplayName: name,
+			Alias:       alias,
+			Dialect:     string(dialect),
+			BaseURL:     n.BaseURL,
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+		}
+		if err := s.db.CustomProviders().CreateProvider(ctx, p); err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("node %s: create custom provider: %v", n.ID, err))
+			continue
+		}
+		connectors.RegisterDynamicProvider(connectors.DynamicProvider{
+			ID: p.ID, DisplayName: p.DisplayName, Alias: p.Alias, Dialect: dialect, BaseURL: p.BaseURL,
+		})
+		nodeIDMap[n.ID] = id
+		res.CustomProviders++
+	}
+	return nodeIDMap
+}
+
+func nodeDialectToken(t string) string {
+	switch strings.ToLower(strings.TrimSpace(t)) {
+	case "openai-compatible":
+		return "openai"
+	case "anthropic-compatible":
+		return "anthropic"
+	case "custom-embedding":
+		return "openai" // embeddings ride the OpenAI-compatible dialect
+	default:
+		return t
+	}
+}
+
+// n9routerConnection mirrors the exported providerConnection shape.
+type n9routerConnection struct {
+	ID           string         `json:"id"`
+	Provider     string         `json:"provider"`
+	AuthType     string         `json:"authType"`
+	Name         string         `json:"name"`
+	DisplayName  string         `json:"displayName"`
+	Email        string         `json:"email"`
+	Priority     int            `json:"priority"`
+	IsActive     *bool          `json:"isActive"`
+	APIKey       string         `json:"apiKey"`
+	AccessToken  string         `json:"accessToken"`
+	RefreshToken string         `json:"refreshToken"`
+	ExpiresAt    string         `json:"expiresAt"`
+	Data         map[string]any `json:"-"`
+}
+
+func (s *Server) importN9routerConnections(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult, nodeIDMap map[string]string) {
+	raw, ok := doc["providerConnections"]
+	if !ok {
+		return
+	}
+	var conns []n9routerConnection
+	if err := json.Unmarshal(raw, &conns); err != nil {
+		res.Errors = append(res.Errors, "providerConnections: "+err.Error())
+		return
+	}
+	// Recover fields nested under the `data` JSON column.
+	var generic []map[string]json.RawMessage
+	_ = json.Unmarshal(raw, &generic)
+
+	for i, c := range conns {
+		if i < len(generic) {
+			if dataRaw, ok := generic[i]["data"]; ok && len(dataRaw) > 0 {
+				_ = json.Unmarshal(dataRaw, &c.Data)
+				if c.APIKey == "" {
+					c.APIKey = strVal(c.Data["apiKey"])
+				}
+				if c.AccessToken == "" {
+					c.AccessToken = strVal(c.Data["accessToken"])
+				}
+				if c.RefreshToken == "" {
+					c.RefreshToken = strVal(c.Data["refreshToken"])
+				}
+				if c.ExpiresAt == "" {
+					c.ExpiresAt = strVal(c.Data["expiresAt"])
+				}
+			}
+		}
+
+		provider := mapN9routerProvider(c.Provider, nodeIDMap)
+		if provider == "" {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("connection %s: unmapped provider %q", c.ID, c.Provider))
+			continue
+		}
+		spec, specOK := connectors.SpecByID(provider)
+
+		authKind, secret := n9routerAuthSecret(c, spec, specOK)
+		if s.vault == nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("connection %s: vault unavailable, skipped", c.ID))
+			continue
+		}
+
+		label := strings.TrimSpace(c.Name)
+		if label == "" {
+			label = strings.TrimSpace(c.DisplayName)
+		}
+		if label == "" {
+			if specOK {
+				label = spec.DisplayName
+			} else {
+				label = provider
+			}
+		}
+		// OAuth accounts are best identified by their email.
+		if c.Email != "" && specOK && spec.AuthKind == "oauth" {
+			label = c.Email
+		}
+
+		// Build metadata. providerSpecificData carries provider-specific
+		// fields (qoder user_id/machine_id, cursor machine_id/ghost_mode,
+		// codex workspaceId, base_url overrides, azure details, ...). These
+		// surface as creds.Extra at request time, so they MUST transfer for
+		// connectors like Qoder that require user_id to sign requests.
+		meta := psdToMetadata(c.Data)
+		// Top-level email is the canonical account email for OAuth providers;
+		// ensure it lands in metadata (qoder/cursor/cloudcode read it).
+		if c.Email != "" && meta["email"] == "" {
+			meta["email"] = c.Email
+		}
+
+		now := time.Now()
+		acc := store.Account{
+			ID:        uuid.NewString(),
+			TenantID:  adminTenant,
+			Provider:  provider,
+			Label:     label,
+			AuthKind:  authKind,
+			Priority:  defaultInt(c.Priority, 100),
+			Disabled:  c.IsActive != nil && !*c.IsActive,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if t := parseRFC3339(c.ExpiresAt); t != nil {
+			acc.TokenExpiresAt = t
+		}
+		if err := s.vault.Seal(&acc, secret); err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("connection %s: seal failed: %v", c.ID, err))
+			continue
+		}
+		if err := s.accounts.Create(ctx, acc); err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("connection %s: create account: %v", c.ID, err))
+			continue
+		}
+		res.Accounts++
+	}
+}
+
+// n9routerAuthSecret maps a 9router authType + credentials to a KeiRouter
+// AuthKind and a vault.NewSecret carrying the plaintext material.
+func n9routerAuthSecret(c n9routerConnection, spec connectors.ProviderSpec, specOK bool) (store.AuthKind, vault.NewSecret) {
+	authType := strings.ToLower(strings.TrimSpace(c.AuthType))
+	if authType == "" {
+		authType = "oauth"
+	}
+	sec := vault.NewSecret{Metadata: map[string]string{}}
+
+	switch authType {
+	case "oauth", "access_token":
+		sec.AccessToken = c.AccessToken
+		sec.RefreshToken = c.RefreshToken
+		// Some OAuth providers (iflow, kimi-coding, xai) also accept an API
+		// key; when only an API key is present, treat as api_key instead.
+		if c.AccessToken == "" && c.RefreshToken == "" && c.APIKey != "" {
+			sec.APIKey = c.APIKey
+			return store.AuthAPIKey, sec
+		}
+		return store.AuthOAuth, sec
+	case "apikey":
+		sec.APIKey = c.APIKey
+		if specOK && spec.AuthKind == "none" && c.APIKey == "" {
+			return store.AuthNone, sec
+		}
+		return store.AuthAPIKey, sec
+	case "cookie":
+		// 9router cookie connections carry the session cookie in apiKey or
+		// providerSpecificData. Store it as the secret so the connector can
+		// use it; map to api_key auth (cookie-bearing providers use
+		// SkipValidation in the catalog).
+		sec.APIKey = c.APIKey
+		return store.AuthAPIKey, sec
+	default:
+		if specOK && spec.AuthKind == "none" {
+			return store.AuthNone, sec
+		}
+		sec.APIKey = c.APIKey
+		return store.AuthAPIKey, sec
+	}
+}
+
+func (s *Server) importN9routerAPIKeys(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	raw, ok := doc["apiKeys"]
+	if !ok {
+		return
+	}
+	var keys []struct {
+		ID       string `json:"id"`
+		Key      string `json:"key"`
+		Name     string `json:"name"`
+		IsActive *bool  `json:"isActive"`
+	}
+	if err := json.Unmarshal(raw, &keys); err != nil {
+		res.Errors = append(res.Errors, "apiKeys: "+err.Error())
+		return
+	}
+	for _, k := range keys {
+		plaintext := strings.TrimSpace(k.Key)
+		if plaintext == "" {
+			res.Skipped++
+			continue
+		}
+		name := strings.TrimSpace(k.Name)
+		if name == "" {
+			name = "imported"
+		}
+		hash, err := crypto.HashAPIKey(plaintext)
+		if err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("key %s: hash failed: %v", k.ID, err))
+			continue
+		}
+		rec := store.APIKey{
+			ID:         uuid.NewString(),
+			TenantID:   adminTenant,
+			Name:       name,
+			KeyHash:    hash,
+			LookupHash: crypto.LookupHash(plaintext),
+			Display:    maskForeignKey(plaintext),
+			Disabled:   k.IsActive != nil && !*k.IsActive,
+			CreatedAt:  time.Now(),
+		}
+		if err := s.identity.Keys().Create(ctx, rec); err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("key %s: create: %v", k.ID, err))
+			continue
+		}
+		res.APIKeys++
+	}
+}
+
+// maskForeignKey renders a foreign key for display without assuming the
+// KeiRouter "kr_" prefix.
+func maskForeignKey(plaintext string) string {
+	body := plaintext
+	for _, p := range []string{"kr_", "sk_", "sk-"} {
+		body = strings.TrimPrefix(body, p)
+	}
+	if len(body) <= 8 {
+		return "…"
+	}
+	prefixLen := len(plaintext) - len(body)
+	return plaintext[:prefixLen] + body[:4] + "…" + body[len(body)-4:]
+}
+
+func (s *Server) importN9routerCombos(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	raw, ok := doc["combos"]
+	if !ok {
+		return
+	}
+	var combos []struct {
+		ID       string   `json:"id"`
+		Name     string   `json:"name"`
+		Kind     string   `json:"kind"`
+		Strategy string   `json:"strategy"`
+		Models   []string `json:"models"`
+	}
+	if err := json.Unmarshal(raw, &combos); err != nil {
+		res.Errors = append(res.Errors, "combos: "+err.Error())
+		return
+	}
+	for _, c := range combos {
+		name := strings.TrimSpace(c.Name)
+		if name == "" {
+			res.Skipped++
+			continue
+		}
+		if verr := validateChainName(name); verr != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("combo %s: %v", c.ID, verr))
+			continue
+		}
+		strategy := mapN9routerStrategy(c.Kind, c.Strategy)
+		now := time.Now()
+		chain := store.Chain{
+			ID:        uuid.NewString(),
+			TenantID:  adminTenant,
+			Name:      name,
+			Strategy:  strategy,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		pos := 0
+		for _, m := range c.Models {
+			provider, model := splitAliasModel(m)
+			if provider == "" || model == "" {
+				res.Skipped++
+				continue
+			}
+			if _, ok := connectors.SpecByAlias(provider); !ok {
+				res.Skipped++
+				res.Errors = append(res.Errors, fmt.Sprintf("combo %s: unknown provider alias %q", c.ID, provider))
+				continue
+			}
+			chain.Steps = append(chain.Steps, store.ChainStep{
+				ID:        uuid.NewString(),
+				ChainID:   chain.ID,
+				Position:  pos,
+				Provider:  provider,
+				Model:     model,
+				CreatedAt: now,
+			})
+			pos++
+		}
+		if len(chain.Steps) == 0 {
+			res.Skipped++
+			continue
+		}
+		if err := s.chains.Create(ctx, chain); err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("combo %s: create chain: %v", c.ID, err))
+			continue
+		}
+		res.Chains++
+	}
+}
+
+func mapN9routerStrategy(kind, strategy string) string {
+	for _, v := range []string{strategy, kind} {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "fallback", "priority":
+			return "priority"
+		case "roundrobin", "round-robin", "round_robin":
+			return "round-robin"
+		case "weighted":
+			return "weighted"
+		case "fill-first", "fillfirst":
+			return "fill-first"
+		case "random":
+			return "random"
+		}
+	}
+	return "priority"
+}
+
+func (s *Server) importN9routerProxyPools(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	raw, ok := doc["proxyPools"]
+	if !ok {
+		return
+	}
+	var pools []struct {
+		Name     string `json:"name"`
+		ProxyURL string `json:"proxyUrl"`
+		NoProxy  string `json:"noProxy"`
+		Type     string `json:"type"`
+		Strict   bool   `json:"strictProxy"`
+		IsActive *bool  `json:"isActive"`
+	}
+	if err := json.Unmarshal(raw, &pools); err != nil {
+		res.Errors = append(res.Errors, "proxyPools: "+err.Error())
+		return
+	}
+	for _, p := range pools {
+		if strings.TrimSpace(p.Name) == "" || strings.TrimSpace(p.ProxyURL) == "" {
+			res.Skipped++
+			continue
+		}
+		now := time.Now()
+		pool := store.ProxyPool{
+			ID:         uuid.NewString(),
+			Name:       p.Name,
+			Type:       defaultStr(p.Type, "http"),
+			ProxyURL:   p.ProxyURL,
+			NoProxy:    p.NoProxy,
+			Strict:     p.Strict,
+			IsActive:   p.IsActive == nil || *p.IsActive,
+			TestStatus: "unknown",
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+		if err := s.pools.Create(ctx, pool); err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("proxy pool %s: %v", p.Name, err))
+			continue
+		}
+		res.ProxyPools++
+	}
+}
+
+func (s *Server) importN9routerAliases(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	raw, ok := doc["modelAliases"]
+	if !ok {
+		return
+	}
+	var aliases map[string]string
+	if err := json.Unmarshal(raw, &aliases); err != nil {
+		res.Errors = append(res.Errors, "modelAliases: "+err.Error())
+		return
+	}
+	for alias, target := range aliases {
+		alias = strings.TrimSpace(alias)
+		target = strings.TrimSpace(target)
+		if alias == "" || target == "" {
+			res.Skipped++
+			continue
+		}
+		if err := s.aliases.Set(ctx, alias, target); err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("alias %s: %v", alias, err))
+			continue
+		}
+		res.Aliases++
+	}
+}
+
+// mapN9routerProvider resolves a 9router provider id (or a node id reference)
+// to a KeiRouter provider id. Returns "" when it cannot be resolved.
+func mapN9routerProvider(provider string, nodeIDMap map[string]string) string {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return ""
+	}
+	// Node reference: custom OpenAI/Anthropic/embedding node.
+	if mapped, ok := nodeIDMap[provider]; ok {
+		return mapped
+	}
+	if _, ok := connectors.SpecByID(provider); ok {
+		return provider
+	}
+	// Try alias resolution (9router aliases sometimes differ from ids).
+	if spec, ok := connectors.SpecByAlias(provider); ok {
+		return spec.ID
+	}
+	return ""
+}
+
+// ── OmniRoute ────────────────────────────────────────────────────────
+//
+// OmniRoute credentials are AES-256-GCM encrypted in its SQLite database and
+// the JSON sidecar exports are deliberately redacted (no tokens/keys). We
+// therefore import the structural config — custom provider nodes, combos,
+// proxy pools, model aliases, and account stubs (provider + label only,
+// marked disabled so the user re-authenticates) — but cannot transfer
+// secrets. The UI makes this limitation explicit.
+
+func (s *Server) importOmniRoute(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	// OmniRoute payloads may be a merged sidecar bundle (separate top-level
+	// arrays) or a single object. Normalize to the 9router-ish key set.
+	normalized := normalizeOmniPayload(doc)
+
+	// Custom provider nodes (full data, no secrets).
+	nodeIDMap := s.importN9routerNodes(ctx, normalized, res)
+
+	// Provider connections: stub accounts only (no credentials available).
+	s.importOmniConnections(ctx, normalized, res, nodeIDMap)
+
+	// Combos -> chains. OmniRoute combo models carry richer step objects; the
+	// shared importer handles the simple "alias/model" string form, so we
+	// flatten OmniRoute steps into strings first.
+	s.importOmniCombos(ctx, normalized, res)
+
+	// API keys: OmniRoute redacts to a prefix only; skip (cannot reconstruct).
+	if raw, ok := normalized["apiKeys"]; ok {
+		var keys []struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(raw, &keys); err == nil {
+			res.Skipped += len(keys)
+			if len(keys) > 0 {
+				res.Errors = append(res.Errors, "omniroute api keys are redacted in exports: re-create them in KeiRouter")
+			}
+		}
+	}
+
+	// Proxy pools + aliases reuse the 9router importer shapes.
+	s.importN9routerProxyPools(ctx, normalized, res)
+	s.importN9routerAliases(ctx, normalized, res)
+}
+
+func (s *Server) importOmniConnections(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult, nodeIDMap map[string]string) {
+	raw, ok := doc["providerConnections"]
+	if !ok {
+		return
+	}
+	var conns []struct {
+		ID       string `json:"id"`
+		Provider string `json:"provider"`
+		Name     string `json:"name"`
+		AuthType string `json:"auth_type"`
+		Email    string `json:"email"`
+	}
+	if err := json.Unmarshal(raw, &conns); err != nil {
+		res.Errors = append(res.Errors, "provider_connections: "+err.Error())
+		return
+	}
+	for _, c := range conns {
+		provider := mapN9routerProvider(c.Provider, nodeIDMap)
+		if provider == "" {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("connection %s: unmapped provider %q", c.ID, c.Provider))
+			continue
+		}
+		spec, specOK := connectors.SpecByID(provider)
+		label := strings.TrimSpace(c.Name)
+		if label == "" {
+			label = strings.TrimSpace(c.Email)
+		}
+		if label == "" && specOK {
+			label = spec.DisplayName
+		}
+		if label == "" {
+			label = provider
+		}
+		now := time.Now()
+		acc := store.Account{
+			ID:        uuid.NewString(),
+			TenantID:  adminTenant,
+			Provider:  provider,
+			Label:     label + " (re-auth needed)",
+			AuthKind:  store.AuthAPIKey,
+			Disabled:  true, // no credentials imported; user must re-authenticate
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		// Seal an empty secret so the metadata blob is valid.
+		if s.vault != nil {
+			if err := s.vault.Seal(&acc, vault.NewSecret{Metadata: map[string]string{}}); err != nil {
+				res.Skipped++
+				res.Errors = append(res.Errors, fmt.Sprintf("connection %s: seal stub: %v", c.ID, err))
+				continue
+			}
+		}
+		if err := s.accounts.Create(ctx, acc); err != nil {
+			res.Skipped++
+			res.Errors = append(res.Errors, fmt.Sprintf("connection %s: create account: %v", c.ID, err))
+			continue
+		}
+		res.Accounts++
+	}
+}
+
+func (s *Server) importOmniCombos(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	raw, ok := doc["combos"]
+	if !ok {
+		return
+	}
+	// OmniRoute combos may be either an array of rows with a `data` JSON blob
+	// (live schema) or already-flat objects. Flatten both into the simple
+	// {name, models[]} shape the shared importer expects.
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		res.Errors = append(res.Errors, "combos: "+err.Error())
+		return
+	}
+	flat := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		var name string
+		_ = json.Unmarshal(row["name"], &name)
+		var dataRaw json.RawMessage
+		_ = json.Unmarshal(row["data"], &dataRaw)
+		var models []string
+		if len(dataRaw) > 0 {
+			var data struct {
+				Name   string `json:"name"`
+				Models []struct {
+					Kind     string `json:"kind"`
+					Model    string `json:"model"`
+					Provider string `json:"providerId"`
+				} `json:"models"`
+			}
+			if err := json.Unmarshal(dataRaw, &data); err == nil {
+				if name == "" {
+					name = data.Name
+				}
+				for _, m := range data.Models {
+					if m.Kind != "model" {
+						continue
+					}
+					if m.Provider != "" && m.Model != "" {
+						models = append(models, m.Provider+"/"+m.Model)
+					} else if m.Model != "" {
+						models = append(models, m.Model)
+					}
+				}
+			}
+		}
+		// Fallback: top-level models string array (older shape).
+		if len(models) == 0 {
+			_ = json.Unmarshal(row["models"], &models)
+		}
+		flat = append(flat, map[string]any{"name": name, "models": models})
+	}
+	encoded, _ := json.Marshal(flat)
+	doc["combos"] = encoded
+	s.importN9routerCombos(ctx, doc, res)
+}
+
+// normalizeOmniPayload maps OmniRoute's snake_case keys to the camelCase keys
+// the shared 9router importers expect.
+func normalizeOmniPayload(doc map[string]json.RawMessage) map[string]json.RawMessage {
+	out := make(map[string]json.RawMessage, len(doc))
+	for k, v := range doc {
+		out[k] = v
+	}
+	rename := [][2]string{
+		{"provider_connections", "providerConnections"},
+		{"provider_nodes", "providerNodes"},
+		{"api_keys", "apiKeys"},
+		{"proxy_pools", "proxyPools"},
+		{"model_aliases", "modelAliases"},
+	}
+	for _, r := range rename {
+		if v, ok := out[r[0]]; ok {
+			out[r[1]] = v
+			delete(out, r[0])
+		}
+	}
+	return out
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+// psdToMetadata converts a 9router providerSpecificData map into KeiRouter
+// account metadata. Keys are normalized from camelCase to snake_case so that
+// provider-specific fields land on the keys connectors read from creds.Extra
+// (e.g. qoder userId → user_id, cursor machineId → machine_id, codex
+// workspaceId → workspace_id). Proxy-related keys are dropped because
+// KeiRouter models per-account proxying via ProxyPoolID, not metadata.
+func psdToMetadata(psd map[string]any) map[string]string {
+	meta := map[string]string{}
+	if psd == nil {
+		return meta
+	}
+	skip := map[string]bool{
+		"connectionProxyEnabled": true,
+		"connectionProxyUrl":     true,
+		"connectionNoProxy":      true,
+		"connectionProxyPoolId":  true,
+		"proxyPoolId":            true,
+		"vercelRelayUrl":         true,
+	}
+	for k, v := range psd {
+		if skip[k] {
+			continue
+		}
+		s := strVal(v)
+		if s == "" {
+			continue
+		}
+		meta[camelToSnake(k)] = s
+	}
+	return meta
+}
+
+// camelToSnake converts a camelCase key to snake_case. Already-snake_case keys
+// (containing underscores) pass through unchanged.
+func camelToSnake(s string) string {
+	if strings.Contains(s, "_") {
+		return s
+	}
+	var b strings.Builder
+	for i, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r + 32)
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func strVal(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return fmt.Sprintf("%v", t)
+	case bool:
+		return fmt.Sprintf("%v", t)
+	case nil:
+		return ""
+	default:
+		b, _ := json.Marshal(t)
+		return string(b)
+	}
+}
+
+func parseRFC3339(s string) *time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// splitAliasModel splits a "alias/model" combo entry into its provider alias
+// and model id. The first "/" separates them; a leading "chain:" prefix is
+// stripped (it references another combo, which we skip by returning empty
+// provider so the caller drops it).
+func splitAliasModel(s string) (string, string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+	if strings.HasPrefix(s, "chain:") {
+		return "", ""
+	}
+	idx := strings.Index(s, "/")
+	if idx <= 0 {
+		return "", s
+	}
+	return s[:idx], s[idx+1:]
+}

--- a/backend/internal/gateway/insights.go
+++ b/backend/internal/gateway/insights.go
@@ -449,7 +449,16 @@ func (s *Server) adminQuotaUsage(w http.ResponseWriter, r *http.Request) {
 
 		// Fetch upstream quota for providers that support it (e.g. Kiro) concurrently.
 		if qs := connectors.GetQuotaSource(a.Provider); qs != nil && !a.Disabled {
-			if creds, err := s.vault.Open(a); err == nil {
+			// Refresh OAuth access tokens before probing so expired tokens
+			// don't silently suppress the quota/credits detail box. Mirrors
+			// the refresh-then-probe pattern in validateAccountCredentials.
+			quotaAcc := a
+			if s.refresher != nil {
+				if refreshed, rerr := s.refresher.EnsureFresh(ctx, a); rerr == nil {
+					quotaAcc = refreshed
+				}
+			}
+			if creds, err := s.vault.Open(quotaAcc); err == nil {
 				wg.Add(1)
 				go func(idx int, qs connectors.QuotaSource, creds core.Credentials) {
 					defer wg.Done()

--- a/backend/internal/gateway/media.go
+++ b/backend/internal/gateway/media.go
@@ -24,6 +24,16 @@ func (s *Server) mediaOptions(r *http.Request, model string) (pipeline.MediaOpti
 	if err != nil {
 		return pipeline.MediaOptions{}, err
 	}
+	if len(resolved.Targets) > 0 {
+		filtered, ferr := s.filterAllowedTargets(r.Context(), key.ID, resolved.Targets)
+		if ferr != nil {
+			return pipeline.MediaOptions{}, ferr
+		}
+		if len(filtered) == 0 {
+			return pipeline.MediaOptions{}, accessDeniedError{model: model}
+		}
+		resolved.Targets = filtered
+	}
 	effectiveLimits, err := s.effectiveLimits(r.Context(), key)
 	if err != nil {
 		return pipeline.MediaOptions{}, err
@@ -53,6 +63,10 @@ func readJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 
 // writeMediaError maps a pipeline/provider error (or bad-model error) to HTTP.
 func (s *Server) writeMediaError(w http.ResponseWriter, err error) {
+	if denied, ok := err.(accessDeniedError); ok {
+		writeError(w, http.StatusForbidden, denied.Error())
+		return
+	}
 	var bad badModelError
 	if asBadModel(err, &bad) {
 		writeError(w, http.StatusBadRequest, bad.Error())
@@ -337,4 +351,10 @@ func asBadModel(err error, target *badModelError) bool {
 		return true
 	}
 	return false
+}
+
+type accessDeniedError struct{ model string }
+
+func (e accessDeniedError) Error() string {
+	return "access denied: this API key is not permitted to use model " + e.model
 }

--- a/backend/internal/gateway/settings.go
+++ b/backend/internal/gateway/settings.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/connectors"
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
 	"github.com/mydisha/keirouter/backend/internal/headroom"
+	"github.com/mydisha/keirouter/backend/internal/httputil"
 	"github.com/mydisha/keirouter/backend/internal/ponytail"
 	"github.com/mydisha/keirouter/backend/internal/slimmer"
 	"github.com/mydisha/keirouter/backend/internal/terse"
@@ -256,6 +257,10 @@ func (s *Server) adminTestHeadroom(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "headroom_url is required to test the connection")
 		return
 	}
+	if err := httputil.ValidateBaseURL(url); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid headroom_url: URL blocked by security policy")
+		return
+	}
 
 	timeoutMs := es.HeadroomTimeoutMs
 	if body.TimeoutMs != nil {
@@ -380,6 +385,12 @@ func (s *Server) adminUpdateEndpointSettings(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusBadRequest, "headroom_url is required when Headroom is enabled")
 		return
 	}
+	if strings.TrimSpace(current.HeadroomURL) != "" {
+		if err := httputil.ValidateBaseURL(current.HeadroomURL); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid headroom_url: URL blocked by security policy")
+			return
+		}
+	}
 	if patch.RoutingStrategy != nil {
 		normalized, ok := normalizeAccountRoutingStrategy(*patch.RoutingStrategy)
 		if !ok {
@@ -415,6 +426,12 @@ func (s *Server) adminUpdateEndpointSettings(w http.ResponseWriter, r *http.Requ
 	}
 	if patch.OutboundProxyURL != nil {
 		current.OutboundProxyURL = *patch.OutboundProxyURL
+	}
+	if strings.TrimSpace(current.OutboundProxyURL) != "" {
+		if err := httputil.ValidateProxyURL(current.OutboundProxyURL); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid outbound_proxy_url: URL blocked by security policy")
+			return
+		}
 	}
 	if patch.OutboundNoProxy != nil {
 		current.OutboundNoProxy = *patch.OutboundNoProxy

--- a/backend/internal/store/repo_accounts.go
+++ b/backend/internal/store/repo_accounts.go
@@ -147,6 +147,22 @@ func (r *AccountRepo) ClearProviderCooldowns(ctx context.Context, tenantID, prov
 }
 
 // Delete removes an account.
+// DisableByProvider marks every account bound to the given provider as
+// disabled and clears any active cooldown. It is used when a custom provider
+// is deleted so leftover credentials cannot be selected for routing and the
+// dashboard reflects the severed connection. Returns the number of accounts
+// touched. Already-disabled accounts are included so the count reflects total
+// rows matched, but only previously-enabled ones change state.
+func (r *AccountRepo) DisableByProvider(ctx context.Context, tenantID, provider string) (int64, error) {
+	q := r.db.rebind(`UPDATE accounts SET disabled = 1, cooldown_until = NULL WHERE tenant_id = ? AND provider = ?`)
+	res, err := r.db.sql.ExecContext(ctx, q, tenantID, provider)
+	if err != nil {
+		return 0, fmt.Errorf("store: disable accounts by provider: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
 func (r *AccountRepo) Delete(ctx context.Context, id string) error {
 	q := r.db.rebind(`DELETE FROM accounts WHERE id = ?`)
 	_, err := r.db.sql.ExecContext(ctx, q, id)

--- a/backend/internal/store/repo_custom_providers.go
+++ b/backend/internal/store/repo_custom_providers.go
@@ -120,8 +120,14 @@ func (r *CustomProviderRepo) DeleteProvider(ctx context.Context, id string) erro
 	if _, err := tx.ExecContext(ctx, r.db.rebind(`DELETE FROM custom_models WHERE provider_id = ?`), id); err != nil {
 		return fmt.Errorf("store: delete custom provider models: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, r.db.rebind(`DELETE FROM custom_providers WHERE id = ?`), id); err != nil {
+	res, err := tx.ExecContext(ctx, r.db.rebind(`DELETE FROM custom_providers WHERE id = ?`), id)
+	if err != nil {
 		return fmt.Errorf("store: delete custom provider: %w", err)
+	}
+	// Explicit not-found signal so callers can map it to a404 without a
+	// separate existence probe (which would race with concurrent deletes).
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
 	}
 	return tx.Commit()
 }
@@ -181,7 +187,7 @@ func (r *CustomProviderRepo) ListManualModelsByProvider(ctx context.Context, pro
 	}
 	defer rows.Close()
 
-	var out[]CustomModel
+	var out []CustomModel
 	for rows.Next() {
 		m, err := scanCustomModel(rows)
 		if err != nil {

--- a/backend/internal/store/repo_health.go
+++ b/backend/internal/store/repo_health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -75,6 +76,44 @@ func (r *HealthRepo) IsUnhealthy(ctx context.Context, accountID, model string) (
 		}
 	}
 	return false, rows.Err()
+}
+
+// UnhealthyAccounts returns the set of account IDs (from accountIDs) marked
+// unhealthy for model or '__all__'. Batches per-target health checks into a
+// single query instead of one IsUnhealthy query per account.
+func (r *HealthRepo) UnhealthyAccounts(ctx context.Context, accountIDs []string, model string) (map[string]bool, error) {
+	out := make(map[string]bool)
+	if len(accountIDs) == 0 {
+		return out, nil
+	}
+
+	placeholders := make([]string, len(accountIDs))
+	args := make([]any, 0, len(accountIDs)+1)
+	for i, id := range accountIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	args = append(args, model)
+
+	q := r.db.rebind(`SELECT DISTINCT account_id FROM account_health
+		WHERE account_id IN (` + strings.Join(placeholders, ",") + `)
+		  AND model IN (?, '__all__')
+		  AND status = 'unhealthy'`)
+
+	rows, err := r.db.sql.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("store: unhealthy accounts: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			continue
+		}
+		out[id] = true
+	}
+	return out, rows.Err()
 }
 
 // MarkHealthy sets an account/model pair to healthy when real traffic succeeds,

--- a/backend/internal/store/repo_routing.go
+++ b/backend/internal/store/repo_routing.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -72,6 +73,45 @@ func (r *RoutingRepo) IsModelCooldownActive(ctx context.Context, accountID, mode
 		}
 	}
 	return false, rows.Err()
+}
+
+// ActiveCooldowns returns the set of account IDs (from accountIDs) that have an
+// active model-level cooldown for model or '__all__' at the current time. It
+// batches what would otherwise be one IsModelCooldownActive query per account
+// into a single query per target.
+func (r *RoutingRepo) ActiveCooldowns(ctx context.Context, accountIDs []string, model string) (map[string]bool, error) {
+	out := make(map[string]bool)
+	if len(accountIDs) == 0 {
+		return out, nil
+	}
+
+	placeholders := make([]string, len(accountIDs))
+	args := make([]any, 0, len(accountIDs)+3)
+	for i, id := range accountIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	args = append(args, model, "__all__", formatTime(time.Now()))
+
+	q := r.db.rebind(`SELECT DISTINCT account_id FROM model_cooldowns
+		WHERE account_id IN (` + strings.Join(placeholders, ",") + `)
+		  AND model IN (?, ?)
+		  AND cooldown_until > ?`)
+
+	rows, err := r.db.sql.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("store: active model cooldowns: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			continue
+		}
+		out[id] = true
+	}
+	return out, rows.Err()
 }
 
 // ExpireModelCooldowns removes all expired model cooldowns (garbage collection).

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -13,6 +13,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"fmt"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -70,7 +71,7 @@ func Open(ctx context.Context, cfg config.DatabaseConfig, dataDir string) (*DB, 
 	if dialect == DialectSQLite {
 		maxOpen := cfg.MaxOpenConns
 		if maxOpen <= 0 {
-			maxOpen = 4
+			maxOpen = max(runtime.GOMAXPROCS(0), 8)
 		}
 		sqlDB.SetMaxOpenConns(maxOpen)
 		if cfg.MaxIdleConns > 0 {

--- a/frontend/src/components/CustomModelsSection.tsx
+++ b/frontend/src/components/CustomModelsSection.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Plus, Pencil, Trash2, Sparkles } from "lucide-react";
+import { Plus, Pencil, Trash2, Sparkles, AlertTriangle, Loader2, CheckCircle, Search } from "lucide-react";
 
 import { api, type CustomModel, type CustomModelInput, type Provider } from "../lib/api";
 import { Card, CardHeader, Button, Input, Field, Select, Badge, Modal, EmptyState } from "./ui";
@@ -24,6 +24,32 @@ export function CustomModelsSection({ provider }: { provider: Provider }) {
 
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<CustomModel | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CustomModel | null>(null);
+
+  const models = customModels.data?.models ?? [];
+
+  // Search + pagination
+  const [searchQuery, setSearchQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const PER_PAGE = 12;
+
+  const filteredModels = useMemo(() => {
+    if (!searchQuery.trim()) return models;
+    const q = searchQuery.toLowerCase();
+    return models.filter(m =>
+      m.id.toLowerCase().includes(q) ||
+      (m.name && m.name.toLowerCase().includes(q)) ||
+      (m.kind && m.kind.toLowerCase().includes(q))
+    );
+  }, [models, searchQuery]);
+
+  useEffect(() => { setPage(1); }, [searchQuery]);
+
+  const totalPages = Math.ceil(filteredModels.length / PER_PAGE);
+  const paginatedModels = filteredModels.slice(
+    (page - 1) * PER_PAGE,
+    page * PER_PAGE,
+  );
 
   const invalidate = () => {
     qc.invalidateQueries({ queryKey: ["custom-models", providerId] });
@@ -57,12 +83,11 @@ export function CustomModelsSection({ provider }: { provider: Provider }) {
     mutationFn: (dbId: string) => api.deleteCustomModel(providerId, dbId),
     onSuccess: () => {
       invalidate();
+      setDeleteTarget(null);
       toast.success("Model removed", "The custom model was deleted.");
     },
     onError: (e: Error) => toast.error("Couldn't remove model", e.message),
   });
-
-  const models = customModels.data?.models ?? [];
 
   const openAdd = () => {
     setEditing(null);
@@ -79,7 +104,6 @@ export function CustomModelsSection({ provider }: { provider: Provider }) {
         title="Custom Models"
         description="Models you register yourself, beyond the predefined catalog. Use Fetch from /models to import the upstream listing, or add entries manually."
         action={
-
           <Button variant="ghost" className="h-8 px-3 text-xs" onClick={openAdd}>
             <Plus className="h-3.5 w-3.5" />
             Add model
@@ -95,49 +119,66 @@ export function CustomModelsSection({ provider }: { provider: Provider }) {
           />
         </div>
       ) : (
-        <div className="divide-y divide-[var(--border)] border-t border-[var(--border)]">
-          {models.map((m) => (
-            <div key={m.db_id} className="flex items-center gap-3 px-6 py-3">
-              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-100 text-accent-700 dark:bg-accent-800/40 dark:text-accent-200">
-                <Sparkles className="h-4 w-4" />
+        <>
+          {filteredModels.length > 0 && (
+            <div className="flex flex-col gap-3 border-t border-[var(--border)] bg-[var(--bg-subtle)] px-6 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="relative w-full max-w-sm">
+                <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-muted)]" />
+                <Input
+                  placeholder="Search custom models..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-9 h-8 text-sm"
+                />
               </div>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <code className="truncate font-mono text-xs text-[var(--text)]" title={`${provider.alias || provider.id}/${m.id}`}>
-                    {provider.alias || provider.id}/{m.id}
-                  </code>
-                  <Badge tone="accent">custom</Badge>
-                  {m.kind && m.kind !== "llm" && <Badge tone="neutral">{m.kind}</Badge>}
-                </div>
-                <div className="mt-0.5 flex items-center gap-3 text-[10px] text-[var(--text-muted)]">
-                  {m.name && m.name !== m.id && <span className="truncate">{m.name}</span>}
-                  {m.context_window > 0 && <span>{m.context_window.toLocaleString()} ctx</span>}
-                  {(m.input_per_m > 0 || m.output_per_m > 0) && (
-                    <span>
-                      ${m.input_per_m}/${m.output_per_m} per M
-                    </span>
-                  )}
-                </div>
-              </div>
-              <button
-                className="flex h-7 w-7 items-center justify-center rounded text-[var(--text-muted)] transition-colors hover:bg-ink-100 hover:text-[var(--text)] dark:hover:bg-ink-800"
-                title="Edit model"
-                onClick={() => openEdit(m)}
-              >
-                <Pencil className="h-3.5 w-3.5" />
-              </button>
-              <button
-                className="flex h-7 w-7 items-center justify-center rounded text-[var(--text-muted)] transition-colors hover:bg-[color:var(--color-danger)]/10 hover:text-[color:var(--color-danger)]"
-                title="Remove model"
-                onClick={() => {
-                  if (confirm(`Remove custom model "${m.id}"?`)) deleteMut.mutate(m.db_id);
-                }}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </button>
+              <span className="text-xs text-[var(--text-muted)]">
+                {filteredModels.length} model{filteredModels.length === 1 ? "" : "s"}
+              </span>
             </div>
-          ))}
-        </div>
+          )}
+          {filteredModels.length === 0 ? (
+            <div className="px-6 py-12 text-center text-sm text-[var(--text-muted)] border-t border-[var(--border)]">
+              No custom models found matching "{searchQuery}"
+            </div>
+          ) : (
+            <div className={`grid grid-cols-1 gap-px overflow-hidden border-t border-[var(--border)] bg-[var(--border)] sm:grid-cols-2 lg:grid-cols-3 ${totalPages <= 1 ? "rounded-b-2xl" : ""}`}>
+              {paginatedModels.map((m) => (
+                <CustomModelCell
+                  key={m.db_id}
+                  model={m}
+                  provider={provider}
+                  onEdit={() => openEdit(m)}
+                  onDelete={() => setDeleteTarget(m)}
+                />
+              ))}
+            </div>
+          )}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between rounded-b-2xl border-t border-[var(--border)] bg-[var(--bg-subtle)] px-6 py-3">
+              <span className="text-xs text-[var(--text-muted)]">
+                Showing {(page - 1) * PER_PAGE + 1} to {Math.min(page * PER_PAGE, filteredModels.length)} of {filteredModels.length} models
+              </span>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  className="h-8 px-2 text-xs"
+                  disabled={page === 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="ghost"
+                  className="h-8 px-2 text-xs"
+                  disabled={page === totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
       )}
 
       <CustomModelModal
@@ -156,7 +197,133 @@ export function CustomModelsSection({ provider }: { provider: Provider }) {
           }
         }}
       />
+
+      {/* Delete confirmation dialog */}
+      <Modal
+        open={!!deleteTarget}
+        onClose={() => { if (!deleteMut.isPending) setDeleteTarget(null); }}
+        title={`Remove custom model "${deleteTarget?.id}"?`}
+        subtitle="This model will no longer be routable."
+        maxWidth="max-w-md"
+      >
+        <div className="space-y-4 px-6 py-5">
+          <div className="flex items-start gap-3 rounded-xl border border-[color:var(--color-danger)]/30 bg-[color:var(--color-danger)]/10 px-3.5 py-3">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--color-danger)]" strokeWidth={2} />
+            <div className="text-sm leading-snug text-[color:var(--color-danger)]">
+              The model will be unregistered from this provider.
+              <span className="font-semibold"> This action cannot be undone.</span>
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => setDeleteTarget(null)}
+              disabled={deleteMut.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              onClick={() => deleteTarget && deleteMut.mutate(deleteTarget.db_id)}
+              disabled={deleteMut.isPending}
+            >
+              {deleteMut.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5" />
+              )}
+              Remove model
+            </Button>
+          </div>
+        </div>
+      </Modal>
     </Card>
+  );
+}
+
+// CustomModelCell renders a single custom model in a hairline grid cell,
+// matching the style of the catalog model list.
+function CustomModelCell({
+  model: m,
+  provider,
+  onEdit,
+  onDelete,
+}: {
+  model: CustomModel;
+  provider: Provider;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const fullModel = `${provider.alias || provider.id}/${m.id}`;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(fullModel);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="group relative flex flex-col justify-between bg-[var(--bg-elevated)] p-4 transition-all hover:bg-[var(--bg-subtle)]">
+      <div className="mb-3 flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          <div className="flex h-6 w-6 items-center justify-center rounded-md bg-accent-100 text-accent-700 dark:bg-accent-800/40 dark:text-accent-200">
+            <Sparkles className="h-3.5 w-3.5" />
+          </div>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+            {m.kind || "Model"}
+          </span>
+        </div>
+        <div className="flex items-center gap-0.5">
+          <button
+            onClick={onEdit}
+            className="flex h-7 w-7 items-center justify-center rounded bg-transparent text-[var(--text-muted)] transition-colors hover:bg-ink-100 hover:text-[var(--text)] dark:hover:bg-ink-800"
+            title="Edit model"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+          <button
+            onClick={onDelete}
+            className="flex h-7 w-7 items-center justify-center rounded bg-transparent text-[var(--text-muted)] transition-colors hover:bg-[color:var(--color-danger)]/10 hover:text-[color:var(--color-danger)]"
+            title="Remove model"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+      <div>
+        <code className="block truncate font-mono text-xs text-[var(--text)] tracking-tight" title={fullModel}>
+          {fullModel}
+        </code>
+        {m.name && m.name !== m.id && (
+          <span className="mt-1 block truncate text-[10px] text-[var(--text-muted)]" title={m.name}>
+            {m.name}
+          </span>
+        )}
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <Badge tone="accent">custom</Badge>
+          {m.context_window > 0 && (
+            <span className="text-[10px] text-[var(--text-muted)]">{m.context_window.toLocaleString()} ctx</span>
+          )}
+          {(m.input_per_m > 0 || m.output_per_m > 0) && (
+            <span className="text-[10px] text-[var(--text-muted)]">
+              ${m.input_per_m}/${m.output_per_m}/M
+            </span>
+          )}
+          <button
+            onClick={handleCopy}
+            className="ml-auto flex h-6 w-6 items-center justify-center rounded text-[var(--text-muted)] opacity-0 transition-all hover:bg-ink-100 hover:text-[var(--text)] dark:hover:bg-ink-800 group-hover:opacity-100"
+            title="Copy model path"
+          >
+            {copied ? (
+              <CheckCircle className="h-3.5 w-3.5 text-green-500" />
+            ) : (
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -460,14 +460,12 @@ export function PageHeader({
   action?: ReactNode;
 }) {
   return (
-    <div className="mb-5 flex items-start justify-between gap-4">
-      <div className="flex items-start gap-3">
-        <div>
-          <h1 className="font-display text-3xl font-semibold tracking-tight">{title}</h1>
-          {description && <p className="mt-1 text-sm text-[var(--text-muted)]">{description}</p>}
-        </div>
+    <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+      <div className="min-w-0">
+        <h1 className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">{title}</h1>
+        {description && <p className="mt-1 text-sm text-[var(--text-muted)]">{description}</p>}
       </div>
-      {action}
+      {action && <div className="shrink-0">{action}</div>}
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -786,6 +786,19 @@ export interface SQLiteRestoreResult {
   safety_backup: string;
 }
 
+export interface ForeignImportResult {
+  source: string;
+  imported: number;
+  skipped: number;
+  accounts: number;
+  custom_providers: number;
+  api_keys: number;
+  chains: number;
+  aliases: number;
+  proxy_pools: number;
+  errors?: string[];
+}
+
 class APIError extends Error {
   status: number;
   constructor(status: number, message: string) {
@@ -1194,6 +1207,11 @@ export const api = {
     ),
   importDatabase: (payload: Record<string, unknown>, passphrase?: string) =>
     request<{ imported: number }>("POST", "/settings/database", passphrase ? { ...payload, passphrase } : payload),
+
+  // Foreign config import: convert a 9router or OmniRoute backup JSON into
+  // KeiRouter records (accounts re-sealed, api keys re-hashed, combos → chains).
+  importForeignConfig: (source: "9router" | "omniroute", config: Record<string, unknown>) =>
+    request<ForeignImportResult>("POST", "/settings/database/import-foreign", { source, config }),
 
   sqliteStatus: () => request<SQLiteStatus>("GET", "/settings/sqlite"),
   backupSQLite: () => requestBlob("GET", "/settings/sqlite/backup"),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1029,7 +1029,7 @@ export const api = {
   updateCustomProvider: (id: string, patch: { display_name?: string; alias?: string; base_url?: string }) =>
     request<CustomProvider>("PATCH", `/custom-providers/${id}`, patch),
   deleteCustomProvider: (id: string) =>
-    request<{ id: string; deleted: boolean }>("DELETE", `/custom-providers/${id}`),
+    request<{ id: string; deleted: boolean; accounts_disabled?: number }>("DELETE", `/custom-providers/${id}`),
 
   importModels: (id: string) =>
     request<{ provider_id: string; imported: number; skipped: number; total: number }>(

--- a/frontend/src/pages/ProviderDetail.tsx
+++ b/frontend/src/pages/ProviderDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useMemo } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Plus, Trash2, Plug, X, Zap, ArrowUp, ArrowDown, CheckCircle, ToggleLeft, ToggleRight, Search, Route, AlertCircle, AlertTriangle, RefreshCw, Globe, Copy, Check, Upload, Loader2, XCircle, Layers, FileText, Download } from "lucide-react";
 import { api, type DeviceCode, type OAuthProvider, type Provider, type Account, type ProxyPool, type UpstreamQuota, type ProviderRoutingSettings, type BulkAccountResult, type QuotaAccount } from "../lib/api";
@@ -49,6 +49,7 @@ function redirectURIForProvider(provider: OAuthProvider): string {
 
 export function ProviderDetailPage() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const qc = useQueryClient();
   const toast = useToast();
 
@@ -121,6 +122,7 @@ export function ProviderDetailPage() {
   const [commandcodeOpen, setCommandcodeOpen] = useState(false);
   const [addKeyOpen, setAddKeyOpen] = useState(false);
   const [bulkOpen, setBulkOpen] = useState(false);
+  const [deleteProviderOpen, setDeleteProviderOpen] = useState(false);
 
   // Model search and pagination
   const [modelSearchQuery, setModelSearchQuery] = useState("");
@@ -321,6 +323,20 @@ export function ProviderDetailPage() {
     onError: (e: Error) => toast.error("Bulk removal failed", e.message),
   });
 
+  const deleteProviderMut = useMutation({
+    mutationFn: () => api.deleteCustomProvider(id!),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ["providers"] });
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      const detail = data?.accounts_disabled
+        ? `${provider?.display_name} has been removed. ${data.accounts_disabled} bound account(s) disabled.`
+        : `${provider?.display_name} has been removed.`;
+      toast.success("Provider deleted", detail);
+      navigate("/providers");
+    },
+    onError: (e: Error) => toast.error("Failed to delete provider", e.message),
+  });
+
   // Sort accounts by priority for display.
   const sortedAccounts = [...myAccounts].sort((a, b) => a.priority - b.priority);
   const disabledModelIds = new Set(disabledModels.data?.ids ?? []);
@@ -442,10 +458,25 @@ export function ProviderDetailPage() {
       <header className="mb-7 flex items-start gap-4">
         <ProviderIcon provider={provider} size={56} />
         <div className="min-w-0 flex-1">
-          <h1 className="font-display text-3xl font-semibold tracking-tight">{provider.display_name}</h1>
-          <p className="mt-1 text-sm text-[var(--text-muted)]">
-            {myAccounts.length} connected {myAccounts.length === 1 ? "account" : "accounts"}
-          </p>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h1 className="font-display text-3xl font-semibold tracking-tight">{provider.display_name}</h1>
+              <p className="mt-1 text-sm text-[var(--text-muted)]">
+                {myAccounts.length} connected {myAccounts.length === 1 ? "account" : "accounts"}
+              </p>
+            </div>
+            {provider.custom && (
+              <Button
+                variant="ghost"
+                className="h-8 shrink-0 px-3 text-xs text-[color:var(--color-danger)] hover:bg-[color:var(--color-danger)]/10"
+                onClick={() => setDeleteProviderOpen(true)}
+                title="Delete this custom provider"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete provider
+              </Button>
+            )}
+          </div>
           <div className="mt-2 flex flex-wrap gap-1">
             {(provider.service_kinds ?? []).map((k) => (
               <Badge key={k} tone="accent">
@@ -887,6 +918,46 @@ export function ProviderDetailPage() {
                 <Trash2 className="h-3.5 w-3.5" />
               )}
               Delete {selectedList.length} account{selectedList.length > 1 ? "s" : ""}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Delete custom provider confirmation */}
+      <Modal
+        open={deleteProviderOpen}
+        onClose={() => { if (!deleteProviderMut.isPending) setDeleteProviderOpen(false); }}
+        title={`Delete ${provider.display_name}?`}
+        subtitle="This removes the custom provider, its custom models, and disables all bound accounts."
+        maxWidth="max-w-md"
+      >
+        <div className="space-y-4 px-6 py-5">
+          <div className="flex items-start gap-3 rounded-xl border border-[color:var(--color-danger)]/30 bg-[color:var(--color-danger)]/10 px-3.5 py-3">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--color-danger)]" strokeWidth={2} />
+            <div className="text-sm leading-snug text-[color:var(--color-danger)]">
+              Its accounts and custom models will no longer be routable.
+              <span className="font-semibold"> This action cannot be undone.</span>
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => setDeleteProviderOpen(false)}
+              disabled={deleteProviderMut.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              onClick={() => deleteProviderMut.mutate()}
+              disabled={deleteProviderMut.isPending}
+            >
+              {deleteProviderMut.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5" />
+              )}
+              Delete provider
             </Button>
           </div>
         </div>

--- a/frontend/src/pages/ProviderHealth.tsx
+++ b/frontend/src/pages/ProviderHealth.tsx
@@ -119,7 +119,7 @@ function Overview() {
         title="Provider Health"
         description="Monitor the health of every AI provider connected to KeiRouter. See which are failing or slow, why, which routing chains are affected, and what to do next."
         action={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <SegmentedControl value={range} onChange={setRange} options={RANGES} />
             <button
               onClick={() => overview.refetch()}

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Boxes, Search, X, AlertTriangle, Plus } from "lucide-react";
+import { Boxes, Search, X, AlertTriangle, Plus, Trash2 } from "lucide-react";
 import { api, type Provider, type Account } from "../lib/api";
 import { PageHeader } from "../components/Layout";
 import { Card, CardHeader, Badge, Spinner, EmptyState, StatusDot, Button, Modal, Field, Input, Select, ErrorBanner } from "../components/ui";
@@ -112,11 +112,29 @@ const kindFilters = [
 ];
 
 export function ProvidersPage() {
+  const qc = useQueryClient();
+  const toast = useToast();
   const providers = useQuery({ queryKey: ["providers"], queryFn: () => api.providers() });
   const accounts = useQuery({ queryKey: ["accounts"], queryFn: () => api.listAccounts() });
   const [filter, setFilter] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [customOpen, setCustomOpen] = useState(false);
+
+  const removeProvider = useMutation({
+    mutationFn: (id: string) => api.deleteCustomProvider(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["providers"] });
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      toast.success("Provider deleted", "The custom provider has been removed.");
+    },
+    onError: (e: Error) => toast.error("Failed to delete provider", e.message),
+  });
+
+  const onDeleteProvider = (p: Provider) => {
+    if (confirm(`Delete custom provider "${p.display_name}"?\n\nIts accounts and custom models will no longer be routable.`)) {
+      removeProvider.mutate(p.id);
+    }
+  };
 
 
   // Count accounts per provider id so we can split connected vs available.
@@ -368,16 +386,30 @@ function CreateCustomProviderModal({ open, onClose }: { open: boolean; onClose: 
 }
 
 function ProviderCard({ provider: p, accountCount }: { provider: Provider; accountCount: number }) {
-
+  const qc = useQueryClient();
   const navigate = useNavigate();
+  const toast = useToast();
   const connected = accountCount > 0;
 
+  const remove = useMutation({
+    mutationFn: () => api.deleteCustomProvider(p.id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["providers"] });
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      toast.success("Provider deleted", `"${p.display_name}" has been removed.`);
+    },
+    onError: (e: Error) => toast.error("Failed to delete provider", e.message),
+  });
+
   return (
-    <button
-      onClick={() => navigate(`/providers/${p.id}`)}
-      className="flex h-full flex-col items-start gap-3 bg-[var(--bg-elevated)] p-5 text-left transition-colors hover:bg-ink-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-400/60 dark:hover:bg-ink-800/40"
-    >
-      <div className="flex w-full items-start justify-between gap-2">
+    <div className="group relative flex h-full flex-col items-start gap-3 bg-[var(--bg-elevated)] p-5 text-left transition-colors hover:bg-ink-50 focus-within:ring-2 focus-within:ring-inset focus-within:ring-accent-400/60 dark:hover:bg-ink-800/40">
+      <button
+        type="button"
+        onClick={() => navigate(`/providers/${p.id}`)}
+        className="absolute inset-0 h-full w-full cursor-pointer focus:outline-none"
+        aria-label={`Open ${p.display_name}`}
+      />
+      <div className="relative flex w-full items-start justify-between gap-2">
         <ProviderIcon provider={p} />
         {connected ? (
           <span className="inline-flex items-center gap-1.5 rounded-md bg-accent-100 px-2 py-0.5 text-xs font-medium text-accent-700 dark:bg-accent-800/40 dark:text-accent-200">
@@ -396,17 +428,35 @@ function ProviderCard({ provider: p, accountCount }: { provider: Provider; accou
         ) : null}
       </div>
 
-      <div className="min-w-0">
+      {p.custom ? (
+        <button
+          type="button"
+          disabled={remove.isPending}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (confirm(`Delete custom provider "${p.display_name}"?\n\nIts accounts and custom models will no longer be routable.`)) {
+              remove.mutate();
+            }
+          }}
+          className="absolute right-2 top-2 z-10 rounded-md p-1.5 text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[color:var(--color-danger)]/10 hover:text-[color:var(--color-danger)] focus:opacity-100 group-hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-50"
+          title="Delete custom provider"
+          aria-label={`Delete custom provider ${p.display_name}`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
+
+      <div className="relative min-w-0">
         <p className="truncate text-sm font-semibold">{p.display_name}</p>
         <p className="mt-0.5 truncate font-mono text-xs text-[var(--text-muted)]">{p.id}</p>
       </div>
 
-      <p className="mt-auto text-xs text-[var(--text-muted)]">
+      <p className="relative mt-auto text-xs text-[var(--text-muted)]">
         {connected
           ? `${accountCount} ${accountCount === 1 ? "account" : "accounts"}`
           : "Connect"}
       </p>
-    </button>
+    </div>
   );
 }
 

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Boxes, Search, X, AlertTriangle, Plus, Trash2 } from "lucide-react";
+import { Boxes, Search, X, AlertTriangle, Plus } from "lucide-react";
 import { api, type Provider, type Account } from "../lib/api";
 import { PageHeader } from "../components/Layout";
 import { Card, CardHeader, Badge, Spinner, EmptyState, StatusDot, Button, Modal, Field, Input, Select, ErrorBanner } from "../components/ui";
@@ -112,32 +112,12 @@ const kindFilters = [
 ];
 
 export function ProvidersPage() {
-  const qc = useQueryClient();
-  const toast = useToast();
   const providers = useQuery({ queryKey: ["providers"], queryFn: () => api.providers() });
   const accounts = useQuery({ queryKey: ["accounts"], queryFn: () => api.listAccounts() });
   const [filter, setFilter] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [customOpen, setCustomOpen] = useState(false);
 
-  const removeProvider = useMutation({
-    mutationFn: (id: string) => api.deleteCustomProvider(id),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["providers"] });
-      qc.invalidateQueries({ queryKey: ["accounts"] });
-      toast.success("Provider deleted", "The custom provider has been removed.");
-    },
-    onError: (e: Error) => toast.error("Failed to delete provider", e.message),
-  });
-
-  const onDeleteProvider = (p: Provider) => {
-    if (confirm(`Delete custom provider "${p.display_name}"?\n\nIts accounts and custom models will no longer be routable.`)) {
-      removeProvider.mutate(p.id);
-    }
-  };
-
-
-  // Count accounts per provider id so we can split connected vs available.
   const accountsByProvider = useMemo(() => {
     const map = new Map<string, Account[]>();
     for (const a of accounts.data?.accounts ?? []) {
@@ -386,30 +366,17 @@ function CreateCustomProviderModal({ open, onClose }: { open: boolean; onClose: 
 }
 
 function ProviderCard({ provider: p, accountCount }: { provider: Provider; accountCount: number }) {
-  const qc = useQueryClient();
   const navigate = useNavigate();
-  const toast = useToast();
   const connected = accountCount > 0;
 
-  const remove = useMutation({
-    mutationFn: () => api.deleteCustomProvider(p.id),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["providers"] });
-      qc.invalidateQueries({ queryKey: ["accounts"] });
-      toast.success("Provider deleted", `"${p.display_name}" has been removed.`);
-    },
-    onError: (e: Error) => toast.error("Failed to delete provider", e.message),
-  });
-
   return (
-    <div className="group relative flex h-full flex-col items-start gap-3 bg-[var(--bg-elevated)] p-5 text-left transition-colors hover:bg-ink-50 focus-within:ring-2 focus-within:ring-inset focus-within:ring-accent-400/60 dark:hover:bg-ink-800/40">
-      <button
-        type="button"
-        onClick={() => navigate(`/providers/${p.id}`)}
-        className="absolute inset-0 h-full w-full cursor-pointer focus:outline-none"
-        aria-label={`Open ${p.display_name}`}
-      />
-      <div className="relative flex w-full items-start justify-between gap-2">
+    <button
+      type="button"
+      onClick={() => navigate(`/providers/${p.id}`)}
+      aria-label={`Open ${p.display_name}`}
+      className="group relative flex h-full w-full flex-col items-start gap-3 rounded-none bg-[var(--bg-elevated)] p-5 text-left transition-colors hover:bg-ink-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-400/60 dark:hover:bg-ink-800/40"
+    >
+      <div className="flex w-full items-start justify-between gap-2">
         <ProviderIcon provider={p} />
         {connected ? (
           <span className="inline-flex items-center gap-1.5 rounded-md bg-accent-100 px-2 py-0.5 text-xs font-medium text-accent-700 dark:bg-accent-800/40 dark:text-accent-200">
@@ -428,35 +395,17 @@ function ProviderCard({ provider: p, accountCount }: { provider: Provider; accou
         ) : null}
       </div>
 
-      {p.custom ? (
-        <button
-          type="button"
-          disabled={remove.isPending}
-          onClick={(e) => {
-            e.stopPropagation();
-            if (confirm(`Delete custom provider "${p.display_name}"?\n\nIts accounts and custom models will no longer be routable.`)) {
-              remove.mutate();
-            }
-          }}
-          className="absolute right-2 top-2 z-10 rounded-md p-1.5 text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[color:var(--color-danger)]/10 hover:text-[color:var(--color-danger)] focus:opacity-100 group-hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-50"
-          title="Delete custom provider"
-          aria-label={`Delete custom provider ${p.display_name}`}
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </button>
-      ) : null}
-
-      <div className="relative min-w-0">
+      <div className="min-w-0">
         <p className="truncate text-sm font-semibold">{p.display_name}</p>
         <p className="mt-0.5 truncate font-mono text-xs text-[var(--text-muted)]">{p.id}</p>
       </div>
 
-      <p className="relative mt-auto text-xs text-[var(--text-muted)]">
+      <p className="mt-auto text-xs text-[var(--text-muted)]">
         {connected
           ? `${accountCount} ${accountCount === 1 ? "account" : "accounts"}`
           : "Connect"}
       </p>
-    </div>
+    </button>
   );
 }
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,7 +6,7 @@ import {
   Gauge, Eye, EyeOff, KeyRound, Download, Upload, ShieldCheck, Info,
   Palette, Shield,
 } from "lucide-react";
-import { api, type EndpointSettings, type BrandingSettings, type HeadroomTestResult } from "../lib/api";
+import { api, type EndpointSettings, type BrandingSettings, type HeadroomTestResult, type ForeignImportResult } from "../lib/api";
 import { ChangelogMarkdown } from "../components/ChangelogMarkdown";
 import { PALETTES, getPaletteScales } from "../lib/palettes";
 import { applyShadeScale, generateShades } from "../lib/color-utils";
@@ -1142,6 +1142,7 @@ function BrandingTab() {
 function SystemTab() {
   return (
     <div className="space-y-4">
+      <ForeignImportSettings />
       <DatabaseSettings />
       <UpdatesSettings />
     </div>
@@ -1206,6 +1207,165 @@ function strengthOf(pass: string): { label: string; tone: "muted" | "weak" | "ok
   if (score <= 2) return { label: "Weak — short or simple", tone: "weak", pct: 33 };
   if (score <= 3) return { label: "OK — could be stronger", tone: "ok", pct: 66 };
   return { label: "Strong", tone: "strong", pct: 100 };
+}
+
+function ForeignImportSettings() {
+  const toast = useToast();
+  const import9rRef = useRef<HTMLInputElement>(null);
+  const importOmniRef = useRef<HTMLInputElement>(null);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<ForeignImportResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const runImport = async (source: "9router" | "omniroute", file: File) => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const raw = await file.text();
+      const config = JSON.parse(raw);
+      const res = await api.importForeignConfig(source, config);
+      setResult(res);
+      const parts: string[] = [];
+      if (res.accounts) parts.push(`${res.accounts} account${res.accounts === 1 ? "" : "s"}`);
+      if (res.custom_providers) parts.push(`${res.custom_providers} provider${res.custom_providers === 1 ? "" : "s"}`);
+      if (res.api_keys) parts.push(`${res.api_keys} key${res.api_keys === 1 ? "" : "s"}`);
+      if (res.chains) parts.push(`${res.chains} chain${res.chains === 1 ? "" : "s"}`);
+      if (res.aliases) parts.push(`${res.aliases} alias${res.aliases === 1 ? "" : "es"}`);
+      if (res.proxy_pools) parts.push(`${res.proxy_pools} pool${res.proxy_pools === 1 ? "" : "s"}`);
+      const summary = parts.length ? parts.join(", ") : "nothing";
+      toast.success(
+        `${source === "9router" ? "9router" : "OmniRoute"} import complete`,
+        `${res.imported} record${res.imported === 1 ? "" : "s"} imported (${summary}).${res.skipped ? ` ${res.skipped} skipped.` : ""}`,
+      );
+    } catch (e) {
+      setError((e as Error).message || "Import failed.");
+      toast.error("Import failed", (e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handle9rFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void runImport("9router", file);
+    if (import9rRef.current) import9rRef.current.value = "";
+  };
+
+  const handleOmniFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void runImport("omniroute", file);
+    if (importOmniRef.current) importOmniRef.current.value = "";
+  };
+
+  return (
+    <Card>
+      <SectionHeader
+        title="Import from other routers"
+        description="Migrate providers, keys, and routing chains from a 9router or OmniRoute backup. Imports are additive — existing data is kept."
+        icon={Upload}
+      />
+      <div className="grid gap-4 border-t border-[var(--border)] px-6 py-4 sm:grid-cols-2">
+        {/* 9router */}
+        <div className="flex flex-col gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg)] p-4">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-accent-100 text-xs font-bold text-accent-700 dark:bg-accent-900/40 dark:text-accent-200">
+              9R
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-[var(--text)]">9router backup</p>
+              <p className="text-[11px] text-[var(--text-muted)]">Full credential transfer</p>
+            </div>
+          </div>
+          <p className="text-xs leading-relaxed text-[var(--text-muted)]">
+            Imports provider connections (API keys &amp; OAuth tokens re-sealed), custom provider nodes, API keys
+            (re-hashed — same key string keeps working), combos (→ chains), proxy pools, and model aliases.
+          </p>
+          <Button variant="ghost" onClick={() => import9rRef.current?.click()} disabled={loading} className="w-full">
+            <Upload className="h-4 w-4" />
+            Select 9router backup JSON
+          </Button>
+          <input
+            ref={import9rRef}
+            type="file"
+            accept="application/json,.json"
+            className="hidden"
+            onChange={handle9rFile}
+          />
+        </div>
+
+        {/* OmniRoute */}
+        <div className="flex flex-col gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg)] p-4">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-secondary-100 text-xs font-bold text-secondary-700 dark:bg-secondary-900/40 dark:text-secondary-200">
+              OR
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-[var(--text)]">OmniRoute backup</p>
+              <p className="text-[11px] text-[var(--text-muted)]">Structural import (creds redacted)</p>
+            </div>
+          </div>
+          <p className="text-xs leading-relaxed text-[var(--text-muted)]">
+            OmniRoute JSON exports redact credentials, so accounts are imported as disabled stubs — re-authenticate after
+            import. Custom provider nodes, combos (→ chains), proxy pools, and aliases transfer fully. API keys must be
+            re-created.
+          </p>
+          <Button variant="ghost" onClick={() => importOmniRef.current?.click()} disabled={loading} className="w-full">
+            <Upload className="h-4 w-4" />
+            Select OmniRoute backup JSON
+          </Button>
+          <input
+            ref={importOmniRef}
+            type="file"
+            accept="application/json,.json"
+            className="hidden"
+            onChange={handleOmniFile}
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div className="border-t border-[var(--border)] px-6 pb-4">
+          <ErrorBanner message={error} />
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-3 border-t border-[var(--border)] px-6 py-4">
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-xs">
+            <Stat label="Accounts" value={result.accounts} />
+            <Stat label="Custom providers" value={result.custom_providers} />
+            <Stat label="API keys" value={result.api_keys} />
+            <Stat label="Chains" value={result.chains} />
+            <Stat label="Aliases" value={result.aliases} />
+            <Stat label="Proxy pools" value={result.proxy_pools} />
+            <Stat label="Skipped" value={result.skipped} muted />
+          </div>
+          {result.errors && result.errors.length > 0 && (
+            <details className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2">
+              <summary className="cursor-pointer text-xs font-medium text-[var(--text-muted)]">
+                {result.errors.length} warning{result.errors.length === 1 ? "" : "s"}
+              </summary>
+              <ul className="mt-2 max-h-40 space-y-1 overflow-y-auto text-[11px] text-[var(--text-muted)]">
+                {result.errors.map((e, i) => (
+                  <li key={i} className="font-mono break-all">{e}</li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function Stat({ label, value, muted }: { label: string; value: number; muted?: boolean }) {
+  return (
+    <div>
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">{label}</span>{" "}
+      <span className={`font-mono text-sm ${muted ? "text-[var(--text-muted)]" : "text-[var(--text)]"}`}>{value}</span>
+    </div>
+  );
 }
 
 function DatabaseSettings() {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -19,14 +19,15 @@ import {
 } from "../components/ui";
 
 // ── Tab definitions ─────────────────────────────────────────────────
-type SettingsTab = "saving" | "routing" | "network" | "branding" | "system";
+type SettingsTab = "saving" | "routing" | "network" | "branding" | "import-export" | "system";
 
 const settingsTabs = [
   { value: "saving" as const, label: "Token Saving", icon: Zap },
   { value: "routing" as const, label: "Routing", icon: Route },
   { value: "network" as const, label: "Network", icon: Gauge },
   { value: "branding" as const, label: "Branding", icon: Palette },
-  { value: "system" as const, label: "System", icon: Database },
+  { value: "import-export" as const, label: "Import / Export", icon: Database },
+  { value: "system" as const, label: "System", icon: ArrowUpCircle },
 ];
 
 function useHashTab(defaultTab: SettingsTab): [SettingsTab, (t: SettingsTab) => void] {
@@ -152,6 +153,7 @@ export function SettingsPage() {
             {tab === "routing" && <RoutingTab local={local} update={update} />}
             {tab === "network" && <NetworkTab local={local} update={update} />}
             {tab === "branding" && <BrandingTab />}
+            {tab === "import-export" && <ImportExportTab />}
             {tab === "system" && <SystemTab />}
           </div>
 
@@ -1138,12 +1140,20 @@ function BrandingTab() {
   );
 }
 
-// ── System Tab ──────────────────────────────────────────────────────
-function SystemTab() {
+// ── Import / Export Tab ─────────────────────────────────────────────
+function ImportExportTab() {
   return (
     <div className="space-y-4">
       <ForeignImportSettings />
       <DatabaseSettings />
+    </div>
+  );
+}
+
+// ── System Tab ──────────────────────────────────────────────────────
+function SystemTab() {
+  return (
+    <div className="space-y-4">
       <UpdatesSettings />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add admin support for importing foreign router configs
- Improve router compatibility with provider health/routing checks and related UI updates
- Harden gateway behavior with target access enforcement and URL validation
- Separate Import/Export settings into its own tab in Settings page

## Changed Areas
- Backend config, dispatch, gateway, and store routing/health repositories
- Admin import endpoint for foreign router configs
- Frontend provider health, provider settings, and layout/API integrations
- Frontend Settings page: new Import / Export tab

## Testing
- Not run (PR creation only)

Closes #31