### PR TITLE
feat(pricing): backfill legacy unpriced usage rows and merge custom model prices

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -132,8 +132,15 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 	}
 
 	pricing := buildPricing()
-	modelPrices := buildModelPrices()
+	modelPrices := buildModelPrices(ctx, db, log)
 	mtr := meter.New(db.Usage(), pricing, modelPrices)
+	// Reprice deterministic legacy rows before serving analytics. Unknown or
+	// subscription-only models remain visibly unpriced instead of silently free.
+	if updated, backfillErr := mtr.BackfillUnpriced(ctx); backfillErr != nil {
+		log.Warn("usage price backfill failed", "err", backfillErr, "updated", updated)
+	} else if updated > 0 {
+		log.Info("usage price backfill completed", "updated", updated)
+	}
 	mtr.EnableAsync(meter.AsyncConfig{
 		Enabled:              cfg.Meter.Async,
 		BatchSize:            cfg.Meter.BatchSize,
@@ -358,6 +365,18 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 		MaxModelsPerProvider: cfg.Health.MaxModelsPerProvider,
 	}, log, db.Accounts(), db.Health(), connRegistry, v)
 
+	reloadPricing := func(reloadCtx context.Context) error {
+		mtr.ReplacePrices(buildPricing(), buildModelPrices(reloadCtx, db, log))
+		updated, reloadErr := mtr.BackfillUnpriced(reloadCtx)
+		if updated > 0 {
+			log.Info("usage pricing reloaded and historical rows backfilled", "updated", updated)
+		}
+		if reloadErr != nil {
+			return fmt.Errorf("reload usage pricing: %w", reloadErr)
+		}
+		return nil
+	}
+
 	gw := gateway.New(gateway.Deps{
 		Config:               cfg,
 		Logger:               log,
@@ -389,6 +408,7 @@ func Build(ctx context.Context, cfg config.Config, log *slog.Logger, version str
 		ProxyNotifier:        proxyNotifier,
 		RateLimiter:          limiter,
 		Refresher:            tokenRefresher,
+		ReloadPricing:        reloadPricing,
 		Guardrails:           guardrailEngine,
 		GuardrailRepo:        db.Guardrails(),
 		GuardrailLogs:        db.GuardrailLogs(),
@@ -781,15 +801,40 @@ func (a *App) runCooldownSweeper(ctx context.Context) {
 }
 
 // buildModelPrices builds the per-model pricing table from the connector model prices.
-func buildModelPrices() map[string]meter.Price {
+func buildModelPrices(ctx context.Context, db *store.DB, log *slog.Logger) map[string]meter.Price {
 	out := make(map[string]meter.Price)
 	for _, mp := range connectors.ModelPricingTable() {
+		source := mp.Source
+		if source == "" {
+			source = "catalog"
+		}
+		estimated := mp.Estimated || mp.Provider == "kiro"
 		out[mp.Provider+"/"+mp.Model] = meter.Price{
-			InputPerM:       mp.InputPerM,
-			OutputPerM:      mp.OutputPerM,
-			CachedInputPerM: mp.CachedInputPerM,
-			CacheWritePerM:  mp.CacheWritePerM,
-			ReasoningPerM:   mp.ReasoningPerM,
+			InputPerM: mp.InputPerM, OutputPerM: mp.OutputPerM,
+			CachedInputPerM: mp.CachedInputPerM, CacheWritePerM: mp.CacheWritePerM,
+			ReasoningPerM:        mp.ReasoningPerM,
+			LongContextThreshold: mp.LongContextThreshold,
+			LongInputPerM:        mp.LongInputPerM, LongOutputPerM: mp.LongOutputPerM,
+			LongCachedInputPerM: mp.LongCachedInputPerM, LongCacheWritePerM: mp.LongCacheWritePerM,
+			Source: source, SourceURL: mp.SourceURL, Estimated: estimated, ExplicitFree: mp.ExplicitFree,
+		}
+	}
+	// User-entered custom prices are the highest-priority exact match. Imported
+	// zero values mean "unknown", not free, and intentionally do not override a
+	// canonical vendor catalog match.
+	models, err := db.CustomProviders().ListModels(ctx, store.DefaultTenantID)
+	if err != nil {
+		log.Warn("load custom model prices failed", "err", err)
+		return out
+	}
+	for _, model := range models {
+		if model.InputPerM <= 0 && model.OutputPerM <= 0 {
+			continue
+		}
+		out[model.ProviderID+"/"+model.ModelID] = meter.Price{
+			InputPerM: model.InputPerM, OutputPerM: model.OutputPerM,
+			CachedInputPerM: model.InputPerM, CacheWritePerM: model.InputPerM,
+			ReasoningPerM: model.OutputPerM, Source: "custom", Estimated: false,
 		}
 	}
 	return out

--- a/backend/internal/connectors/kiro.go
+++ b/backend/internal/connectors/kiro.go
@@ -788,6 +788,7 @@ func estimateKiroUsage(req *core.ChatRequest, outputChars int) *core.Usage {
 		PromptTokens:     prompt,
 		CompletionTokens: completion,
 		TotalTokens:      prompt + completion,
+		Source:           core.UsageSourceEstimated,
 	}
 }
 
@@ -871,6 +872,7 @@ func parseKiroUsage(eventType string, payload []byte) *core.Usage {
 		PromptTokens:     p.InputTokens,
 		CompletionTokens: p.OutputTokens,
 		TotalTokens:      p.InputTokens + p.OutputTokens,
+		Source:           core.UsageSourceProvider,
 	}
 }
 

--- a/backend/internal/connectors/model_prices.go
+++ b/backend/internal/connectors/model_prices.go
@@ -1,37 +1,131 @@
 package connectors
 
-// ModelPrice holds per-million-token rates for a specific model.
+import "strings"
+
+// ModelPrice holds immutable catalog metadata and per-million-token rates for a
+// specific model. Source metadata lets analytics distinguish actual list price,
+// a user-configured price, and a retail-equivalent estimate.
 type ModelPrice struct {
-	Provider        string
-	Model           string
-	InputPerM       float64 // USD per million standard input tokens
-	OutputPerM      float64 // USD per million standard output tokens
-	CachedInputPerM float64 // USD per million cache-read input tokens (0 = no cache discount)
-	CacheWritePerM  float64 // USD per million cache-write input tokens (0 = no separate rate)
-	ReasoningPerM   float64 // USD per million reasoning tokens (0 = no separate rate)
+	Provider             string
+	Model                string
+	InputPerM            float64
+	OutputPerM           float64
+	CachedInputPerM      float64
+	CacheWritePerM       float64
+	ReasoningPerM        float64
+	LongContextThreshold int
+	LongInputPerM        float64
+	LongOutputPerM       float64
+	LongCachedInputPerM  float64
+	LongCacheWritePerM   float64
+	Source               string
+	SourceURL            string
+	Estimated            bool
+	ExplicitFree         bool
 }
 
-// ModelPriceByProviderModel looks up the price for a specific provider/model pair.
+// ModelPriceByProviderModel resolves exact provider/model entries first, then
+// controlled provider aliases and finally a globally unique canonical model.
+// Iterating in reverse lets currentOfficialModelPrices override stale entries.
 func ModelPriceByProviderModel(provider, model string) (ModelPrice, bool) {
-	// Try exact "model" field match (may include provider prefix like "openai/gpt-5").
-	key := provider + "/" + model
-	for _, mp := range ModelPricingTable() {
-		if mp.Provider+"/"+mp.Model == key {
-			return mp, true
+	table := ModelPricingTable()
+	providers := []string{normalizePriceProvider(provider)}
+	if p := strings.ToLower(strings.TrimSpace(provider)); p != providers[0] {
+		providers = append(providers, p)
+	}
+	models := priceModelCandidates(model)
+	for i := len(table) - 1; i >= 0; i-- {
+		mp := table[i]
+		for _, p := range providers {
+			for _, m := range models {
+				if normalizePriceProvider(mp.Provider) == p && strings.EqualFold(mp.Model, m) {
+					return mp, true
+				}
+			}
 		}
 	}
-	// Try matching just the model suffix (e.g. model="gpt-4o" matches provider="openai", model="gpt-4o").
-	for _, mp := range ModelPricingTable() {
-		if mp.Provider == provider && mp.Model == model {
-			return mp, true
+
+	// Custom OpenAI-compatible endpoints often expose a vendor model without a
+	// billable-provider id. Use a cross-provider match only when every canonical
+	// match has the same rates; ambiguity remains visibly unpriced.
+	fingerprints := make(map[string]struct{}, len(models))
+	for _, m := range models {
+		fingerprints[priceModelFingerprint(m)] = struct{}{}
+	}
+	seenKeys := map[string]struct{}{}
+	var found ModelPrice
+	hasFound := false
+	for i := len(table) - 1; i >= 0; i-- {
+		mp := table[i]
+		key := normalizePriceProvider(mp.Provider) + "/" + strings.ToLower(mp.Model)
+		if _, seen := seenKeys[key]; seen {
+			continue
+		}
+		seenKeys[key] = struct{}{}
+		if _, ok := fingerprints[priceModelFingerprint(mp.Model)]; !ok {
+			continue
+		}
+		if !hasFound {
+			found, hasFound = mp, true
+			continue
+		}
+		if !sameModelRates(found, mp) {
+			return ModelPrice{}, false
 		}
 	}
-	return ModelPrice{}, false
+	return found, hasFound
 }
 
-// ModelPricingTable returns accurate per-model pricing for all major providers.
-// Prices are in USD per million tokens. Cached input rates reflect each
-// provider's prompt caching discount (typically 50-75% off standard input).
+func normalizePriceProvider(provider string) string {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	switch p {
+	case "codex", "openai-codex":
+		return "openai"
+	case "claude", "claude-code":
+		return "anthropic"
+	case "gemini-cli", "antigravity":
+		return "gemini"
+	case "cloudflare", "workers-ai":
+		return "cloudflare-ai"
+	default:
+		return p
+	}
+}
+
+func priceModelCandidates(model string) []string {
+	m := strings.TrimSpace(model)
+	out := []string{m}
+	for strings.Contains(m, "/") {
+		m = strings.TrimPrefix(m[strings.IndexByte(m, '/')+1:], "/")
+		out = append(out, m)
+	}
+	for _, suffix := range []string{"-xhigh-review", "-high-review", "-low-review", "-none-review", "-review", "-xhigh", "-high", "-low", "-none"} {
+		if strings.HasSuffix(strings.ToLower(m), suffix) {
+			out = append(out, m[:len(m)-len(suffix)])
+			break
+		}
+	}
+	return out
+}
+
+func priceModelFingerprint(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if i := strings.LastIndexByte(m, '/'); i >= 0 {
+		m = m[i+1:]
+	}
+	replacer := strings.NewReplacer("-", "", "_", "", ".", "", " ", "")
+	return replacer.Replace(m)
+}
+
+func sameModelRates(a, b ModelPrice) bool {
+	return a.InputPerM == b.InputPerM && a.OutputPerM == b.OutputPerM &&
+		a.CachedInputPerM == b.CachedInputPerM && a.CacheWritePerM == b.CacheWritePerM &&
+		a.ReasoningPerM == b.ReasoningPerM && a.LongInputPerM == b.LongInputPerM &&
+		a.LongOutputPerM == b.LongOutputPerM
+}
+
+// ModelPricingTable returns the built-in catalog. Later entries override older
+// compatibility entries when provider/model keys collide.
 func ModelPricingTable() []ModelPrice {
 	var out []ModelPrice
 	out = append(out, openaiModelPrices()...)
@@ -53,6 +147,7 @@ func ModelPricingTable() []ModelPrice {
 	out = append(out, glmModelPrices()...)
 	out = append(out, mimoModelPrices()...)
 	out = append(out, kiroModelPrices()...)
+	out = append(out, currentOfficialModelPrices()...)
 	return out
 }
 
@@ -299,18 +394,27 @@ func nvidiaModelPrices() []ModelPrice {
 }
 
 func openrouterModelPrices() []ModelPrice {
-	// OpenRouter prices are pass-through to underlying providers.
-	// These are typical markups; actual prices vary by model.
+	// OpenRouter routes can select different upstream variants and prices can
+	// change independently. Keep these fallback catalog values explicitly
+	// estimated; exact current spend should come from provider billing metadata.
+	const sourceURL = "https://openrouter.ai/models"
+	estimated := func(model string, input, output, cached, write float64) ModelPrice {
+		return ModelPrice{
+			Provider: "openrouter", Model: model,
+			InputPerM: input, OutputPerM: output, CachedInputPerM: cached, CacheWritePerM: write,
+			Source: "retail_equivalent", SourceURL: sourceURL, Estimated: true,
+		}
+	}
 	return []ModelPrice{
-		{Provider: "openrouter", Model: "anthropic/claude-opus-4-7", InputPerM: 15, OutputPerM: 75, CachedInputPerM: 1.875, CacheWritePerM: 18.75},
-		{Provider: "openrouter", Model: "anthropic/claude-sonnet-4-6", InputPerM: 3, OutputPerM: 15, CachedInputPerM: 0.375, CacheWritePerM: 3.75},
-		{Provider: "openrouter", Model: "openai/gpt-5", InputPerM: 2.5, OutputPerM: 10, CachedInputPerM: 1.25, CacheWritePerM: 2.5},
-		{Provider: "openrouter", Model: "openai/gpt-4o", InputPerM: 2.5, OutputPerM: 10, CachedInputPerM: 1.25, CacheWritePerM: 2.5},
-		{Provider: "openrouter", Model: "openai/gpt-4o-mini", InputPerM: 0.15, OutputPerM: 0.6, CachedInputPerM: 0.075, CacheWritePerM: 0.15},
-		{Provider: "openrouter", Model: "deepseek/deepseek-chat", InputPerM: 0.27, OutputPerM: 1.1, CachedInputPerM: 0.07, CacheWritePerM: 0.27},
-		{Provider: "openrouter", Model: "google/gemini-2.5-pro", InputPerM: 1.25, OutputPerM: 10, CachedInputPerM: 0.3125, CacheWritePerM: 1.25},
-		{Provider: "openrouter", Model: "google/gemini-2.5-flash", InputPerM: 0.15, OutputPerM: 0.6, CachedInputPerM: 0.0375, CacheWritePerM: 0.15},
-		{Provider: "openrouter", Model: "meta-llama/llama-3.3-70b-instruct", InputPerM: 0.1, OutputPerM: 0.1},
+		estimated("anthropic/claude-opus-4-7", 15, 75, 1.875, 18.75),
+		estimated("anthropic/claude-sonnet-4-6", 3, 15, 0.375, 3.75),
+		estimated("openai/gpt-5", 2.5, 10, 1.25, 2.5),
+		estimated("openai/gpt-4o", 2.5, 10, 1.25, 2.5),
+		estimated("openai/gpt-4o-mini", 0.15, 0.6, 0.075, 0.15),
+		estimated("deepseek/deepseek-chat", 0.27, 1.1, 0.07, 0.27),
+		estimated("google/gemini-2.5-pro", 1.25, 10, 0.3125, 1.25),
+		estimated("google/gemini-2.5-flash", 0.15, 0.6, 0.0375, 0.15),
+		estimated("meta-llama/llama-3.3-70b-instruct", 0.1, 0.1, 0, 0),
 	}
 }
 
@@ -332,25 +436,28 @@ func glmModelPrices() []ModelPrice {
 }
 
 func mimoModelPrices() []ModelPrice {
-	// Xiaomi MiMo pricing. Both xiaomi-mimo and xiaomi-tokenplan share models.
-	// Flash pricing from genai-prices; Pro/standard tiers estimated from
-	// comparable Chinese AI provider pricing (DeepSeek, Alibaba, GLM).
+	// MiMo standard/pro/omni values are admitted retail-equivalent estimates,
+	// not authoritative token invoices. Keep that provenance explicit so they
+	// never appear as exact catalog spend.
+	estimated := func(provider, model string, input, output float64) ModelPrice {
+		return ModelPrice{
+			Provider: provider, Model: model, InputPerM: input, OutputPerM: output,
+			Source: "retail_equivalent", Estimated: true,
+		}
+	}
 	var out []ModelPrice
 	for _, provider := range []string{"xiaomi-mimo", "xiaomi-tokenplan"} {
-		out = append(out, []ModelPrice{
-			// Top-tier reasoning model
-			{Provider: provider, Model: "mimo-v2.5-pro", InputPerM: 1.0, OutputPerM: 3.0},
-			// Mid-tier general model
-			{Provider: provider, Model: "mimo-v2.5", InputPerM: 0.2, OutputPerM: 0.6},
-			// Previous-gen pro
-			{Provider: provider, Model: "mimo-v2-pro", InputPerM: 0.5, OutputPerM: 1.5},
-			// Multimodal (omni)
-			{Provider: provider, Model: "mimo-v2-omni", InputPerM: 0.2, OutputPerM: 0.6},
-			// Fast/cheap model (from genai-prices: $0.10/$0.30)
-			{Provider: provider, Model: "mimo-v2-flash", InputPerM: 0.1, OutputPerM: 0.3},
-		}...)
+		out = append(out,
+			estimated(provider, "mimo-v2.5-pro", 1.0, 3.0),
+			estimated(provider, "mimo-v2.5", 0.2, 0.6),
+			estimated(provider, "mimo-v2-pro", 0.5, 1.5),
+			estimated(provider, "mimo-v2-omni", 0.2, 0.6),
+			estimated(provider, "mimo-v2-flash", 0.1, 0.3),
+		)
 	}
-	// mimo-free: free tier, zero cost.
-	out = append(out, ModelPrice{Provider: "mimo-free", Model: "mimo-auto", InputPerM: 0, OutputPerM: 0})
+	// This connector is intentionally a zero-charge tier, not an unknown price.
+	out = append(out, ModelPrice{
+		Provider: "mimo-free", Model: "mimo-auto", Source: "catalog", ExplicitFree: true,
+	})
 	return out
 }

--- a/backend/internal/connectors/model_prices_current.go
+++ b/backend/internal/connectors/model_prices_current.go
@@ -1,0 +1,79 @@
+package connectors
+
+// currentOfficialModelPrices contains rates verified against vendor pricing
+// pages in July 2026. These entries intentionally come last in the catalog so
+// they override compatibility values retained in model_prices.go.
+func currentOfficialModelPrices() []ModelPrice {
+	const (
+		openAIURL     = "https://platform.openai.com/docs/pricing/"
+		cloudflareURL = "https://developers.cloudflare.com/workers-ai/platform/pricing/"
+		qwenURL       = "https://modelstudio.alibabacloud.com/"
+		geminiURL     = "https://ai.google.dev/gemini-api/docs/pricing"
+	)
+	prices := []ModelPrice{
+		// OpenAI standard short-context rates. The resolver switches to the
+		// long-context snapshot when prompt tokens exceed 272K.
+		{Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5, CachedInputPerM: .5, CacheWritePerM: 6.25, OutputPerM: 30, LongContextThreshold: 272000, LongInputPerM: 10, LongCachedInputPerM: 1, LongCacheWritePerM: 12.5, LongOutputPerM: 45, Source: "official", SourceURL: openAIURL},
+		{Provider: "openai", Model: "gpt-5.6-terra", InputPerM: 2.5, CachedInputPerM: .25, CacheWritePerM: 3.125, OutputPerM: 15, LongContextThreshold: 272000, LongInputPerM: 5, LongCachedInputPerM: .5, LongCacheWritePerM: 6.25, LongOutputPerM: 22.5, Source: "official", SourceURL: openAIURL},
+		{Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 1, CachedInputPerM: .1, CacheWritePerM: 1.25, OutputPerM: 6, LongContextThreshold: 272000, LongInputPerM: 2, LongCachedInputPerM: .2, LongCacheWritePerM: 2.5, LongOutputPerM: 9, Source: "official", SourceURL: openAIURL},
+		{Provider: "openai", Model: "gpt-5.5", InputPerM: 5, CachedInputPerM: .5, CacheWritePerM: 5, OutputPerM: 30, LongContextThreshold: 272000, LongInputPerM: 10, LongCachedInputPerM: 1, LongCacheWritePerM: 10, LongOutputPerM: 45, Source: "official", SourceURL: openAIURL},
+		{Provider: "openai", Model: "gpt-5.4", InputPerM: 2.5, CachedInputPerM: .25, CacheWritePerM: 2.5, OutputPerM: 15, LongContextThreshold: 272000, LongInputPerM: 5, LongCachedInputPerM: .5, LongCacheWritePerM: 5, LongOutputPerM: 22.5, Source: "official", SourceURL: openAIURL},
+		{Provider: "openai", Model: "gpt-5.4-mini", InputPerM: .75, CachedInputPerM: .075, CacheWritePerM: .75, OutputPerM: 4.5, Source: "official", SourceURL: openAIURL},
+		{Provider: "openai", Model: "gpt-5.4-nano", InputPerM: .2, CachedInputPerM: .02, CacheWritePerM: .2, OutputPerM: 1.25, Source: "official", SourceURL: openAIURL},
+		{Provider: "openai", Model: "gpt-5.3-codex", InputPerM: 1.75, CachedInputPerM: .175, CacheWritePerM: 1.75, OutputPerM: 14, Source: "official", SourceURL: openAIURL},
+
+		// Alibaba retail list price. Qoder promotions and subscription credits
+		// are not token prices and are therefore not applied here.
+		{Provider: "qwen", Model: "qwen3.7-max", InputPerM: 2.5, OutputPerM: 7.5, CachedInputPerM: .25, CacheWritePerM: 2.5, Source: "official", SourceURL: qwenURL},
+		{Provider: "qwen", Model: "qwen-3.7-max", InputPerM: 2.5, OutputPerM: 7.5, CachedInputPerM: .25, CacheWritePerM: 2.5, Source: "official", SourceURL: qwenURL},
+		// Plus is tiered by context on the vendor page. The lower standard tier
+		// is retained as a retail-equivalent estimate until the request captures
+		// the vendor's exact tier metadata.
+		{Provider: "qwen", Model: "qwen3.7-plus", InputPerM: .4, OutputPerM: 1.6, CachedInputPerM: .04, CacheWritePerM: .4, Source: "official_range", SourceURL: qwenURL, Estimated: true},
+		{Provider: "qwen", Model: "qwen-3.7-plus", InputPerM: .4, OutputPerM: 1.6, CachedInputPerM: .04, CacheWritePerM: .4, Source: "official_range", SourceURL: qwenURL, Estimated: true},
+
+		// Google bills thinking as output; ReasoningPerM therefore equals output
+		// and Meter subtracts the reasoning subset before pricing normal output.
+		{Provider: "gemini", Model: "gemini-2.5-pro", InputPerM: 1.25, OutputPerM: 10, CachedInputPerM: .125, CacheWritePerM: 1.25, ReasoningPerM: 10, LongContextThreshold: 200000, LongInputPerM: 2.5, LongCachedInputPerM: .25, LongCacheWritePerM: 2.5, LongOutputPerM: 15, Source: "official", SourceURL: geminiURL},
+		{Provider: "gemini", Model: "gemini-2.5-flash", InputPerM: .3, OutputPerM: 2.5, CachedInputPerM: .03, CacheWritePerM: .3, ReasoningPerM: 2.5, Source: "official", SourceURL: geminiURL},
+		{Provider: "gemini", Model: "gemini-2.5-flash-lite", InputPerM: .1, OutputPerM: .4, CachedInputPerM: .01, CacheWritePerM: .1, ReasoningPerM: .4, Source: "official", SourceURL: geminiURL},
+		{Provider: "gemini", Model: "gemini-3-flash-preview", InputPerM: .5, OutputPerM: 3, CachedInputPerM: .05, CacheWritePerM: .5, ReasoningPerM: 3, Source: "official", SourceURL: geminiURL},
+		{Provider: "gemini", Model: "gemini-3.1-pro-preview", InputPerM: 2, OutputPerM: 12, CachedInputPerM: .2, CacheWritePerM: 2, ReasoningPerM: 12, LongContextThreshold: 200000, LongInputPerM: 4, LongCachedInputPerM: .4, LongCacheWritePerM: 4, LongOutputPerM: 18, Source: "official", SourceURL: geminiURL},
+
+		// Cloudflare Workers AI token rates.
+		{Provider: "cloudflare-ai", Model: "@cf/zai-org/glm-5.2", InputPerM: 1.4, CachedInputPerM: .26, CacheWritePerM: 1.4, OutputPerM: 4.4, ReasoningPerM: 4.4, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/zai-org/glm-4.7-flash", InputPerM: .06, OutputPerM: .4, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/qwen/qwq-32b", InputPerM: .66, OutputPerM: 1, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/qwen/qwen2.5-coder-32b-instruct", InputPerM: .66, OutputPerM: 1, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/qwen/qwen3-30b-a3b-fp8", InputPerM: .051, OutputPerM: .335, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/openai/gpt-oss-120b", InputPerM: .35, OutputPerM: .75, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/openai/gpt-oss-20b", InputPerM: .2, OutputPerM: .3, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/moonshotai/kimi-k2.5", InputPerM: .6, CachedInputPerM: .1, OutputPerM: 3, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/moonshotai/kimi-k2.6", InputPerM: .95, CachedInputPerM: .16, OutputPerM: 4, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b", InputPerM: .497, OutputPerM: 4.881, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast", InputPerM: .293, OutputPerM: 2.253, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/meta/llama-3.2-1b-instruct", InputPerM: .027, OutputPerM: .201, Source: "official", SourceURL: cloudflareURL},
+		{Provider: "cloudflare-ai", Model: "@cf/meta/llama-3.2-3b-instruct", InputPerM: .051, OutputPerM: .335, Source: "official", SourceURL: cloudflareURL},
+	}
+
+	// Kiro is subscription/credit based. These entries are explicitly marked
+	// retail-equivalent rather than actual spend.
+	for _, model := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		for _, p := range prices {
+			if p.Provider != "openai" || p.Model != model {
+				continue
+			}
+			p.Provider = "kiro"
+			p.Source = "retail_equivalent"
+			p.Estimated = true
+			prices = append(prices, p)
+			for _, suffix := range []string{"-thinking", "-agentic", "-thinking-agentic"} {
+				variant := p
+				variant.Model += suffix
+				prices = append(prices, variant)
+			}
+			break
+		}
+	}
+	return prices
+}

--- a/backend/internal/core/response.go
+++ b/backend/internal/core/response.go
@@ -11,6 +11,18 @@ const (
 	FinishFilter    FinishReason = "content_filter"
 )
 
+// UsageSource identifies whether token counts came from an upstream usage
+// object, a router estimate, or a semantic-cache replay.
+type UsageSource string
+
+const (
+	UsageSourceProvider  UsageSource = "provider"
+	UsageSourceEstimated UsageSource = "estimated"
+	UsageSourceCache     UsageSource = "cache"
+	UsageSourceLegacy    UsageSource = "legacy"
+	UsageSourceNone      UsageSource = "none"
+)
+
 // Usage reports token accounting for a completion.
 type Usage struct {
 	PromptTokens     int `json:"prompt_tokens"`
@@ -22,8 +34,11 @@ type Usage struct {
 	// CacheWriteTokens counts prompt tokens written into a provider-side prompt
 	// cache (cache writes — often priced at 25% *more* than standard input).
 	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
-	// ReasoningTokens counts tokens spent on extended thinking.
+	// ReasoningTokens is a subset of CompletionTokens, never an additional token
+	// class. This invariant prevents reasoning output from being double charged.
 	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+	// Source is router-internal provenance and is never emitted to API clients.
+	Source UsageSource `json:"-"`
 }
 
 // ChatResponse is the canonical non-streaming completion result.
@@ -39,13 +54,13 @@ type ChatResponse struct {
 type ChunkType string
 
 const (
-	ChunkText       ChunkType = "text"        // incremental assistant text
-	ChunkThinking   ChunkType = "thinking"    // incremental reasoning text
-	ChunkToolCall   ChunkType = "tool_call"   // (partial) tool invocation
-	ChunkUsage      ChunkType = "usage"       // usage update (often final)
-	ChunkFinish     ChunkType = "finish"      // terminal event with finish reason
-	ChunkError      ChunkType = "error"       // mid-stream error
-	ChunkPing       ChunkType = "ping"        // keep-alive / no-op
+	ChunkText     ChunkType = "text"      // incremental assistant text
+	ChunkThinking ChunkType = "thinking"  // incremental reasoning text
+	ChunkToolCall ChunkType = "tool_call" // (partial) tool invocation
+	ChunkUsage    ChunkType = "usage"     // usage update (often final)
+	ChunkFinish   ChunkType = "finish"    // terminal event with finish reason
+	ChunkError    ChunkType = "error"     // mid-stream error
+	ChunkPing     ChunkType = "ping"      // keep-alive / no-op
 )
 
 // StreamChunk is one provider-agnostic streaming event. The transform layer

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -71,7 +71,7 @@ func (s *Server) mountAdmin(r chi.Router) {
 
 	r.Get("/usage", s.adminUsageSummary)
 	r.Get("/usage/insights", s.adminUsageInsights)
-	r.Get("/usage/models", s.adminModelUsage)
+	r.Get("/usage/models", s.adminModelUsageAccurate)
 	r.Get("/usage/stream", s.adminUsageStream)
 	r.Get("/quota", s.adminQuotaUsage)
 	r.Get("/health/accounts", s.adminListAccountHealth)
@@ -1306,29 +1306,29 @@ type codexCreditInfo struct {
 
 // codexUsageDetails represents Codex usage information including rate limits and reset credits.
 type codexUsageDetails struct {
-	UsageData      *codexUsageData    `json:"usage_data,omitempty"`
-	ResetCredits   *codexResetCreditsData `json:"reset_credits,omitempty"`
-	Error          string                 `json:"error,omitempty"`
+	UsageData    *codexUsageData        `json:"usage_data,omitempty"`
+	ResetCredits *codexResetCreditsData `json:"reset_credits,omitempty"`
+	Error        string                 `json:"error,omitempty"`
 }
 
 type codexUsageData struct {
-	PlanType     string `json:"plan_type"`
-	Allowed      bool   `json:"allowed"`
-	LimitReached bool   `json:"limit_reached"`
-	PrimaryUsedPercent   int   `json:"primary_used_percent"`
-	PrimaryResetAt       int64 `json:"primary_reset_at"`
-	PrimaryWindowSeconds int64 `json:"primary_window_seconds"`
-	SecondaryUsedPercent   int   `json:"secondary_used_percent"`
-	SecondaryResetAt       int64 `json:"secondary_reset_at"`
-	SecondaryWindowSeconds int64 `json:"secondary_window_seconds"`
-	CreditsBalance string `json:"credits_balance"`
-	HasCredits     bool   `json:"has_credits"`
-	Unlimited      bool   `json:"unlimited"`
-	ResetCreditsAvailable int `json:"reset_credits_available"`
+	PlanType               string `json:"plan_type"`
+	Allowed                bool   `json:"allowed"`
+	LimitReached           bool   `json:"limit_reached"`
+	PrimaryUsedPercent     int    `json:"primary_used_percent"`
+	PrimaryResetAt         int64  `json:"primary_reset_at"`
+	PrimaryWindowSeconds   int64  `json:"primary_window_seconds"`
+	SecondaryUsedPercent   int    `json:"secondary_used_percent"`
+	SecondaryResetAt       int64  `json:"secondary_reset_at"`
+	SecondaryWindowSeconds int64  `json:"secondary_window_seconds"`
+	CreditsBalance         string `json:"credits_balance"`
+	HasCredits             bool   `json:"has_credits"`
+	Unlimited              bool   `json:"unlimited"`
+	ResetCreditsAvailable  int    `json:"reset_credits_available"`
 }
 
 type codexResetCreditsData struct {
-	AvailableCount int                `json:"available_count"`
+	AvailableCount int               `json:"available_count"`
 	Credits        []codexCreditInfo `json:"credits"`
 }
 
@@ -1363,12 +1363,12 @@ func (s *Server) adminCodexUsageDetails(w http.ResponseWriter, r *http.Request) 
 
 	// Fetch usage data
 	usageData, usageErr := fetchCodexUsage(ctx, creds.AccessToken, creds.Extra)
-	
+
 	// Fetch reset credits
 	resetCredits, resetErr := fetchCodexResetCredits(ctx, creds.AccessToken, creds.Extra)
 
 	result := codexUsageDetails{}
-	
+
 	if usageErr == nil && usageData != nil {
 		result.UsageData = usageData
 	} else {
@@ -1447,10 +1447,10 @@ func fetchCodexUsage(ctx context.Context, accessToken string, extra map[string]s
 	}
 
 	var raw struct {
-		PlanType string `json:"plan_type"`
+		PlanType  string `json:"plan_type"`
 		RateLimit struct {
-			Allowed      bool `json:"allowed"`
-			LimitReached bool `json:"limit_reached"`
+			Allowed       bool `json:"allowed"`
+			LimitReached  bool `json:"limit_reached"`
 			PrimaryWindow struct {
 				UsedPercent        int   `json:"used_percent"`
 				LimitWindowSeconds int64 `json:"limit_window_seconds"`
@@ -1516,9 +1516,9 @@ func fetchCodexResetCredits(ctx context.Context, accessToken string, extra map[s
 	defer resp.Body.Close()
 
 	var data struct {
-		AvailableCount *int `json:"available_count"`
+		AvailableCount  *int `json:"available_count"`
 		AvailableCount2 *int `json:"availableCount"`
-		Credits []struct {
+		Credits         []struct {
 			RedeemRequestID  string `json:"redeem_request_id"`
 			RedeemRequestID2 string `json:"redeemRequestId"`
 			Status           string `json:"status"`
@@ -1631,12 +1631,12 @@ func consumeCodexResetCredit(ctx context.Context, accessToken, redeemRequestID s
 	noCredit := resp.StatusCode < 400 && data.Code == "no_credit"
 
 	return map[string]any{
-		"ok":             ok,
-		"no_credit":      noCredit,
-		"status":         resp.StatusCode,
-		"code":           data.Code,
-		"windows_reset":  data.WindowsReset,
-		"message":        data.Message,
+		"ok":            ok,
+		"no_credit":     noCredit,
+		"status":        resp.StatusCode,
+		"code":          data.Code,
+		"windows_reset": data.WindowsReset,
+		"message":       data.Message,
 	}, nil
 }
 

--- a/backend/internal/gateway/admin_custom_providers.go
+++ b/backend/internal/gateway/admin_custom_providers.go
@@ -300,6 +300,7 @@ func (s *Server) adminDeleteCustomProvider(w http.ResponseWriter, r *http.Reques
 	// Drop the in-memory dynamic provider + its models so routing/discovery
 	// stop exposing it immediately.
 	connectors.UnregisterDynamicProvider(id)
+	s.reloadUsagePricing(r.Context())
 	writeJSON(w, http.StatusOK, map[string]any{
 		"id":                id,
 		"deleted":           true,
@@ -453,6 +454,16 @@ func (s *Server) reloadCustomModels(ctx context.Context, providerID string) {
 		return
 	}
 	connectors.SetDynamicModels(providerID, customModelsToSpecs(models))
+	s.reloadUsagePricing(ctx)
+}
+
+func (s *Server) reloadUsagePricing(ctx context.Context) {
+	if s.reloadPricing == nil {
+		return
+	}
+	if err := s.reloadPricing(ctx); err != nil {
+		s.log.Warn("reload usage pricing failed", "err", err)
+	}
 }
 
 func customModelsToSpecs(models []store.CustomModel) []connectors.ModelSpec {

--- a/backend/internal/gateway/insights.go
+++ b/backend/internal/gateway/insights.go
@@ -51,7 +51,7 @@ func sinceForPeriod(period, tz string) time.Time {
 // adminUsageInsights returns the rich payload that powers the Usage page: the
 // per-provider routing breakdown, a bucketed activity-over-time series, recent
 // activity rows, and headline metrics (success rate, average latency).
-func (s *Server) adminUsageInsights(w http.ResponseWriter, r *http.Request) {
+func (s *Server) adminUsageInsightsLegacy(w http.ResponseWriter, r *http.Request) {
 	period := r.URL.Query().Get("period")
 	tz := r.URL.Query().Get("tz")
 	cacheKey := "insights|" + period + "|" + tz
@@ -399,10 +399,9 @@ func (s *Server) adminQuotaUsage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var wg sync.WaitGroup
-	var mu sync.Mutex
 	out := make([]map[string]any, 0, len(accs))
 
-	for i, a := range accs {
+	for _, a := range accs {
 		u := usageByID[a.ID]
 		status := "active"
 		if a.Disabled {
@@ -419,9 +418,16 @@ func (s *Server) adminQuotaUsage(w http.ResponseWriter, r *http.Request) {
 			outputPerM = spec.OutputPerM
 			providerNotice = spec.Notice
 		}
-		usageType := "token"
-		if connectors.GetQuotaSource(a.Provider) != nil {
+		quotaSource := connectors.GetQuotaSource(a.Provider)
+		quotaSupported := quotaSource != nil
+		quotaState := "usage_only"
+		usageType := "token" // Kept for API compatibility; this is not a paid/free classification.
+		if quotaSupported {
 			usageType = "credit"
+			quotaState = "pending"
+			if a.Disabled {
+				quotaState = "paused"
+			}
 		}
 		entry := map[string]any{
 			"id":                 a.ID,
@@ -432,6 +438,8 @@ func (s *Server) adminQuotaUsage(w http.ResponseWriter, r *http.Request) {
 			"priority":           a.Priority,
 			"status":             status,
 			"usage_type":         usageType,
+			"quota_supported":    quotaSupported,
+			"quota_state":        quotaState,
 			"total_requests":     u.TotalRequests,
 			"prompt_tokens":      u.PromptTokens,
 			"completion_tokens":  u.CompletionTokens,
@@ -448,7 +456,7 @@ func (s *Server) adminQuotaUsage(w http.ResponseWriter, r *http.Request) {
 		out = append(out, entry)
 
 		// Fetch upstream quota for providers that support it (e.g. Kiro) concurrently.
-		if qs := connectors.GetQuotaSource(a.Provider); qs != nil && !a.Disabled {
+		if quotaSource != nil && !a.Disabled {
 			// Refresh OAuth access tokens before probing so expired tokens
 			// don't silently suppress the quota/credits detail box. Mirrors
 			// the refresh-then-probe pattern in validateAccountCredentials.
@@ -460,7 +468,7 @@ func (s *Server) adminQuotaUsage(w http.ResponseWriter, r *http.Request) {
 			}
 			if creds, err := s.vault.Open(quotaAcc); err == nil {
 				wg.Add(1)
-				go func(idx int, qs connectors.QuotaSource, creds core.Credentials) {
+				go func(target map[string]any, qs connectors.QuotaSource, creds core.Credentials) {
 					defer wg.Done()
 					quotaCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
 					quota, qerr := qs.FetchQuota(quotaCtx, creds)
@@ -477,15 +485,22 @@ func (s *Server) adminQuotaUsage(w http.ResponseWriter, r *http.Request) {
 							})
 						}
 
-						mu.Lock()
-						out[idx]["plan_name"] = quota.PlanName
-						out[idx]["message"] = quota.Message
+						target["plan_name"] = quota.PlanName
+						target["message"] = quota.Message
 						if len(quotas) > 0 {
-							out[idx]["upstream_quotas"] = quotas
+							target["quota_state"] = "reported"
+							target["upstream_quotas"] = quotas
+						} else {
+							target["quota_state"] = "unavailable"
 						}
-						mu.Unlock()
+					} else {
+						target["quota_state"] = "error"
+						target["message"] = "Upstream quota could not be refreshed."
 					}
-				}(i, qs, creds)
+				}(entry, quotaSource, creds)
+			} else {
+				entry["quota_state"] = "error"
+				entry["message"] = "Credentials could not be opened for quota refresh."
 			}
 		}
 	}

--- a/backend/internal/gateway/provider_health.go
+++ b/backend/internal/gateway/provider_health.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -61,109 +62,134 @@ func parseRangeDuration(raw string) time.Duration {
 }
 
 // adminHealthOverview returns summary cards + a per-provider status table.
+// provider_health_current is computed by the telemetry service over its
+// configured rolling window. The response publishes that effective window so
+// callers never mistake an arbitrary query range for historical aggregation.
 func (s *Server) adminHealthOverview(w http.ResponseWriter, r *http.Request) {
-	if s.providerHealth == nil && s.db == nil {
+	if s.db == nil {
 		writeError(w, http.StatusServiceUnavailable, "provider health not configured")
 		return
 	}
 	statusFilter := r.URL.Query().Get("status")
-	_ = parseRange(r.URL.Query().Get("range"))
+	requestedRange := r.URL.Query().Get("range")
 
-	rows, err := s.db.ProviderHealth().ListCurrent(r.Context(), statusFilter)
+	rows, err := s.db.ProviderHealth().ListCurrent(r.Context(), "")
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "internal server error"))
 		return
 	}
 
-	// Aggregate by provider for the summary cards + provider table.
+	// Aggregate account/model/capability keys into one truthful provider row.
 	type provAgg struct {
-		provider          string
-		status            string
-		score             int
-		accounts          map[string]struct{}
-		models            map[string]struct{}
-		requests          int64
-		successes         int64
-		failures          int64
-		fallbacks         int64
-		latencyP95        int
-		ttftP95           int
-		lastProbe         *time.Time
-		mainIssue         string
-		recommendation    string
+		provider       string
+		status         string
+		score          int
+		accounts       map[string]struct{}
+		models         map[string]struct{}
+		requests       int64
+		successes      float64
+		failures       float64
+		fallbacks      int64
+		latencyP95     int
+		ttftP95        int
+		lastProbe      *time.Time
+		mainIssue      string
+		recommendation string
 	}
 	byProvider := map[string]*provAgg{}
-	summary := map[string]int64{
-		"healthy": 0, "degraded": 0, "unhealthy": 0, "unknown": 0, "disabled": 0,
-		"fallbacks": 0, "rate_limit_events": 0,
-	}
-	var totalP95 int
-	var p95Count int
-
-	for _, c := range rows {
-		summary[c.HealthStatus]++
-		summary["fallbacks"] += c.FallbackCount
-
-		agg, ok := byProvider[c.Provider]
+	for _, current := range rows {
+		agg, ok := byProvider[current.Provider]
 		if !ok {
 			agg = &provAgg{
-				provider:  c.Provider,
-				accounts:  map[string]struct{}{},
-				models:    map[string]struct{}{},
-				score:     100,
-				status:    health.StatusHealthy,
+				provider: current.Provider,
+				accounts: map[string]struct{}{},
+				models:   map[string]struct{}{},
+				score:    current.HealthScore,
+				status:   current.HealthStatus,
 			}
-			byProvider[c.Provider] = agg
+			if current.MainIssue != nil {
+				agg.mainIssue = *current.MainIssue
+			}
+			if current.Recommendation != nil {
+				agg.recommendation = *current.Recommendation
+			}
+			byProvider[current.Provider] = agg
+		} else {
+			replaceIssue := rank(current.HealthStatus) > rank(agg.status) || current.HealthScore < agg.score
+			if rank(current.HealthStatus) > rank(agg.status) {
+				agg.status = current.HealthStatus
+			}
+			if current.HealthScore < agg.score {
+				agg.score = current.HealthScore
+			}
+			if current.MainIssue != nil && *current.MainIssue != "" && (agg.mainIssue == "" || replaceIssue) {
+				agg.mainIssue = *current.MainIssue
+				if current.Recommendation != nil {
+					agg.recommendation = *current.Recommendation
+				}
+			}
 		}
-		if c.ProviderAccountID != "" {
-			agg.accounts[c.ProviderAccountID] = struct{}{}
+		if current.ProviderAccountID != "" {
+			agg.accounts[current.ProviderAccountID] = struct{}{}
 		}
-		if c.Model != "" {
-			agg.models[c.Model] = struct{}{}
+		if current.Model != "" {
+			agg.models[current.Model] = struct{}{}
 		}
-		agg.requests += c.RequestCount
-		// successes derived from success_rate * requests (approx for rollup).
-		agg.successes += int64(float64(c.RequestCount) * c.SuccessRate)
-		agg.failures += int64(float64(c.RequestCount) * c.ErrorRate)
-		agg.fallbacks += c.FallbackCount
-		if c.LatencyP95Ms != nil && *c.LatencyP95Ms > agg.latencyP95 {
-			agg.latencyP95 = *c.LatencyP95Ms
+		agg.requests += current.RequestCount
+		agg.successes += float64(current.RequestCount) * current.SuccessRate
+		agg.failures += float64(current.RequestCount) * current.ErrorRate
+		agg.fallbacks += current.FallbackCount
+		if current.LatencyP95Ms != nil && *current.LatencyP95Ms > agg.latencyP95 {
+			agg.latencyP95 = *current.LatencyP95Ms
 		}
-		if c.TTFTP95Ms != nil && *c.TTFTP95Ms > agg.ttftP95 {
-			agg.ttftP95 = *c.TTFTP95Ms
+		if current.TTFTP95Ms != nil && *current.TTFTP95Ms > agg.ttftP95 {
+			agg.ttftP95 = *current.TTFTP95Ms
 		}
-		if c.LastProbeAt != nil && (agg.lastProbe == nil || c.LastProbeAt.After(*agg.lastProbe)) {
-			agg.lastProbe = c.LastProbeAt
-		}
-		// Roll up status: worst status wins, and lowest score.
-		if rank(c.HealthStatus) > rank(agg.status) {
-			agg.status = c.HealthStatus
-		}
-		if c.HealthScore < agg.score {
-			agg.score = c.HealthScore
-		}
-		if c.MainIssue != nil && *c.MainIssue != "" && agg.mainIssue == "" {
-			agg.mainIssue = *c.MainIssue
-		}
-		if c.Recommendation != nil && *c.Recommendation != "" && agg.recommendation == "" {
-			agg.recommendation = *c.Recommendation
-		}
-		if c.LatencyP95Ms != nil {
-			totalP95 += *c.LatencyP95Ms
-			p95Count++
+		if current.LastProbeAt != nil && (agg.lastProbe == nil || current.LastProbeAt.After(*agg.lastProbe)) {
+			agg.lastProbe = current.LastProbeAt
 		}
 	}
 
+	providerIDs := make([]string, 0, len(byProvider))
+	for provider := range byProvider {
+		providerIDs = append(providerIDs, provider)
+	}
+	sort.Strings(providerIDs)
+
+	summary := map[string]int64{
+		"healthy": 0, "degraded": 0, "unhealthy": 0, "unknown": 0, "disabled": 0,
+		"fallbacks": 0,
+	}
+	if s.providerHealth != nil {
+		summary["telemetry_dropped"] = int64(s.providerHealth.DroppedEvents())
+	}
 	providers := make([]map[string]any, 0, len(byProvider))
-	for _, agg := range byProvider {
+	var totalProviderP95 int
+	var providerP95Count int
+	for _, provider := range providerIDs {
+		agg := byProvider[provider]
+		summary[agg.status]++
+		summary["fallbacks"] += agg.fallbacks
+		if agg.latencyP95 > 0 {
+			totalProviderP95 += agg.latencyP95
+			providerP95Count++
+		}
+		if statusFilter != "" && agg.status != statusFilter {
+			continue
+		}
+		successRate, errorRate := 0.0, 0.0
+		if agg.requests > 0 {
+			successRate = agg.successes / float64(agg.requests) * 100
+			errorRate = agg.failures / float64(agg.requests) * 100
+		}
 		entry := map[string]any{
 			"provider":         agg.provider,
 			"status":           agg.status,
 			"score":            agg.score,
 			"accounts":         len(agg.accounts),
 			"models_monitored": len(agg.models),
-			"success_rate":     pct(agg.successes, agg.requests),
-			"error_rate":       pct(agg.failures, agg.requests),
+			"success_rate":     successRate,
+			"error_rate":       errorRate,
 			"latency_p95_ms":   agg.latencyP95,
 			"ttft_p95_ms":      agg.ttftP95,
 			"fallback_count":   agg.fallbacks,
@@ -177,18 +203,35 @@ func (s *Server) adminHealthOverview(w http.ResponseWriter, r *http.Request) {
 	}
 
 	avgP95 := 0
-	if p95Count > 0 {
-		avgP95 = totalP95 / p95Count
+	if providerP95Count > 0 {
+		avgP95 = totalProviderP95 / providerP95Count
+	}
+	generatedAt := time.Now().UTC()
+	windowDuration := time.Duration(0)
+	if s.providerHealth != nil {
+		windowDuration = s.providerHealth.RollingWindow()
+	}
+	window := map[string]any{
+		"kind":             "rolling_current",
+		"duration_seconds": int64(windowDuration.Seconds()),
+		"requested_range":  requestedRange,
+		"generated_at":     generatedAt,
+	}
+	if windowDuration > 0 {
+		window["since"] = generatedAt.Add(-windowDuration)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
+		"window": window,
 		"summary": map[string]any{
-			"healthy":           summary["healthy"],
-			"degraded":          summary["degraded"],
-			"unhealthy":         summary["unhealthy"],
-			"unknown":           summary["unknown"],
-			"disabled":          summary["disabled"],
-			"fallbacks":         summary["fallbacks"],
-			"avg_p95_latency_ms": avgP95,
+			"healthy":                 summary["healthy"],
+			"degraded":                summary["degraded"],
+			"unhealthy":               summary["unhealthy"],
+			"unknown":                 summary["unknown"],
+			"disabled":                summary["disabled"],
+			"fallbacks":               summary["fallbacks"],
+			"avg_p95_latency_ms":      avgP95,
+			"telemetry_dropped":       summary["telemetry_dropped"],
+			"telemetry_dropped_scope": "process_lifetime",
 		},
 		"providers": providers,
 	})
@@ -260,12 +303,12 @@ func (s *Server) adminHealthProviderDetail(w http.ResponseWriter, r *http.Reques
 		"main_issue":     mainIssue,
 		"recommendation": recommendation,
 		"metrics": map[string]any{
-			"requests":        requests,
-			"success_rate":    pct(successes, requests),
-			"error_rate":      pct(failures, requests),
-			"latency_p95_ms":  lp95,
-			"ttft_p95_ms":     ttft95,
-			"fallback_count":  fallbacks,
+			"requests":       requests,
+			"success_rate":   pct(successes, requests),
+			"error_rate":     pct(failures, requests),
+			"latency_p95_ms": lp95,
+			"ttft_p95_ms":    ttft95,
+			"fallback_count": fallbacks,
 		},
 		"error_breakdown": errBreakdown,
 		"models":          rows,
@@ -354,13 +397,13 @@ func (s *Server) adminHealthChains(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		entry := map[string]any{
-			"chain_id":           c.ID,
-			"name":               c.Name,
-			"status":             worstStatus,
-			"affected_provider":  affectedProvider,
-			"affected_model":     affectedModel,
-			"main_issue":         mainIssue,
-			"step_count":         len(c.Steps),
+			"chain_id":          c.ID,
+			"name":              c.Name,
+			"status":            worstStatus,
+			"affected_provider": affectedProvider,
+			"affected_model":    affectedModel,
+			"main_issue":        mainIssue,
+			"step_count":        len(c.Steps),
 		}
 		if st, ok := chainStats[c.ID]; ok {
 			entry["requests"] = st.Requests
@@ -412,11 +455,11 @@ func (s *Server) adminHealthChainDetail(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 		steps = append(steps, map[string]any{
-			"position":  step.Position,
-			"provider":  step.Provider,
-			"model":     step.Model,
-			"status":    status,
-			"score":     score,
+			"position":   step.Position,
+			"provider":   step.Provider,
+			"model":      step.Model,
+			"status":     status,
+			"score":      score,
 			"main_issue": mainIssue,
 		})
 	}

--- a/backend/internal/gateway/server.go
+++ b/backend/internal/gateway/server.go
@@ -5,6 +5,7 @@
 package gateway
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"os"
@@ -43,98 +44,100 @@ import (
 
 // Server holds the gateway's dependencies and HTTP routes.
 type Server struct {
-	cfg             config.Config
-	log             *slog.Logger
-	db              *store.DB
-	identity        *identity.Service
-	auth            *auth.Service
-	pipeline        *pipeline.Pipeline
-	conns           *connectors.Registry
-	chains          *store.ChainRepo
-	aliases         *store.AliasRepo
-	accounts        *store.AccountRepo
-	pools           *store.ProxyPoolRepo
-	budgets         *store.BudgetRepo
-	budgetEngine    *budget.Engine
-	usage           *store.UsageRepo
-	resources       *store.ResourceRepo
-	settings        *store.SettingsRepo
-	vault           *vault.Vault
-	codecs          *transform.Registry
-	metrics         *observ.Metrics
-	consoleLog      *consolelog.Buffer
-	cliTools        *clitools.Registry
-	cliToolHome     string
-	frontendDir     string
-	dataDir         string
-	oauthSessions   *oauth.SessionStore
-	cfManager       *cloudflare.Manager
-	tsManager       *tailscale.Manager
-	usageHub        *usagehub.Hub
-	timeoutNotifier *TimeoutNotifier
-	proxyNotifier   *ProxyNotifier
-	rateLimiter     interface{ SetEnabled(bool) }
-	refresher       dispatch.TokenRefresher
-	version         string
-	updates         *update.Checker
-	insightsCache   *ttlCache
+	cfg                 config.Config
+	log                 *slog.Logger
+	db                  *store.DB
+	identity            *identity.Service
+	auth                *auth.Service
+	pipeline            *pipeline.Pipeline
+	conns               *connectors.Registry
+	chains              *store.ChainRepo
+	aliases             *store.AliasRepo
+	accounts            *store.AccountRepo
+	pools               *store.ProxyPoolRepo
+	budgets             *store.BudgetRepo
+	budgetEngine        *budget.Engine
+	usage               *store.UsageRepo
+	resources           *store.ResourceRepo
+	settings            *store.SettingsRepo
+	vault               *vault.Vault
+	codecs              *transform.Registry
+	metrics             *observ.Metrics
+	consoleLog          *consolelog.Buffer
+	cliTools            *clitools.Registry
+	cliToolHome         string
+	frontendDir         string
+	dataDir             string
+	oauthSessions       *oauth.SessionStore
+	cfManager           *cloudflare.Manager
+	tsManager           *tailscale.Manager
+	usageHub            *usagehub.Hub
+	timeoutNotifier     *TimeoutNotifier
+	proxyNotifier       *ProxyNotifier
+	rateLimiter         interface{ SetEnabled(bool) }
+	refresher           dispatch.TokenRefresher
+	reloadPricing       func(context.Context) error
+	version             string
+	updates             *update.Checker
+	insightsCache       *ttlCache
 	guardrails          *guardrails.Engine
 	guardrailRepo       *store.GuardrailRepo
 	guardrailLogs       *store.GuardrailLogRepo
 	guardrailHub        *guardrails.LogHub
 	guardrailTenantFlag *guardrails.SettingsTenantPolicy
 	guardrailTestRL     *guardrailTestRateLimiter
-	health          *store.HealthRepo
-	healthChecker   *healthcheck.Checker
-	providerHealth  *health.Service
-	probeRunner     *health.ProbeRunner
-	router          chi.Router
+	health              *store.HealthRepo
+	healthChecker       *healthcheck.Checker
+	providerHealth      *health.Service
+	probeRunner         *health.ProbeRunner
+	router              chi.Router
 }
 
 // Deps bundles the gateway's collaborators.
 type Deps struct {
-	Config          config.Config
-	Logger          *slog.Logger
-	Version         string
-	Updates         *update.Checker
-	DB              *store.DB
-	Identity        *identity.Service
-	Auth            *auth.Service
-	Pipeline        *pipeline.Pipeline
-	Conns           *connectors.Registry
-	Chains          *store.ChainRepo
-	Aliases         *store.AliasRepo
-	Accounts        *store.AccountRepo
-	Pools           *store.ProxyPoolRepo
-	Budgets         *store.BudgetRepo
-	BudgetEngine    *budget.Engine
-	Usage           *store.UsageRepo
-	Resources       *store.ResourceRepo
-	Settings        *store.SettingsRepo
-	Vault           *vault.Vault
-	Codecs          *transform.Registry
-	Metrics         *observ.Metrics
-	ConsoleLog      *consolelog.Buffer
-	CLITools        *clitools.Registry
-	CLITHome        string
-	FrontendDir     string
-	DataDir         string
-	CfManager       *cloudflare.Manager
-	TsManager       *tailscale.Manager
-	UsageHub        *usagehub.Hub
-	TimeoutNotifier *TimeoutNotifier
-	ProxyNotifier   *ProxyNotifier
-	RateLimiter     interface{ SetEnabled(bool) }
-	Refresher       dispatch.TokenRefresher
+	Config               config.Config
+	Logger               *slog.Logger
+	Version              string
+	Updates              *update.Checker
+	DB                   *store.DB
+	Identity             *identity.Service
+	Auth                 *auth.Service
+	Pipeline             *pipeline.Pipeline
+	Conns                *connectors.Registry
+	Chains               *store.ChainRepo
+	Aliases              *store.AliasRepo
+	Accounts             *store.AccountRepo
+	Pools                *store.ProxyPoolRepo
+	Budgets              *store.BudgetRepo
+	BudgetEngine         *budget.Engine
+	Usage                *store.UsageRepo
+	Resources            *store.ResourceRepo
+	Settings             *store.SettingsRepo
+	Vault                *vault.Vault
+	Codecs               *transform.Registry
+	Metrics              *observ.Metrics
+	ConsoleLog           *consolelog.Buffer
+	CLITools             *clitools.Registry
+	CLITHome             string
+	FrontendDir          string
+	DataDir              string
+	CfManager            *cloudflare.Manager
+	TsManager            *tailscale.Manager
+	UsageHub             *usagehub.Hub
+	TimeoutNotifier      *TimeoutNotifier
+	ProxyNotifier        *ProxyNotifier
+	RateLimiter          interface{ SetEnabled(bool) }
+	Refresher            dispatch.TokenRefresher
+	ReloadPricing        func(context.Context) error
 	Guardrails           *guardrails.Engine
 	GuardrailRepo        *store.GuardrailRepo
 	GuardrailLogs        *store.GuardrailLogRepo
 	GuardrailHub         *guardrails.LogHub
 	GuardrailTenantFlags *guardrails.SettingsTenantPolicy
-	Health          *store.HealthRepo
-	HealthChecker   *healthcheck.Checker
-	ProviderHealth  *health.Service
-	ProbeRunner     *health.ProbeRunner
+	Health               *store.HealthRepo
+	HealthChecker        *healthcheck.Checker
+	ProviderHealth       *health.Service
+	ProbeRunner          *health.ProbeRunner
 }
 
 // New builds a gateway Server and wires its routes.
@@ -156,51 +159,52 @@ func New(d Deps) *Server {
 		conLog = consolelog.New()
 	}
 	s := &Server{
-		cfg:             d.Config,
-		log:             log,
-		db:              d.DB,
-		identity:        d.Identity,
-		auth:            d.Auth,
-		pipeline:        d.Pipeline,
-		conns:           d.Conns,
-		chains:          d.Chains,
-		aliases:         d.Aliases,
-		accounts:        d.Accounts,
-		pools:           d.Pools,
-		budgets:         d.Budgets,
-		budgetEngine:    d.BudgetEngine,
-		usage:           d.Usage,
-		resources:       d.Resources,
-		settings:        d.Settings,
-		vault:           d.Vault,
-		codecs:          d.Codecs,
-		metrics:         d.Metrics,
-		consoleLog:      conLog,
-		cliTools:        cliTools,
-		cliToolHome:     cliToolHome,
-		frontendDir:     d.FrontendDir,
-		dataDir:         d.DataDir,
-		oauthSessions:   oauth.NewSessionStore(),
-		cfManager:       d.CfManager,
-		tsManager:       d.TsManager,
-		usageHub:        d.UsageHub,
-		timeoutNotifier: d.TimeoutNotifier,
-		proxyNotifier:   d.ProxyNotifier,
-		rateLimiter:     d.RateLimiter,
-		refresher:       d.Refresher,
-		version:         d.Version,
-		updates:         d.Updates,
-		insightsCache:   newTTLCache(insightsCacheTTL),
+		cfg:                 d.Config,
+		log:                 log,
+		db:                  d.DB,
+		identity:            d.Identity,
+		auth:                d.Auth,
+		pipeline:            d.Pipeline,
+		conns:               d.Conns,
+		chains:              d.Chains,
+		aliases:             d.Aliases,
+		accounts:            d.Accounts,
+		pools:               d.Pools,
+		budgets:             d.Budgets,
+		budgetEngine:        d.BudgetEngine,
+		usage:               d.Usage,
+		resources:           d.Resources,
+		settings:            d.Settings,
+		vault:               d.Vault,
+		codecs:              d.Codecs,
+		metrics:             d.Metrics,
+		consoleLog:          conLog,
+		cliTools:            cliTools,
+		cliToolHome:         cliToolHome,
+		frontendDir:         d.FrontendDir,
+		dataDir:             d.DataDir,
+		oauthSessions:       oauth.NewSessionStore(),
+		cfManager:           d.CfManager,
+		tsManager:           d.TsManager,
+		usageHub:            d.UsageHub,
+		timeoutNotifier:     d.TimeoutNotifier,
+		proxyNotifier:       d.ProxyNotifier,
+		rateLimiter:         d.RateLimiter,
+		refresher:           d.Refresher,
+		reloadPricing:       d.ReloadPricing,
+		version:             d.Version,
+		updates:             d.Updates,
+		insightsCache:       newTTLCache(insightsCacheTTL),
 		guardrails:          d.Guardrails,
 		guardrailRepo:       d.GuardrailRepo,
 		guardrailLogs:       d.GuardrailLogs,
 		guardrailHub:        d.GuardrailHub,
 		guardrailTenantFlag: d.GuardrailTenantFlags,
 		guardrailTestRL:     newGuardrailTestRateLimiter(10, time.Minute),
-		health:          d.Health,
-		healthChecker:   d.HealthChecker,
-		providerHealth:  d.ProviderHealth,
-		probeRunner:     d.ProbeRunner,
+		health:              d.Health,
+		healthChecker:       d.HealthChecker,
+		providerHealth:      d.ProviderHealth,
+		probeRunner:         d.ProbeRunner,
 	}
 	s.router = s.routes()
 	startSystemCollector(d.Resources)

--- a/backend/internal/gateway/usage_v2.go
+++ b/backend/internal/gateway/usage_v2.go
@@ -1,0 +1,473 @@
+package gateway
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/mydisha/keirouter/backend/internal/connectors"
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+const usageTimelineBuckets = 24
+
+// adminUsageInsights returns the authoritative Usage dashboard payload. Costs
+// come from immutable nanodollar snapshots; cached and reasoning tokens remain
+// subsets of input/output so aggregate token totals never double count them.
+func (s *Server) adminUsageInsights(w http.ResponseWriter, r *http.Request) {
+	period := r.URL.Query().Get("period")
+	tz := r.URL.Query().Get("tz")
+	cacheKey := "insights-v2|" + period + "|" + tz
+	if s.cacheHit(w, cacheKey) {
+		return
+	}
+
+	recentLimit := 50
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 && parsed <= 200 {
+			recentLimit = parsed
+		}
+	}
+
+	ctx := r.Context()
+	now := time.Now().UTC()
+	since := sinceForPeriod(period, tz)
+	var (
+		summary       store.AccurateSummary
+		providers     []store.AccurateProviderUsage
+		recent        []store.AccurateRecentRecord
+		timeline      []store.AccurateTimeBucket
+		ruleSavings   []store.RuleSavings
+		clientSavings []store.ClientSavings
+	)
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		var err error
+		summary, err = s.usage.SummarizeAccurate(groupCtx, adminTenant, since)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		providers, err = s.usage.BreakdownAccurate(groupCtx, adminTenant, since)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		recent, err = s.usage.RecentAccurate(groupCtx, adminTenant, since, recentLimit)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		timeline, err = s.usage.TimelineAccurate(groupCtx, adminTenant, since, now, usageTimelineBuckets)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		ruleSavings, err = s.usage.SavingsByRule(groupCtx, adminTenant, since)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		clientSavings, err = s.usage.SavingsByClient(groupCtx, adminTenant, since)
+		return err
+	})
+	if err := group.Wait(); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	totalTokens := summary.PromptTokens + summary.CompletionTokens
+	pricingEligibleRequests := summary.PricedRequests + summary.UnpricedRequests
+	successRate := ratio(summary.SuccessCount, summary.TotalRequests)
+	requestPricingCoverage := optionalRatio(summary.PricedRequests, pricingEligibleRequests)
+	tokenPricingCoverage := optionalRatio(totalTokens-summary.UnpricedTokens, totalTokens)
+
+	providerRows := make([]map[string]any, 0, len(providers))
+	for _, provider := range providers {
+		display, color, icon := usageProviderMetadata(provider.Provider)
+		providerRows = append(providerRows, map[string]any{
+			"provider":                  provider.Provider,
+			"display_name":              display,
+			"color":                     color,
+			"icon":                      icon,
+			"total_requests":            provider.TotalRequests,
+			"successful_requests":       provider.SuccessCount,
+			"failed_requests":           provider.TotalRequests - provider.SuccessCount,
+			"success_rate":              ratio(provider.SuccessCount, provider.TotalRequests),
+			"prompt_tokens":             provider.PromptTokens,
+			"completion_tokens":         provider.CompletionTokens,
+			"cached_tokens":             provider.CachedTokens,
+			"cache_write_tokens":        provider.CacheWriteTokens,
+			"reasoning_tokens":          provider.ReasoningTokens,
+			"total_tokens":              provider.PromptTokens + provider.CompletionTokens,
+			"cost_usd":                  nanosToUSD(provider.CostNanos),
+			"saved_cost_usd":            nanosToUSD(provider.SavedCostNanos),
+			"avoided_cost_usd":          nanosToUSD(provider.AvoidedCostNanos),
+			"avg_latency_ms":            provider.AvgLatencyMS,
+			"avg_ttft_ms":               provider.AvgTTFTMS,
+			"pricing_eligible_requests": provider.PricingEligibleRequests,
+			"unpriced_requests":         provider.UnpricedRequests,
+			"estimated_requests":        provider.EstimatedRequests,
+			"estimated_usage_requests":  provider.EstimatedUsageRequests,
+			"legacy_usage_requests":     provider.LegacyUsageRequests,
+			"backfilled_requests":       provider.BackfilledRequests,
+			"pricing_request_coverage":  optionalRatio(provider.PricingEligibleRequests-provider.UnpricedRequests, provider.PricingEligibleRequests),
+			"share_pct":                 ratio(provider.TotalRequests, summary.TotalRequests) * 100,
+			"token_share_pct":           ratio(provider.PromptTokens+provider.CompletionTokens, totalTokens) * 100,
+		})
+	}
+
+	recentRows := make([]map[string]any, 0, len(recent))
+	for _, record := range recent {
+		display, color, icon := usageProviderMetadata(record.Provider)
+		recentRows = append(recentRows, map[string]any{
+			"id":                     record.ID,
+			"request_id":             record.RequestID,
+			"provider":               record.Provider,
+			"provider_name":          display,
+			"provider_color":         color,
+			"provider_icon":          icon,
+			"model":                  record.Model,
+			"status":                 record.Status,
+			"error_kind":             record.ErrorKind,
+			"usage_source":           record.UsageSource,
+			"prompt_tokens":          record.PromptTokens,
+			"completion_tokens":      record.CompletionTokens,
+			"cached_tokens":          record.CachedTokens,
+			"cache_write_tokens":     record.CacheWriteTokens,
+			"reasoning_tokens":       record.ReasoningTokens,
+			"tokens":                 record.PromptTokens + record.CompletionTokens,
+			"cost_usd":               nanosToUSD(record.CostNanos),
+			"input_cost_usd":         nanosToUSD(record.InputCostNanos),
+			"cached_cost_usd":        nanosToUSD(record.CachedCostNanos),
+			"cache_write_cost_usd":   nanosToUSD(record.CacheWriteCostNanos),
+			"output_cost_usd":        nanosToUSD(record.OutputCostNanos),
+			"reasoning_cost_usd":     nanosToUSD(record.ReasoningCostNanos),
+			"saved_cost_usd":         nanosToUSD(record.SavedCostNanos),
+			"avoided_cost_usd":       nanosToUSD(record.AvoidedCostNanos),
+			"pricing_status":         record.PricingStatus,
+			"pricing_source":         record.PricingSource,
+			"pricing_key":            record.PricingKey,
+			"pricing_match_kind":     record.PricingMatchKind,
+			"pricing_source_url":     record.PricingSourceURL,
+			"pricing_as_of":          record.PricingAsOf,
+			"pricing_backfilled":     record.PricingBackfilled,
+			"input_rate_per_m":       record.InputRatePerM,
+			"cached_rate_per_m":      record.CachedRatePerM,
+			"cache_write_rate_per_m": record.CacheWriteRatePerM,
+			"output_rate_per_m":      record.OutputRatePerM,
+			"reasoning_rate_per_m":   record.ReasoningRatePerM,
+			"cache_hit":              record.CacheHit,
+			"latency_ms":             record.EndToEndLatencyMS,
+			"upstream_latency_ms":    record.UpstreamLatencyMS,
+			"end_to_end_latency_ms":  record.EndToEndLatencyMS,
+			"ttft_ms":                record.TTFTMS,
+			"slim_bytes_saved":       record.SlimBytesSaved,
+			"slim_tokens_saved":      record.SlimTokensSaved,
+			"slim_rules":             record.SlimRules,
+			"slim_active":            record.SlimActive,
+			"caveman_active":         record.CavemanActive,
+			"terse_active":           record.TerseActive,
+			"headroom_tokens_saved":  record.HeadroomTokensSaved,
+			"headroom_bytes_saved":   record.HeadroomBytesSaved,
+			"headroom_active":        record.HeadroomActive,
+			"ponytail_active":        record.PonytailActive,
+			"created_at":             record.CreatedAt,
+		})
+	}
+
+	series, busiest := accurateTimelineSeries(timeline, since, now, usageTimelineBuckets, tz)
+	rules := make([]map[string]any, 0, len(ruleSavings))
+	for _, saving := range ruleSavings {
+		rules = append(rules, map[string]any{
+			"rule":         saving.Rule,
+			"count":        saving.Count,
+			"bytes_saved":  saving.BytesSaved,
+			"tokens_saved": saving.BytesSaved / 4,
+		})
+	}
+	clients := make([]map[string]any, 0, len(clientSavings))
+	for _, saving := range clientSavings {
+		if saving.SlimTokensSaved == 0 && saving.HeadroomTokensSaved == 0 &&
+			saving.CavemanRequests == 0 && saving.TerseRequests == 0 && saving.PonytailRequests == 0 {
+			continue
+		}
+		clients = append(clients, map[string]any{
+			"client":                saving.Client,
+			"requests":              saving.Requests,
+			"optimized_requests":    saving.OptimizedRequests,
+			"bytes_saved":           saving.SlimBytesSaved,
+			"tokens_saved":          saving.SlimTokensSaved + saving.HeadroomTokensSaved,
+			"slim_tokens_saved":     saving.SlimTokensSaved,
+			"caveman_requests":      saving.CavemanRequests,
+			"terse_requests":        saving.TerseRequests,
+			"headroom_tokens_saved": saving.HeadroomTokensSaved,
+			"ponytail_requests":     saving.PonytailRequests,
+			"saved_cost_usd":        nanosToUSD(saving.SavedCostNanos),
+			"avoided_cost_usd":      nanosToUSD(saving.AvoidedCostNanos),
+			"usd_saved":             nanosToUSD(saving.SavedCostNanos + saving.AvoidedCostNanos),
+		})
+	}
+
+	tokensSaved := summary.SlimTokensSaved + summary.HeadroomTokensSaved
+	totalSavedNanos := summary.SavedCostNanos + summary.AvoidedCostNanos
+	savingsEstimated := totalSavedNanos > 0 && (summary.SlimTokensSaved > 0 ||
+		summary.AvoidedCostNanos > 0 || summary.EstimatedRequests > 0 ||
+		summary.EstimatedUsageRequests > 0 || summary.LegacyUsageRequests > 0 ||
+		summary.BackfilledRequests > 0)
+	response := map[string]any{
+		"period":       period,
+		"since":        since,
+		"generated_at": now,
+		"summary": map[string]any{
+			"total_requests":            summary.TotalRequests,
+			"successful_requests":       summary.SuccessCount,
+			"failed_requests":           summary.FailureCount,
+			"prompt_tokens":             summary.PromptTokens,
+			"completion_tokens":         summary.CompletionTokens,
+			"cached_tokens":             summary.CachedTokens,
+			"cache_write_tokens":        summary.CacheWriteTokens,
+			"reasoning_tokens":          summary.ReasoningTokens,
+			"total_tokens":              totalTokens,
+			"cost_usd":                  nanosToUSD(summary.CostNanos),
+			"cost_per_request_usd":      perRequestUSD(summary.CostNanos, summary.TotalRequests),
+			"tokens_per_request":        averageCount(totalTokens, summary.TotalRequests),
+			"cache_hits":                summary.CacheHits,
+			"success_rate":              successRate,
+			"avg_latency_ms":            summary.AvgLatencyMS,
+			"avg_ttft_ms":               summary.AvgTTFTMS,
+			"pricing_eligible_requests": pricingEligibleRequests,
+			"priced_requests":           summary.PricedRequests,
+			"unpriced_requests":         summary.UnpricedRequests,
+			"unpriced_tokens":           summary.UnpricedTokens,
+			"estimated_requests":        summary.EstimatedRequests,
+			"estimated_usage_requests":  summary.EstimatedUsageRequests,
+			"estimated_usage_tokens":    summary.EstimatedUsageTokens,
+			"legacy_usage_requests":     summary.LegacyUsageRequests,
+			"legacy_usage_tokens":       summary.LegacyUsageTokens,
+			"backfilled_requests":       summary.BackfilledRequests,
+			"pricing_request_coverage":  requestPricingCoverage,
+			"pricing_token_coverage":    tokenPricingCoverage,
+			"since":                     since,
+		},
+		"savings": map[string]any{
+			"slim_bytes_saved":                   summary.SlimBytesSaved,
+			"slim_tokens_saved":                  summary.SlimTokensSaved,
+			"headroom_tokens_saved":              summary.HeadroomTokensSaved,
+			"total_tokens_saved":                 tokensSaved,
+			"saved_tokens_per_request":           averageCount(tokensSaved, summary.TotalRequests),
+			"saved_tokens_per_optimized_request": averageCount(tokensSaved, summary.OptimizedRequests),
+			"optimized_requests":                 summary.OptimizedRequests,
+			"caveman_requests":                   summary.CavemanRequests,
+			"terse_requests":                     summary.TerseRequests,
+			"headroom_requests":                  summary.HeadroomRequests,
+			"ponytail_requests":                  summary.PonytailRequests,
+			"saved_cost_usd":                     nanosToUSD(summary.SavedCostNanos),
+			"avoided_cost_usd":                   nanosToUSD(summary.AvoidedCostNanos),
+			"usd_saved":                          nanosToUSD(totalSavedNanos),
+			"usd_saved_estimate":                 savingsEstimated,
+			"rules":                              rules,
+			"by_client":                          clients,
+		},
+		"providers": providerRows,
+		"recent":    recentRows,
+		"series":    series,
+		"busiest":   busiest,
+	}
+	writeJSONCached(w, s.insightsCache, cacheKey, response)
+}
+
+// adminModelUsageAccurate returns per-model request, token, latency, price
+// coverage, rate snapshot, and cost totals for the selected period.
+func (s *Server) adminModelUsageAccurate(w http.ResponseWriter, r *http.Request) {
+	period := r.URL.Query().Get("period")
+	tz := r.URL.Query().Get("tz")
+	cacheKey := "models-v2|" + period + "|" + tz
+	if s.cacheHit(w, cacheKey) {
+		return
+	}
+
+	since := sinceForPeriod(period, tz)
+	models, err := s.usage.ByModelAccurate(r.Context(), adminTenant, since)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	rows := make([]map[string]any, 0, len(models))
+	for _, model := range models {
+		display, color, icon := usageProviderMetadata(model.Provider)
+		pricingStatus := aggregateModelPricingStatus(model)
+		rows = append(rows, map[string]any{
+			"provider":                  model.Provider,
+			"provider_name":             display,
+			"provider_color":            color,
+			"provider_icon":             icon,
+			"model":                     model.Model,
+			"total_requests":            model.TotalRequests,
+			"successful_requests":       model.SuccessCount,
+			"failed_requests":           model.TotalRequests - model.SuccessCount,
+			"success_rate":              ratio(model.SuccessCount, model.TotalRequests),
+			"prompt_tokens":             model.PromptTokens,
+			"completion_tokens":         model.CompletionTokens,
+			"cached_tokens":             model.CachedTokens,
+			"cache_write_tokens":        model.CacheWriteTokens,
+			"reasoning_tokens":          model.ReasoningTokens,
+			"total_tokens":              model.PromptTokens + model.CompletionTokens,
+			"cost_usd":                  nanosToUSD(model.CostNanos),
+			"saved_cost_usd":            nanosToUSD(model.SavedCostNanos),
+			"avoided_cost_usd":          nanosToUSD(model.AvoidedCostNanos),
+			"avg_latency_ms":            model.AvgLatencyMS,
+			"avg_ttft_ms":               model.AvgTTFTMS,
+			"pricing_eligible_requests": model.PricingEligibleRequests,
+			"unpriced_requests":         model.UnpricedRequests,
+			"missing_pricing_requests":  model.MissingPricingRequests,
+			"legacy_pricing_requests":   model.LegacyPricingRequests,
+			"estimated_requests":        model.EstimatedRequests,
+			"estimated_usage_requests":  model.EstimatedUsageRequests,
+			"legacy_usage_requests":     model.LegacyUsageRequests,
+			"backfilled_requests":       model.BackfilledRequests,
+			"pricing_request_coverage":  optionalRatio(model.PricingEligibleRequests-model.UnpricedRequests, model.PricingEligibleRequests),
+			"pricing_status":            pricingStatus,
+			"pricing_mixed":             model.PricingMixed,
+			"pricing_source":            model.PricingSource,
+			"pricing_key":               model.PricingKey,
+			"input_per_m":               model.InputRatePerM,
+			"cached_input_per_m":        model.CachedRatePerM,
+			"cache_write_per_m":         model.CacheWriteRatePerM,
+			"output_per_m":              model.OutputRatePerM,
+			"reasoning_per_m":           model.ReasoningRatePerM,
+		})
+	}
+	writeJSONCached(w, s.insightsCache, cacheKey, map[string]any{
+		"period":       period,
+		"since":        since,
+		"generated_at": time.Now().UTC(),
+		"models":       rows,
+	})
+}
+
+func usageProviderMetadata(provider string) (display, color, icon string) {
+	display = provider
+	if spec, ok := connectors.SpecByID(provider); ok {
+		display = spec.DisplayName
+		color = spec.Color
+	}
+	icon = "/providers/" + providerIconID(provider) + ".png"
+	return display, color, icon
+}
+
+func nanosToUSD(nanos int64) float64 {
+	return float64(nanos) / 1_000_000_000
+}
+
+func perRequestUSD(nanos, requests int64) float64 {
+	if requests <= 0 {
+		return 0
+	}
+	return nanosToUSD(nanos) / float64(requests)
+}
+
+func averageCount(total, requests int64) float64 {
+	if requests <= 0 {
+		return 0
+	}
+	return float64(total) / float64(requests)
+}
+
+func ratio(numerator, denominator int64) float64 {
+	if denominator <= 0 {
+		return 0
+	}
+	if numerator < 0 {
+		numerator = 0
+	}
+	if numerator > denominator {
+		numerator = denominator
+	}
+	return float64(numerator) / float64(denominator)
+}
+
+// optionalRatio represents an undefined empty-set ratio as JSON null instead
+// of presenting 0/0 as measured zero (or complete coverage).
+func optionalRatio(numerator, denominator int64) *float64 {
+	if denominator <= 0 {
+		return nil
+	}
+	value := ratio(numerator, denominator)
+	return &value
+}
+
+func aggregateModelPricingStatus(model store.AccurateModelUsage) string {
+	switch {
+	case model.PricingEligibleRequests == 0:
+		return "none"
+	case model.MissingPricingRequests == model.PricingEligibleRequests:
+		return "missing"
+	case model.LegacyPricingRequests == model.PricingEligibleRequests:
+		return "legacy"
+	case model.UnpricedRequests > 0:
+		return "partial"
+	case model.PricingMixed:
+		return "mixed"
+	case model.EstimatedRequests > 0:
+		return "estimated"
+	default:
+		return model.PricingStatus
+	}
+}
+
+func accurateTimelineSeries(points []store.AccurateTimeBucket, from, to time.Time, count int, tz string) ([]map[string]any, string) {
+	if count <= 0 {
+		count = usageTimelineBuckets
+	}
+	span := to.Sub(from)
+	if span <= 0 {
+		span = time.Hour
+	}
+	slot := span / time.Duration(count)
+	if slot <= 0 {
+		slot = time.Minute
+	}
+	location := time.Local
+	if tz != "" {
+		if parsed, err := time.LoadLocation(tz); err == nil {
+			location = parsed
+		}
+	}
+
+	byIndex := make(map[int]store.AccurateTimeBucket, len(points))
+	for _, point := range points {
+		byIndex[point.Bucket] = point
+	}
+	series := make([]map[string]any, 0, count)
+	busiest := ""
+	var busiestRequests int64
+	for index := 0; index < count; index++ {
+		start := from.Add(time.Duration(index) * slot)
+		labelFormat := "15:04"
+		if span > 48*time.Hour {
+			labelFormat = "Jan 02"
+		}
+		point := byIndex[index]
+		label := start.In(location).Format(labelFormat)
+		if point.Requests > busiestRequests {
+			busiestRequests = point.Requests
+			busiest = label
+		}
+		series = append(series, map[string]any{
+			"label":             label,
+			"start":             start.UTC(),
+			"count":             point.Requests,
+			"requests":          point.Requests,
+			"failures":          point.Failed,
+			"prompt_tokens":     point.PromptTokens,
+			"completion_tokens": point.CompletionTokens,
+			"cost_usd":          nanosToUSD(point.CostNanos),
+		})
+	}
+	return series, busiest
+}

--- a/backend/internal/gateway/usage_v2_test.go
+++ b/backend/internal/gateway/usage_v2_test.go
@@ -1,0 +1,61 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+func TestAggregateModelPricingStatusPreservesLegacyTotals(t *testing.T) {
+	tests := []struct {
+		name  string
+		model store.AccurateModelUsage
+		want  string
+	}{
+		{
+			name: "all legacy",
+			model: store.AccurateModelUsage{
+				PricingEligibleRequests: 2, UnpricedRequests: 2, LegacyPricingRequests: 2,
+				PricingStatus: "legacy",
+			},
+			want: "legacy",
+		},
+		{
+			name: "all missing",
+			model: store.AccurateModelUsage{
+				PricingEligibleRequests: 2, UnpricedRequests: 2, MissingPricingRequests: 2,
+			},
+			want: "missing",
+		},
+		{
+			name: "legacy and missing",
+			model: store.AccurateModelUsage{
+				PricingEligibleRequests: 2, UnpricedRequests: 2,
+				LegacyPricingRequests: 1, MissingPricingRequests: 1,
+			},
+			want: "partial",
+		},
+		{
+			name:  "no eligible usage",
+			model: store.AccurateModelUsage{PricingStatus: "missing"},
+			want:  "none",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := aggregateModelPricingStatus(tt.model); got != tt.want {
+				t.Fatalf("aggregateModelPricingStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOptionalRatioEmptySetIsUnavailable(t *testing.T) {
+	if got := optionalRatio(0, 0); got != nil {
+		t.Fatalf("optionalRatio(0, 0) = %v, want nil", *got)
+	}
+	got := optionalRatio(3, 4)
+	if got == nil || *got != 0.75 {
+		t.Fatalf("optionalRatio(3, 4) = %v, want 0.75", got)
+	}
+}

--- a/backend/internal/health/telemetry.go
+++ b/backend/internal/health/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,11 +35,11 @@ type ProviderTelemetryEvent struct {
 	ErrorType    ProviderErrorType
 	ErrorMessage string
 
-	ChainID           string
-	FallbackTriggered bool
+	ChainID            string
+	FallbackTriggered  bool
 	FallbackToProvider string
 	FallbackToModel    string
-	FinalFailure      bool
+	FinalFailure       bool
 }
 
 // LatencyThresholds maps a capability to its p95 latency threshold in ms.
@@ -93,8 +94,8 @@ type Config struct {
 // All recording is best-effort: a full queue or a DB write failure logs a
 // warning and continues. The gateway request path never blocks on telemetry.
 type Service struct {
-	cfg Config
-	log *slog.Logger
+	cfg  Config
+	log  *slog.Logger
 	repo *store.ProviderHealthRepo
 
 	ch      chan ProviderTelemetryEvent
@@ -102,52 +103,55 @@ type Service struct {
 	done    chan struct{}
 	started bool
 
-	mu     sync.Mutex // guards states + chains maps
-	states map[string]*keyState
-	chains map[string]*chainState // key = chain_id
+	mu      sync.Mutex // guards states + chains maps
+	states  map[string]*keyState
+	chains  map[string]*chainState // key = chain_id
+	dropped atomic.Uint64
 }
 
 // chainState rolls up telemetry across all providers in one chain so the
 // dashboard can show fallback rate and final-failure count per chain.
 type chainState struct {
-	chainID      string
-	buckets      map[int64]*chainBucket // key = unix minute
-	lastUpdated  time.Time
+	chainID     string
+	buckets     map[int64]*chainBucket // key = unix minute
+	lastUpdated time.Time
 }
 
 type chainBucket struct {
-	minute      time.Time
-	requests    int64
-	successes   int64
-	failures    int64
-	fallbacks   int64
-	finalFails  int64
+	minute     time.Time
+	requests   int64
+	successes  int64
+	failures   int64
+	fallbacks  int64
+	finalFails int64
 }
 
 type keyState struct {
-	provider          string
-	account           string
-	model             string
-	capability        string
-	buckets           map[int64]*minuteBucket // key = unix minute
+	provider            string
+	account             string
+	model               string
+	capability          string
+	buckets             map[int64]*minuteBucket // key = unix minute
 	consecutiveFailures int
-	lastSuccess       *time.Time
-	lastFailure       *time.Time
+	lastSuccess         *time.Time
+	lastFailure         *time.Time
 }
 
 type minuteBucket struct {
-	minute      time.Time
-	requests    int64
-	successes   int64
-	failures    int64
-	fallbacks   int64
-	finalFails  int64
-	inputTokens int64
-	outputTokens int64
-	costMicros  int64
-	latencies   []int
-	ttfts       []int
-	errCounts   map[ProviderErrorType]int64
+	minute              time.Time
+	revision            uint64
+	snapshottedRevision uint64
+	requests            int64
+	successes           int64
+	failures            int64
+	fallbacks           int64
+	finalFails          int64
+	inputTokens         int64
+	outputTokens        int64
+	costMicros          int64
+	latencies           []int
+	ttfts               []int
+	errCounts           map[ProviderErrorType]int64
 }
 
 // New builds a health telemetry Service. The caller must call Start to launch
@@ -197,23 +201,43 @@ func (s *Service) Record(ev ProviderTelemetryEvent) {
 	select {
 	case s.ch <- ev:
 	default:
+		s.dropped.Add(1)
 		s.log.Debug("health telemetry queue full; dropping event",
 			"provider", ev.Provider, "model", ev.Model)
 	}
 }
 
+// DroppedEvents reports telemetry events lost because the non-blocking queue
+// was full. Surfacing this value lets dashboards qualify health coverage.
+func (s *Service) DroppedEvents() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.dropped.Load()
+}
+
+// RollingWindow reports the configured lookback represented by
+// provider_health_current. Dashboards must expose this actual collector window
+// instead of implying that an arbitrary requested range was applied.
+func (s *Service) RollingWindow() time.Duration {
+	if s == nil {
+		return 0
+	}
+	return s.cfg.RollingWindow
+}
+
 // ChainStat is the rolled-up health of one routing chain over the rolling
 // window, used by the chain-impact view.
 type ChainStat struct {
-	ChainID         string
-	Requests        int64
-	Successes       int64
-	Failures        int64
-	Fallbacks       int64
-	FinalFailures   int64
-	FallbackRate    float64 // 0-1
+	ChainID          string
+	Requests         int64
+	Successes        int64
+	Failures         int64
+	Fallbacks        int64
+	FinalFailures    int64
+	FallbackRate     float64 // 0-1
 	FinalFailureRate float64 // 0-1
-	LastUpdated     time.Time
+	LastUpdated      time.Time
 }
 
 // ChainStats returns rolled-up per-chain stats over the rolling window. Chains
@@ -313,58 +337,70 @@ func (s *Service) run(ctx context.Context) {
 }
 
 func (s *Service) ingest(ev ProviderTelemetryEvent) {
-	key := store.HealthKey(ev.Provider, ev.ProviderAccountID, ev.Model, ev.Capability)
-	s.mu.Lock()
-	ks, ok := s.states[key]
-	if !ok {
-		ks = &keyState{
-			provider:   ev.Provider,
-			account:    ev.ProviderAccountID,
-			model:      ev.Model,
-			capability: ev.Capability,
-			buckets:    make(map[int64]*minuteBucket),
-		}
-		s.states[key] = ks
-	}
 	min := ev.Timestamp.UTC().Truncate(time.Minute)
-	bucket, ok := ks.buckets[min.Unix()]
-	if !ok {
-		bucket = &minuteBucket{minute: min, errCounts: make(map[ProviderErrorType]int64)}
-		ks.buckets[min.Unix()] = bucket
+	s.mu.Lock()
+
+	// A final-failure marker exists only to close the chain-level request. The
+	// concrete provider attempt was already recorded immediately before it;
+	// aggregating the marker again would double-count failed requests and create
+	// a second account-less provider row.
+	if ev.FinalFailure && ev.Provider != "" {
+		key := store.HealthKey(ev.Provider, ev.ProviderAccountID, ev.Model, ev.Capability)
+		if ks, ok := s.states[key]; ok {
+			if bucket, ok := ks.buckets[min.Unix()]; ok {
+				bucket.finalFails++
+				bucket.revision++
+			}
+		}
 	}
-	bucket.requests++
-	bucket.inputTokens += int64(ev.InputTokens)
-	bucket.outputTokens += int64(ev.OutputTokens)
-	bucket.costMicros += ev.CostMicroUSD
-	if ev.Status == "success" {
-		bucket.successes++
-		ks.consecutiveFailures = 0
-		now := ev.Timestamp
-		ks.lastSuccess = &now
-	} else {
-		bucket.failures++
-		bucket.errCounts[ev.ErrorType]++
-		ks.consecutiveFailures++
-		now := ev.Timestamp
-		ks.lastFailure = &now
-	}
-	if ev.FallbackTriggered && ev.Status == "failed" && !ev.FinalFailure {
-		bucket.fallbacks++
-	}
-	if ev.FinalFailure {
-		bucket.finalFails++
-	}
-	if ev.LatencyMs > 0 && len(bucket.latencies) < s.cfg.MaxSamplesPerBucket {
-		bucket.latencies = append(bucket.latencies, ev.LatencyMs)
-	}
-	if ev.TTFTMs > 0 && len(bucket.ttfts) < s.cfg.MaxSamplesPerBucket {
-		bucket.ttfts = append(bucket.ttfts, ev.TTFTMs)
+	if !ev.FinalFailure && ev.Provider != "" {
+		key := store.HealthKey(ev.Provider, ev.ProviderAccountID, ev.Model, ev.Capability)
+		ks, ok := s.states[key]
+		if !ok {
+			ks = &keyState{
+				provider:   ev.Provider,
+				account:    ev.ProviderAccountID,
+				model:      ev.Model,
+				capability: ev.Capability,
+				buckets:    make(map[int64]*minuteBucket),
+			}
+			s.states[key] = ks
+		}
+		bucket, ok := ks.buckets[min.Unix()]
+		if !ok {
+			bucket = &minuteBucket{minute: min, errCounts: make(map[ProviderErrorType]int64)}
+			ks.buckets[min.Unix()] = bucket
+		}
+		bucket.requests++
+		bucket.inputTokens += int64(ev.InputTokens)
+		bucket.outputTokens += int64(ev.OutputTokens)
+		bucket.costMicros += ev.CostMicroUSD
+		if ev.Status == "success" {
+			bucket.successes++
+			ks.consecutiveFailures = 0
+			now := ev.Timestamp
+			ks.lastSuccess = &now
+		} else {
+			bucket.failures++
+			bucket.errCounts[ev.ErrorType]++
+			ks.consecutiveFailures++
+			now := ev.Timestamp
+			ks.lastFailure = &now
+		}
+		if ev.FallbackTriggered && ev.Status == "failed" {
+			bucket.fallbacks++
+		}
+		if ev.LatencyMs > 0 && len(bucket.latencies) < s.cfg.MaxSamplesPerBucket {
+			bucket.latencies = append(bucket.latencies, ev.LatencyMs)
+		}
+		if ev.TTFTMs > 0 && len(bucket.ttfts) < s.cfg.MaxSamplesPerBucket {
+			bucket.ttfts = append(bucket.ttfts, ev.TTFTMs)
+		}
+		bucket.revision++
 	}
 
 	// Chain-level rollup: only terminal events (success or FinalFailure)
-	// count as requests. FallbackTriggered on a terminal event means the
-	// request fell back ≥1 time before completing. Non-terminal per-attempt
-	// failure events are ignored at chain level (they're not requests).
+	// count as requests. Non-terminal per-attempt failures are ignored here.
 	if ev.ChainID != "" {
 		cs, ok := s.chains[ev.ChainID]
 		if !ok {
@@ -396,6 +432,9 @@ func (s *Service) ingest(ev ProviderTelemetryEvent) {
 // flushCurrent recomputes provider_health_current for every active key from its
 // rolling window of minute buckets.
 func (s *Service) flushCurrent(ctx context.Context) {
+	if s.repo == nil {
+		return
+	}
 	s.mu.Lock()
 	now := time.Now().UTC()
 	windowStart := now.Add(-s.cfg.RollingWindow).Truncate(time.Minute)
@@ -404,32 +443,56 @@ func (s *Service) flushCurrent(ctx context.Context) {
 		keys = append(keys, ks)
 	}
 	s.mu.Unlock()
+	if err := s.repo.DeleteStaleTrafficCurrent(ctx, windowStart); err != nil {
+		s.log.Warn("stale health current cleanup failed", "err", err)
+	}
 
 	for _, ks := range keys {
 		agg := s.aggregate(ks, windowStart, now)
 		if agg.requests == 0 {
+			// Leave a concurrently refreshed probe-only row intact, but remove the
+			// expired traffic aggregate so the API cannot label it as current.
+			if err := s.repo.DeleteTrafficCurrent(ctx, ks.provider, ks.account, ks.model,
+				ks.capability, now.Add(-time.Second)); err != nil {
+				s.log.Warn("expired health current cleanup failed", "err", err,
+					"provider", ks.provider, "model", ks.model)
+			}
 			continue
 		}
 		s.upsertCurrent(ctx, ks, agg, now)
 	}
 }
 
-// flushSnapshots writes completed (elapsed) minute buckets as snapshot rows and
-// removes them from memory. When flushAll is true (shutdown), the current
-// in-progress minute is also written.
+// flushSnapshots persists completed minute buckets while retaining them through
+// the rolling window used by provider_health_current. A revision marker avoids
+// rewriting unchanged buckets; late events make a retained bucket dirty and
+// replace the same persisted snapshot on the next flush.
 func (s *Service) flushSnapshots(ctx context.Context, flushAll bool) {
+	if s.repo == nil {
+		return
+	}
 	s.mu.Lock()
-	currentMinute := time.Now().UTC().Truncate(time.Minute).Unix()
+	now := time.Now().UTC()
+	currentMinute := now.Truncate(time.Minute).Unix()
+	windowStart := now.Add(-s.cfg.RollingWindow).Truncate(time.Minute)
 	type pending struct {
-		ks     *keyState
-		minute int64
-		bucket *minuteBucket
+		ks       *keyState
+		minute   int64
+		original *minuteBucket
+		bucket   *minuteBucket
+		revision uint64
 	}
 	var toWrite []pending
 	for _, ks := range s.states {
 		for m, b := range ks.buckets {
-			if m < currentMinute || flushAll {
-				toWrite = append(toWrite, pending{ks, m, b})
+			completed := m < currentMinute || flushAll
+			if completed && b.revision != b.snapshottedRevision {
+				toWrite = append(toWrite, pending{
+					ks: ks, minute: m, original: b, bucket: cloneMinuteBucket(b), revision: b.revision,
+				})
+			}
+			if b.minute.Before(windowStart) && b.revision == b.snapshottedRevision {
+				delete(ks.buckets, m)
 			}
 		}
 	}
@@ -442,13 +505,27 @@ func (s *Service) flushSnapshots(ctx context.Context, flushAll bool) {
 			continue
 		}
 		s.mu.Lock()
-		// Re-fetch: the bucket may have been re-created since snapshot; only
-		// delete if it is the same pointer we wrote.
-		if cur, ok := p.ks.buckets[p.minute]; ok && cur == p.bucket {
-			delete(p.ks.buckets, p.minute)
+		// A late event may have changed the bucket during the DB write. Mark only
+		// the exact revision persisted so that a newer revision is retried.
+		if cur, ok := p.ks.buckets[p.minute]; ok && cur == p.original && cur.revision == p.revision {
+			cur.snapshottedRevision = p.revision
+			if cur.minute.Before(windowStart) {
+				delete(p.ks.buckets, p.minute)
+			}
 		}
 		s.mu.Unlock()
 	}
+}
+
+func cloneMinuteBucket(source *minuteBucket) *minuteBucket {
+	clone := *source
+	clone.latencies = append([]int(nil), source.latencies...)
+	clone.ttfts = append([]int(nil), source.ttfts...)
+	clone.errCounts = make(map[ProviderErrorType]int64, len(source.errCounts))
+	for errorType, count := range source.errCounts {
+		clone.errCounts[errorType] = count
+	}
+	return &clone
 }
 
 type windowAgg struct {
@@ -456,6 +533,8 @@ type windowAgg struct {
 	fallbacks, finalFails         int64
 	inputTokens, outputTokens     int64
 	costMicros                    int64
+	consecutiveFailures           int
+	lastSuccess, lastFailure      *time.Time
 	errCounts                     map[ProviderErrorType]int64
 	latencies                     []int
 	ttfts                         []int
@@ -484,10 +563,16 @@ func (s *Service) aggregate(ks *keyState, windowStart, _ time.Time) windowAgg {
 		a.latencies = append(a.latencies, b.latencies...)
 		a.ttfts = append(a.ttfts, b.ttfts...)
 	}
+	a.consecutiveFailures = ks.consecutiveFailures
+	a.lastSuccess = ks.lastSuccess
+	a.lastFailure = ks.lastFailure
 	return a
 }
 
 func (s *Service) upsertCurrent(ctx context.Context, ks *keyState, a windowAgg, now time.Time) {
+	if s.repo == nil {
+		return
+	}
 	successRate := 0.0
 	if a.requests > 0 {
 		successRate = float64(a.successes) / float64(a.requests)
@@ -506,7 +591,7 @@ func (s *Service) upsertCurrent(ctx context.Context, ks *keyState, a windowAgg, 
 		P95LatencyMs:        p95Lat,
 		LatencyThresholdMs:  threshold,
 		DominantErrorType:   dominant,
-		ConsecutiveFailures: ks.consecutiveFailures,
+		ConsecutiveFailures: a.consecutiveFailures,
 	})
 	status := StatusFromScore(score, a.requests > 0, false)
 	mainIssue := MainIssue(dominant, p95Lat, threshold, a.fallbacks)
@@ -529,9 +614,9 @@ func (s *Service) upsertCurrent(ctx context.Context, ks *keyState, a windowAgg, 
 		FallbackCount:       a.fallbacks,
 		LatencyP95Ms:        intPtr(p95Lat),
 		TTFTP95Ms:           intPtr(p95TTFT),
-		ConsecutiveFailures: ks.consecutiveFailures,
-		LastSuccessAt:       ks.lastSuccess,
-		LastFailureAt:       ks.lastFailure,
+		ConsecutiveFailures: a.consecutiveFailures,
+		LastSuccessAt:       a.lastSuccess,
+		LastFailureAt:       a.lastFailure,
 		LastUpdatedAt:       now,
 	}
 	if mainIssue != "" {

--- a/backend/internal/health/telemetry_test.go
+++ b/backend/internal/health/telemetry_test.go
@@ -1,0 +1,57 @@
+package health
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mydisha/keirouter/backend/internal/config"
+	"github.com/mydisha/keirouter/backend/internal/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletedHealthBucketRemainsInRollingWindowAndAcceptsLateEvents(t *testing.T) {
+	ctx := context.Background()
+	db, err := store.Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: ":memory:"}, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.Migrate(ctx))
+
+	repo := db.ProviderHealth()
+	service := New(Config{Enabled: true, RollingWindow: 15 * time.Minute}, nil, repo)
+	bucketTime := time.Now().UTC().Truncate(time.Minute).Add(-time.Minute)
+	event := ProviderTelemetryEvent{
+		Timestamp: bucketTime.Add(5 * time.Second), Provider: "anthropic", Model: "claude-sonnet",
+		Capability: "chat_completions", Status: "success", LatencyMs: 1200,
+	}
+	service.ingest(event)
+	service.flushSnapshots(ctx, false)
+
+	key := store.HealthKey("anthropic", "", "claude-sonnet", "chat_completions")
+	service.mu.Lock()
+	state := service.states[key]
+	require.NotNil(t, state)
+	require.Len(t, state.buckets, 1, "completed bucket must remain available to rolling current")
+	service.mu.Unlock()
+
+	service.flushCurrent(ctx)
+	current, err := repo.GetCurrent(ctx, "anthropic", "", "claude-sonnet", "chat_completions")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), current.RequestCount)
+
+	// The event arrives after the first snapshot. The retained bucket becomes
+	// dirty and replaces that snapshot on the next flush.
+	event.Timestamp = bucketTime.Add(45 * time.Second)
+	event.LatencyMs = 1800
+	service.ingest(event)
+	service.flushSnapshots(ctx, false)
+	service.flushCurrent(ctx)
+
+	snapshots, err := repo.ListSnapshots(ctx, "anthropic", "", "claude-sonnet", "", bucketTime.Add(-time.Minute))
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	require.Equal(t, int64(2), snapshots[0].RequestCount)
+	current, err = repo.GetCurrent(ctx, "anthropic", "", "claude-sonnet", "chat_completions")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), current.RequestCount)
+}

--- a/backend/internal/meter/meter.go
+++ b/backend/internal/meter/meter.go
@@ -1,9 +1,8 @@
 // Package meter records per-request usage and computes cost.
 //
-// Cost is stored in micros (millionths of a USD) as an integer to avoid
-// floating-point drift in budget accounting. The pricing table maps
-// provider/model to its per-million-token rates; unknown models fall back to
-// provider-level rates, then to zero (treated as free for display purposes).
+// Cost is stored canonically in nanodollars with a micro-USD compatibility
+// value for budgets. Pricing resolution distinguishes explicit free models from
+// missing prices so unknown usage is never silently reported as free.
 package meter
 
 import (
@@ -20,13 +19,24 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/usagehub"
 )
 
-// Price holds per-million-token rates in USD.
+// Price holds per-million-token rates in USD plus immutable provenance.
 type Price struct {
-	InputPerM       float64 // standard input tokens
-	OutputPerM      float64 // standard output tokens
-	CachedInputPerM float64 // cache-read input tokens (often 50-90% off standard)
-	CacheWritePerM  float64 // cache-write input tokens (often 25% above standard)
-	ReasoningPerM   float64 // reasoning/extended-thinking output tokens
+	InputPerM       float64
+	OutputPerM      float64
+	CachedInputPerM float64
+	CacheWritePerM  float64
+	ReasoningPerM   float64
+
+	LongContextThreshold int
+	LongInputPerM        float64
+	LongOutputPerM       float64
+	LongCachedInputPerM  float64
+	LongCacheWritePerM   float64
+
+	Source       string
+	SourceURL    string
+	Estimated    bool
+	ExplicitFree bool
 }
 
 // UsageStore is the persistence surface Meter needs. *store.UsageRepo satisfies
@@ -38,11 +48,14 @@ type UsageStore interface {
 
 // Meter records usage rows and computes cost from a pricing table.
 type Meter struct {
-	usage       UsageStore
+	usage UsageStore
+
+	pricingMu   sync.RWMutex
 	pricing     map[string]Price // provider-level fallback
-	modelPrices map[string]Price // provider/model-level (e.g. "openai/gpt-4o")
-	hub         *usagehub.Hub    // notifies subscribers of new usage records
-	async       *AsyncWriter
+	modelPrices map[string]Price // provider/model-level
+
+	hub   *usagehub.Hub
+	async *AsyncWriter
 }
 
 // SetHub installs a usage event hub. When set, the meter publishes an event
@@ -95,27 +108,33 @@ func (m *Meter) Close(timeout time.Duration) {
 	}
 }
 
-// Event captures the facts about one completed (or cached) request.
+// Event captures the terminal accounting facts for one inbound request.
 type Event struct {
+	RequestID string
 	TenantID  string
 	ProjectID string
 	APIKeyID  string
 	Provider  string
 	Model     string
 	AccountID string
-	Client    string // detected calling tool (claude-code, codex, ...) or "unknown"
-	Usage     core.Usage
-	CacheHit  bool
-	Latency   time.Duration
-	TTFT      time.Duration // time-to-first-token (0 if not measured)
+	Client    string
+	Status    string
+	ErrorKind string
+
+	Usage           core.Usage
+	UsageSource     string // provider | estimated | cache | none
+	CacheHit        bool
+	Latency         time.Duration // winning upstream attempt
+	EndToEndLatency time.Duration
+	TTFT            time.Duration
 
 	// Token-saving analytics.
-	SlimStats      *SlimSnapshot     // nil when RTK did not fire
-	SlimActive     bool              // RTK slimmer was enabled for this request
-	CavemanActive  bool              // caveman output compression was active
-	TerseActive    bool              // terse output compression was active
-	HeadroomStats  *HeadroomSnapshot // nil when Headroom did not yield non-phantom savings
-	PonytailActive bool              // ponytail output injection was active
+	SlimStats      *SlimSnapshot
+	SlimActive     bool
+	CavemanActive  bool
+	TerseActive    bool
+	HeadroomStats  *HeadroomSnapshot
+	PonytailActive bool
 }
 
 // SlimSnapshot captures the RTK slimmer's per-request compression results.
@@ -134,104 +153,105 @@ type HeadroomSnapshot struct {
 	Active      bool
 }
 
-// resolvePrice looks up the price for a provider/model pair. It tries
-// "provider/model" first, then "provider", then returns a zero price.
+// resolvePrice is retained for internal compatibility; callers that need
+// provenance should use ResolvePrice.
 func (m *Meter) resolvePrice(provider, model string) Price {
-	// Try exact model match first.
-	if model != "" {
-		if p, ok := m.modelPrices[provider+"/"+model]; ok {
-			return p
+	return m.ResolvePrice(provider, model).Price
+}
+
+// CostMicros returns the compatibility micro-USD total. CostNanos from
+// CalculateCost is authoritative for analytics and historical aggregation.
+func (m *Meter) CostMicros(provider, model string, u core.Usage, cacheHit bool) int64 {
+	return m.CalculateCost(provider, model, u, cacheHit, 0).CostMicros
+}
+
+// Record persists a canonical terminal request row and returns its actual cost
+// in micro-USD for the existing budget interface.
+func (m *Meter) Record(ctx context.Context, ev Event) (int64, error) {
+	u := clampUsage(ev.Usage)
+	status := ev.Status
+	if status == "" {
+		if ev.CacheHit {
+			status = "cache_hit"
+		} else {
+			status = "success"
 		}
 	}
-	// Fall back to provider-level.
-	if p, ok := m.pricing[provider]; ok {
-		return p
+	usageSource := ev.UsageSource
+	if usageSource == "" {
+		switch {
+		case ev.CacheHit:
+			usageSource = "cache"
+		case u.PromptTokens+u.CompletionTokens > 0:
+			usageSource = "provider"
+		default:
+			usageSource = "none"
+		}
 	}
-	return Price{}
-}
-
-// CostMicros returns the cost of a usage event in micros of USD. Cached
-// requests cost nothing (the whole point of the cache). Cached read tokens
-// use the discounted CachedInputPerM rate; cache write tokens use the
-// (often higher) CacheWritePerM rate. Reasoning tokens use the ReasoningPerM
-// rate when set.
-func (m *Meter) CostMicros(provider, model string, u core.Usage, cacheHit bool) int64 {
-	if cacheHit {
-		return 0
-	}
-	p := m.resolvePrice(provider, model)
-
-	// Standard input tokens = total input minus cache reads and writes.
-	standardInput := u.PromptTokens - u.CachedTokens - u.CacheWriteTokens
-	if standardInput < 0 {
-		standardInput = 0
-	}
-
-	// Cost breakdown:
-	//   standard input     * InputPerM
-	// + cache-read input   * CachedInputPerM  (often 50-90% off InputPerM)
-	// + cache-write input  * CacheWritePerM   (often 25% above InputPerM)
-	// + reasoning tokens   * ReasoningPerM    (often same as OutputPerM)
-	// + completion tokens  * OutputPerM
-	inputCost := float64(standardInput) * p.InputPerM
-	cachedReadCost := float64(u.CachedTokens) * p.CachedInputPerM
-	cacheWriteCost := float64(u.CacheWriteTokens) * p.CacheWritePerM
-	reasoningCost := float64(u.ReasoningTokens) * p.ReasoningPerM
-	outputCost := float64(u.CompletionTokens) * p.OutputPerM
-
-	return int64(inputCost + cachedReadCost + cacheWriteCost + reasoningCost + outputCost)
-}
-
-// Record persists a usage row for an event and returns the computed cost.
-func (m *Meter) Record(ctx context.Context, ev Event) (int64, error) {
-	cost := m.CostMicros(ev.Provider, ev.Model, ev.Usage, ev.CacheHit)
-	rec := store.UsageRecord{
-		ID:               uuid.NewString(),
-		TenantID:         ev.TenantID,
-		ProjectID:        ev.ProjectID,
-		APIKeyID:         ev.APIKeyID,
-		Provider:         ev.Provider,
-		Model:            ev.Model,
-		AccountID:        ev.AccountID,
-		Client:           ev.Client,
-		PromptTokens:     ev.Usage.PromptTokens,
-		CompletionTokens: ev.Usage.CompletionTokens,
-		CachedTokens:     ev.Usage.CachedTokens,
-		CacheWriteTokens: ev.Usage.CacheWriteTokens,
-		CostMicros:       cost,
-		CacheHit:         ev.CacheHit,
-		LatencyMS:        int(ev.Latency.Milliseconds()),
-		TTFTMS:           int(ev.TTFT.Milliseconds()),
-		CavemanActive:    ev.CavemanActive,
-		SlimActive:       ev.SlimActive,
-		TerseActive:      ev.TerseActive,
-		PonytailActive:   ev.PonytailActive,
-		CreatedAt:        time.Now(),
-	}
+	savedTokens := 0
 	if ev.SlimStats != nil {
-		rec.SlimBytesSaved = ev.SlimStats.BytesSaved
-		rec.SlimTokensSaved = ev.SlimStats.TokensSaved
-		rec.SlimRules = ev.SlimStats.Rules
+		savedTokens += ev.SlimStats.TokensSaved
 	}
 	if ev.HeadroomStats != nil {
-		rec.HeadroomTokensSaved = ev.HeadroomStats.TokensSaved
-		rec.HeadroomBytesSaved = ev.HeadroomStats.BytesSaved
-		rec.HeadroomActive = ev.HeadroomStats.Active
+		savedTokens += ev.HeadroomStats.TokensSaved
+	}
+	var cost CostBreakdown
+	if u.PromptTokens+u.CompletionTokens == 0 && !ev.CacheHit {
+		// A terminal request without upstream usage has no applicable price,
+		// including a nominally successful response whose provider omitted usage.
+		// Do not inflate coverage merely because the target exists in the catalog.
+		cost.Pricing = PricingMatch{Status: "none", MatchKind: "none"}
+	} else {
+		cost = m.CalculateCost(ev.Provider, ev.Model, u, ev.CacheHit, savedTokens)
+	}
+	endToEnd := ev.EndToEndLatency
+	if endToEnd <= 0 {
+		endToEnd = ev.Latency
+	}
+	recordedAt := time.Now().UTC()
+	var pricingAsOf *time.Time
+	if cost.Pricing.Status != "missing" && cost.Pricing.Status != "none" {
+		pricingAsOf = &recordedAt
+	}
+	rec := store.UsageRecord{
+		ID: uuid.NewString(), RequestID: ev.RequestID,
+		TenantID: ev.TenantID, ProjectID: ev.ProjectID, APIKeyID: ev.APIKeyID,
+		Provider: ev.Provider, Model: ev.Model, AccountID: ev.AccountID, Client: ev.Client,
+		Status: status, ErrorKind: ev.ErrorKind, UsageSource: usageSource,
+		PromptTokens: u.PromptTokens, CompletionTokens: u.CompletionTokens,
+		CachedTokens: u.CachedTokens, CacheWriteTokens: u.CacheWriteTokens,
+		ReasoningTokens: u.ReasoningTokens,
+		CostMicros:      cost.CostMicros, CostNanos: cost.CostNanos,
+		InputCostNanos: cost.InputCostNanos, CachedCostNanos: cost.CachedCostNanos,
+		CacheWriteCostNanos: cost.CacheWriteCostNanos, OutputCostNanos: cost.OutputCostNanos,
+		ReasoningCostNanos: cost.ReasoningCostNanos, AvoidedCostNanos: cost.AvoidedCostNanos,
+		SavedCostNanos: cost.SavedCostNanos,
+		PricingStatus:  cost.Pricing.Status, PricingSource: cost.Pricing.Source, PricingKey: cost.Pricing.Key,
+		PricingMatchKind: cost.Pricing.MatchKind, PricingSourceURL: cost.Pricing.SourceURL,
+		PricingAsOf:   pricingAsOf,
+		InputRatePerM: cost.InputRatePerM, CachedRatePerM: cost.CachedRatePerM,
+		CacheWriteRatePerM: cost.CacheWriteRatePerM, OutputRatePerM: cost.OutputRatePerM,
+		ReasoningRatePerM: cost.ReasoningRatePerM,
+		CacheHit:          ev.CacheHit, LatencyMS: int(endToEnd.Milliseconds()),
+		UpstreamLatencyMS: int(ev.Latency.Milliseconds()), EndToEndLatencyMS: int(endToEnd.Milliseconds()),
+		TTFTMS: int(ev.TTFT.Milliseconds()), CavemanActive: ev.CavemanActive,
+		SlimActive: ev.SlimActive, TerseActive: ev.TerseActive, PonytailActive: ev.PonytailActive,
+		CreatedAt: recordedAt,
+	}
+	if ev.SlimStats != nil {
+		rec.SlimBytesSaved, rec.SlimTokensSaved, rec.SlimRules = ev.SlimStats.BytesSaved, ev.SlimStats.TokensSaved, ev.SlimStats.Rules
+	}
+	if ev.HeadroomStats != nil {
+		rec.HeadroomTokensSaved, rec.HeadroomBytesSaved, rec.HeadroomActive = ev.HeadroomStats.TokensSaved, ev.HeadroomStats.BytesSaved, ev.HeadroomStats.Active
 	}
 	if err := m.recordUsage(ctx, rec); err != nil {
-		return cost, err
+		return cost.CostMicros, err
 	}
-	// Notify SSE subscribers of the new usage record for near-real-time
-	// dashboard updates.
 	if m.hub != nil {
-		m.hub.Publish(usagehub.Event{
-			Provider:  ev.Provider,
-			Model:     ev.Model,
-			AccountID: ev.AccountID,
-			Tokens:    ev.Usage.PromptTokens + ev.Usage.CompletionTokens,
-		})
+		m.hub.Publish(usagehub.Event{Provider: ev.Provider, Model: ev.Model, AccountID: ev.AccountID,
+			Tokens: u.PromptTokens + u.CompletionTokens})
 	}
-	return cost, nil
+	return cost.CostMicros, nil
 }
 
 func (m *Meter) recordUsage(ctx context.Context, rec store.UsageRecord) error {

--- a/backend/internal/meter/meter_test.go
+++ b/backend/internal/meter/meter_test.go
@@ -63,8 +63,10 @@ func TestCostMicrosAppliesCacheAndReasoningRates(t *testing.T) {
 		ReasoningTokens:  50,
 	}, false)
 
-	if cost != 4_500 {
-		t.Fatalf("CostMicros() = %d, want 4500", cost)
+	// Reasoning tokens are already included in completion tokens, so only the
+	// non-reasoning remainder is charged at the regular output rate.
+	if cost != 4_100 {
+		t.Fatalf("CostMicros() = %d, want 4100", cost)
 	}
 }
 

--- a/backend/internal/meter/pricing.go
+++ b/backend/internal/meter/pricing.go
@@ -1,0 +1,380 @@
+package meter
+
+import (
+	"context"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+// PricingMatch is the auditable result of resolving a provider/model pair.
+type PricingMatch struct {
+	Price     Price
+	Key       string
+	Status    string // priced | estimated | free | missing | none
+	Source    string
+	MatchKind string // exact | provider_alias | canonical_model | provider | none
+	SourceURL string
+}
+
+// CostBreakdown stores nanodollar components. One token at $0.0028/M costs
+// 2.8 nanodollars, so nanos avoid the systematic all-zero rounding caused by
+// storing only integer microdollars per request.
+type CostBreakdown struct {
+	Pricing PricingMatch
+
+	InputCostNanos      int64
+	CachedCostNanos     int64
+	CacheWriteCostNanos int64
+	OutputCostNanos     int64
+	ReasoningCostNanos  int64
+	CostNanos           int64
+	CostMicros          int64
+	AvoidedCostNanos    int64
+	SavedCostNanos      int64
+
+	InputRatePerM      float64
+	CachedRatePerM     float64
+	CacheWriteRatePerM float64
+	OutputRatePerM     float64
+	ReasoningRatePerM  float64
+}
+
+func normalizeProvider(provider string) string {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	switch p {
+	case "codex", "openai-codex":
+		return "openai"
+	case "claude", "claude-code":
+		return "anthropic"
+	case "gemini-cli", "antigravity":
+		return "gemini"
+	case "cloudflare", "workers-ai":
+		return "cloudflare-ai"
+	default:
+		return p
+	}
+}
+
+func modelCandidates(model string) []string {
+	m := strings.TrimSpace(model)
+	out := []string{m}
+	for strings.Contains(m, "/") {
+		m = strings.TrimPrefix(m[strings.IndexByte(m, '/')+1:], "/")
+		out = append(out, m)
+	}
+	for _, suffix := range []string{"-xhigh-review", "-high-review", "-low-review", "-none-review", "-review", "-xhigh", "-high", "-low", "-none"} {
+		if strings.HasSuffix(strings.ToLower(m), suffix) {
+			out = append(out, m[:len(m)-len(suffix)])
+			break
+		}
+	}
+	return out
+}
+
+func modelFingerprint(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if i := strings.LastIndexByte(m, '/'); i >= 0 {
+		m = m[i+1:]
+	}
+	return strings.NewReplacer("-", "", "_", "", ".", "", " ", "").Replace(m)
+}
+
+func samePrice(a, b Price) bool {
+	return a.InputPerM == b.InputPerM && a.OutputPerM == b.OutputPerM &&
+		a.CachedInputPerM == b.CachedInputPerM && a.CacheWritePerM == b.CacheWritePerM &&
+		a.ReasoningPerM == b.ReasoningPerM && a.LongContextThreshold == b.LongContextThreshold &&
+		a.LongInputPerM == b.LongInputPerM && a.LongOutputPerM == b.LongOutputPerM &&
+		a.LongCachedInputPerM == b.LongCachedInputPerM &&
+		a.LongCacheWritePerM == b.LongCacheWritePerM && a.ExplicitFree == b.ExplicitFree
+}
+
+func canonicalSourcePriority(source string) int {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "official":
+		return 0
+	case "catalog":
+		return 1
+	case "custom":
+		return 2
+	case "retail_equivalent":
+		return 3
+	default:
+		return 4
+	}
+}
+
+func preferCanonicalPrice(candidateKey string, candidate Price, currentKey string, current Price) bool {
+	candidatePriority := canonicalSourcePriority(candidate.Source)
+	currentPriority := canonicalSourcePriority(current.Source)
+	if candidatePriority != currentPriority {
+		return candidatePriority < currentPriority
+	}
+	if candidate.Estimated != current.Estimated {
+		return !candidate.Estimated
+	}
+	return candidateKey < currentKey
+}
+
+// ResolvePrice never silently treats an unknown model as free. Cross-provider
+// canonical matches are allowed only when all matching catalog entries agree,
+// with deterministic provenance favoring the most authoritative source.
+func (m *Meter) ResolvePrice(provider, model string) PricingMatch {
+	m.pricingMu.RLock()
+	defer m.pricingMu.RUnlock()
+
+	rawProvider := strings.ToLower(strings.TrimSpace(provider))
+	canonicalProvider := normalizeProvider(provider)
+	candidates := modelCandidates(model)
+
+	for _, p := range []string{rawProvider, canonicalProvider} {
+		for _, candidate := range candidates {
+			if price, ok := m.modelPrices[p+"/"+candidate]; ok {
+				kind := "exact"
+				estimated := price.Estimated
+				if p != rawProvider {
+					kind, estimated = "provider_alias", true
+				}
+				return pricingMatch(p+"/"+candidate, price, kind, estimated)
+			}
+		}
+	}
+
+	fingerprints := map[string]struct{}{}
+	for _, candidate := range candidates {
+		fingerprints[modelFingerprint(candidate)] = struct{}{}
+	}
+	var found Price
+	foundKey := ""
+	for key, price := range m.modelPrices {
+		parts := strings.SplitN(key, "/", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if _, ok := fingerprints[modelFingerprint(parts[1])]; !ok {
+			continue
+		}
+		if foundKey == "" {
+			found, foundKey = price, key
+			continue
+		}
+		if !samePrice(found, price) {
+			return PricingMatch{Status: "missing", MatchKind: "none"}
+		}
+		if preferCanonicalPrice(key, price, foundKey, found) {
+			found, foundKey = price, key
+		}
+	}
+	if foundKey != "" {
+		return pricingMatch(foundKey, found, "canonical_model", true)
+	}
+
+	if price, ok := m.pricing[rawProvider]; ok && hasAnyRate(price) {
+		return pricingMatch(rawProvider, price, "provider", true)
+	}
+	if price, ok := m.pricing[canonicalProvider]; ok && hasAnyRate(price) {
+		return pricingMatch(canonicalProvider, price, "provider_alias", true)
+	}
+	return PricingMatch{Status: "missing", MatchKind: "none"}
+}
+
+func pricingMatch(key string, price Price, kind string, estimated bool) PricingMatch {
+	status := "priced"
+	if !hasAnyRate(price) {
+		if price.ExplicitFree {
+			status = "free"
+		} else {
+			status = "missing"
+		}
+	} else if estimated || price.Estimated {
+		status = "estimated"
+	}
+	source := price.Source
+	if source == "" {
+		source = "catalog"
+	}
+	return PricingMatch{Price: price, Key: key, Status: status, Source: source, MatchKind: kind, SourceURL: price.SourceURL}
+}
+
+func hasAnyRate(p Price) bool {
+	return p.InputPerM != 0 || p.OutputPerM != 0 || p.CachedInputPerM != 0 ||
+		p.CacheWritePerM != 0 || p.ReasoningPerM != 0 || p.LongInputPerM != 0 || p.LongOutputPerM != 0
+}
+
+func effectivePrice(p Price, promptTokens int) Price {
+	if p.LongContextThreshold <= 0 || promptTokens <= p.LongContextThreshold {
+		return p
+	}
+	if p.LongInputPerM > 0 {
+		p.InputPerM = p.LongInputPerM
+	}
+	if p.LongOutputPerM > 0 {
+		p.OutputPerM = p.LongOutputPerM
+	}
+	if p.LongCachedInputPerM > 0 {
+		p.CachedInputPerM = p.LongCachedInputPerM
+	}
+	if p.LongCacheWritePerM > 0 {
+		p.CacheWritePerM = p.LongCacheWritePerM
+	}
+	return p
+}
+
+func tokenCostNanos(tokens int, ratePerM float64) int64 {
+	if tokens <= 0 || ratePerM <= 0 {
+		return 0
+	}
+	return int64(math.Round(float64(tokens) * ratePerM * 1000))
+}
+
+func clampUsage(u core.Usage) core.Usage {
+	if u.PromptTokens < 0 {
+		u.PromptTokens = 0
+	}
+	if u.CompletionTokens < 0 {
+		u.CompletionTokens = 0
+	}
+	if u.CachedTokens < 0 {
+		u.CachedTokens = 0
+	}
+	if u.CacheWriteTokens < 0 {
+		u.CacheWriteTokens = 0
+	}
+	if u.ReasoningTokens < 0 {
+		u.ReasoningTokens = 0
+	}
+	if u.CachedTokens > u.PromptTokens {
+		u.CachedTokens = u.PromptTokens
+	}
+	remaining := u.PromptTokens - u.CachedTokens
+	if u.CacheWriteTokens > remaining {
+		u.CacheWriteTokens = remaining
+	}
+	if u.ReasoningTokens > u.CompletionTokens {
+		u.ReasoningTokens = u.CompletionTokens
+	}
+	u.TotalTokens = u.PromptTokens + u.CompletionTokens
+	return u
+}
+
+// CalculateCost prices one normalized usage snapshot. Reasoning is a subset of
+// completion, never an additional token class, which prevents double charging.
+func (m *Meter) CalculateCost(provider, model string, raw core.Usage, cacheHit bool, savedInputTokens int) CostBreakdown {
+	u := clampUsage(raw)
+	match := m.ResolvePrice(provider, model)
+	out := CostBreakdown{Pricing: match}
+	if match.Status == "missing" || match.Status == "none" {
+		return out
+	}
+	p := effectivePrice(match.Price, u.PromptTokens)
+	out.InputRatePerM = p.InputPerM
+	out.CachedRatePerM = p.CachedInputPerM
+	if out.CachedRatePerM == 0 {
+		out.CachedRatePerM = p.InputPerM
+	}
+	out.CacheWriteRatePerM = p.CacheWritePerM
+	if out.CacheWriteRatePerM == 0 {
+		out.CacheWriteRatePerM = p.InputPerM
+	}
+	out.OutputRatePerM = p.OutputPerM
+	out.ReasoningRatePerM = p.ReasoningPerM
+	if out.ReasoningRatePerM == 0 {
+		out.ReasoningRatePerM = p.OutputPerM
+	}
+
+	standardInput := u.PromptTokens - u.CachedTokens - u.CacheWriteTokens
+	normalOutput := u.CompletionTokens - u.ReasoningTokens
+	out.InputCostNanos = tokenCostNanos(standardInput, out.InputRatePerM)
+	out.CachedCostNanos = tokenCostNanos(u.CachedTokens, out.CachedRatePerM)
+	out.CacheWriteCostNanos = tokenCostNanos(u.CacheWriteTokens, out.CacheWriteRatePerM)
+	out.OutputCostNanos = tokenCostNanos(normalOutput, out.OutputRatePerM)
+	out.ReasoningCostNanos = tokenCostNanos(u.ReasoningTokens, out.ReasoningRatePerM)
+	retail := out.InputCostNanos + out.CachedCostNanos + out.CacheWriteCostNanos + out.OutputCostNanos + out.ReasoningCostNanos
+	out.SavedCostNanos = tokenCostNanos(savedInputTokens, out.InputRatePerM)
+	if cacheHit {
+		out.AvoidedCostNanos = retail
+	} else {
+		out.CostNanos = retail
+		out.CostMicros = int64(math.Round(float64(retail) / 1000))
+	}
+	return out
+}
+
+// ReplacePrices atomically refreshes catalog/custom prices for subsequent
+// requests. Existing rows retain their immutable snapshots.
+func (m *Meter) ReplacePrices(providerPrices, modelPrices map[string]Price) {
+	if providerPrices == nil {
+		providerPrices = map[string]Price{}
+	}
+	if modelPrices == nil {
+		modelPrices = map[string]Price{}
+	}
+	m.pricingMu.Lock()
+	m.pricing, m.modelPrices = providerPrices, modelPrices
+	m.pricingMu.Unlock()
+}
+
+type pricingBackfillStore interface {
+	ListUnpriced(context.Context, time.Time, string, int) ([]store.UnpricedUsageRecord, error)
+	UpdateUsagePricing(context.Context, string, store.UsagePricingUpdate) error
+}
+
+// BackfillUnpriced estimates deterministic legacy zero-cost rows in stable
+// (created_at,id) order. Historical rates are explicitly marked as backfilled
+// estimates so analytics can recover missing spend without retroactively
+// changing hard-budget enforcement.
+func (m *Meter) BackfillUnpriced(ctx context.Context) (int, error) {
+	repo, ok := m.usage.(pricingBackfillStore)
+	if !ok {
+		return 0, nil
+	}
+	updated := 0
+	cursorTime := time.Time{}
+	cursorID := ""
+	asOf := time.Now().UTC()
+	for {
+		rows, err := repo.ListUnpriced(ctx, cursorTime, cursorID, 1000)
+		if err != nil {
+			return updated, err
+		}
+		if len(rows) == 0 {
+			return updated, nil
+		}
+		for _, row := range rows {
+			cursorTime, cursorID = row.CreatedAt, row.ID
+			usage := core.Usage{PromptTokens: row.PromptTokens, CompletionTokens: row.CompletionTokens,
+				CachedTokens: row.CachedTokens, CacheWriteTokens: row.CacheWriteTokens, ReasoningTokens: row.ReasoningTokens}
+			cost := m.CalculateCost(row.Provider, row.Model, usage, row.CacheHit, row.SlimTokensSaved+row.HeadroomTokensSaved)
+			if cost.Pricing.Status == "missing" || cost.Pricing.Status == "none" {
+				continue
+			}
+			pricingStatus := cost.Pricing.Status
+			if pricingStatus == "priced" {
+				pricingStatus = "estimated"
+			}
+			update := store.UsagePricingUpdate{
+				CostMicros: cost.CostMicros, CostNanos: cost.CostNanos,
+				InputCostNanos: cost.InputCostNanos, CachedCostNanos: cost.CachedCostNanos,
+				CacheWriteCostNanos: cost.CacheWriteCostNanos, OutputCostNanos: cost.OutputCostNanos,
+				ReasoningCostNanos: cost.ReasoningCostNanos, AvoidedCostNanos: cost.AvoidedCostNanos,
+				SavedCostNanos: cost.SavedCostNanos, PricingStatus: pricingStatus,
+				PricingSource: cost.Pricing.Source, PricingKey: cost.Pricing.Key,
+				PricingMatchKind: cost.Pricing.MatchKind, PricingSourceURL: cost.Pricing.SourceURL,
+				PricingAsOf: &asOf, PricingBackfilled: true,
+				InputRatePerM: cost.InputRatePerM, CachedRatePerM: cost.CachedRatePerM,
+				CacheWriteRatePerM: cost.CacheWriteRatePerM, OutputRatePerM: cost.OutputRatePerM,
+				ReasoningRatePerM: cost.ReasoningRatePerM,
+			}
+			if err := repo.UpdateUsagePricing(ctx, row.ID, update); err != nil {
+				return updated, err
+			}
+			updated++
+		}
+		if len(rows) < 1000 {
+			return updated, nil
+		}
+	}
+}

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -178,14 +178,17 @@ type Result struct {
 
 // Chat runs a non-streaming request through the full pipeline with fallback.
 func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options) (*Result, error) {
+	requestStarted := time.Now()
 	if err := p.preflight(ctx, req, opts); err != nil {
 		p.log.Debug("preflight rejected", "err", err)
+		p.recordLocalTerminal(ctx, req.Metadata, opts.Targets, err, requestStarted)
 		return nil, err
 	}
 	release, err := p.acquireLimit(ctx, req, opts)
 	if err != nil {
 		scope := budget.Scope{TenantID: req.Metadata.TenantID, ProjectID: req.Metadata.ProjectID, APIKeyID: req.Metadata.APIKeyID}
 		p.budgetRelease(scope)
+		p.recordLocalTerminal(ctx, req.Metadata, opts.Targets, err, requestStarted)
 		return nil, err
 	}
 	defer release(0)
@@ -198,7 +201,9 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 		p.log.Debug("guardrails blocked inbound", "reason", gres.Reason)
 		scope := budget.Scope{TenantID: req.Metadata.TenantID, ProjectID: req.Metadata.ProjectID, APIKeyID: req.Metadata.APIKeyID}
 		p.budgetRelease(scope)
-		return nil, &core.ProviderError{Kind: core.ErrPolicyBlocked, Message: gres.Reason}
+		err := &core.ProviderError{Kind: core.ErrPolicyBlocked, Message: gres.Reason}
+		p.recordLocalTerminal(ctx, req.Metadata, opts.Targets, err, requestStarted)
+		return nil, err
 	}
 
 	// Semantic cache lookup before any token-saving transform mutates the
@@ -207,24 +212,20 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 	vec := p.embedPrompt(ctx, req)
 	if hit, ok := p.cacheLookup(ctx, vec); ok {
 		p.log.Debug("cache hit, skipping upstream")
-		// Release budget reservation — cache hits cost nothing.
 		scope := budget.Scope{TenantID: req.Metadata.TenantID, ProjectID: req.Metadata.ProjectID, APIKeyID: req.Metadata.APIKeyID}
 		p.budgetRelease(scope)
-		// Record cache hit for usage visibility.
-		if p.meter != nil {
-			p.meter.Record(ctx, meter.Event{
-				TenantID:  req.Metadata.TenantID,
-				ProjectID: req.Metadata.ProjectID,
-				APIKeyID:  req.Metadata.APIKeyID,
-				Provider:  "cache",
-				Model:     hit.Model,
-				CacheHit:  true,
-			})
+		attempt := attemptForTargets(opts.Targets)
+		if hit.Model != "" {
+			attempt.Target.Model = hit.Model
 		}
-		if p.metrics != nil {
-			p.metrics.RecordCache(true)
-		}
-		return &Result{Response: hit, Provider: "cache", Model: hit.Model, CacheHit: true}, nil
+		usage := hit.Usage
+		usage.Source = core.UsageSourceCache
+		cost := p.recordOutcomeWithTTFT(ctx, req.Metadata, attempt, usage, "cache_hit", "", true,
+			0, time.Since(requestStarted), 0, nil)
+		return &Result{
+			Response: hit, Provider: attempt.Target.Provider, Model: attempt.Target.Model,
+			CostMicros: cost, CacheHit: true,
+		}, nil
 	}
 	if p.metrics != nil && p.cache != nil && p.cache.Enabled() {
 		p.metrics.RecordCache(false)
@@ -244,14 +245,18 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 	attempts, err := p.planWithCooldownRetry(ctx, req.Metadata.TenantID, opts.Targets, required, opts.PlanOpts)
 	if err != nil {
 		p.log.Debug("dispatcher plan failed", "err", err)
+		p.recordLocalTerminal(ctx, req.Metadata, opts.Targets, err, requestStarted)
 		return nil, err
 	}
 	p.log.Debug("dispatcher planned", "attempts", len(attempts), "required", required)
 
 	scope := budget.Scope{TenantID: req.Metadata.TenantID, ProjectID: req.Metadata.ProjectID, APIKeyID: req.Metadata.APIKeyID}
 	var lastErr error
+	var lastAttempt dispatch.Attempt
+	var lastLatency time.Duration
 	fellBack := false // tracks whether the current request triggered ≥1 fallback
 	for i, attempt := range attempts {
+		lastAttempt = attempt
 		started := time.Now()
 		p.log.Debug("attempt start", "i", i, "provider", attempt.Target.Provider,
 			"model", attempt.Target.Model, "account", attempt.Account.ID)
@@ -318,6 +323,10 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 				callErr = sErr
 			}
 		}
+		// Include the full transparent stream retry/drain in the upstream attempt
+		// duration, including terminal stream-open and drain failures.
+		latency = time.Since(started)
+		lastLatency = latency
 
 		if callErr != nil {
 			pe := core.AsProviderError(callErr)
@@ -329,7 +338,9 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 			p.recordFailureTelemetry(req.Metadata, attempt, pe, latency, pe.Fallbackable())
 			if !pe.Fallbackable() {
 				p.log.Debug("attempt not fallbackable, aborting", "kind", pe.Kind)
-				p.budgetRelease(scope)
+				pe, cost := p.recordAttemptTerminal(ctx, req.Metadata, attempt, pe, core.Usage{},
+					latency, time.Since(requestStarted), 0, nil, fellBack)
+				p.budgetConfirm(scope, cost)
 				return nil, pe
 			}
 			if p.metrics != nil {
@@ -349,12 +360,21 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 		// still costs the user but never returns the leaked content.
 		if gres := p.guardrails.Outbound(ctx, req, resp); gres.Action == guardrails.ActionBlock {
 			p.log.Debug("guardrails blocked outbound", "reason", gres.Reason)
-			cost := p.record(ctx, req.Metadata, attempt, resp.Usage, false, latency, save, fellBack)
+			blockErr := &core.ProviderError{
+				Kind: core.ErrPolicyBlocked, Provider: attempt.Target.Provider,
+				Model: attempt.Target.Model, Message: gres.Reason,
+			}
+			cost := p.recordOutcomeWithTTFT(ctx, req.Metadata, attempt, resp.Usage,
+				"blocked", string(blockErr.Kind), false, latency, time.Since(requestStarted), 0, save)
+			// The policy blocked delivery, but the provider itself completed
+			// successfully and should remain healthy.
+			p.recordSuccessTelemetry(req.Metadata, attempt, resp.Usage, latency, 0, fellBack, cost)
 			p.budgetConfirm(scope, cost)
-			return nil, &core.ProviderError{Kind: core.ErrPolicyBlocked, Message: gres.Reason}
+			return nil, blockErr
 		}
 
-		cost := p.record(ctx, req.Metadata, attempt, resp.Usage, false, latency, save, fellBack)
+		cost := p.recordWithEndToEnd(ctx, req.Metadata, attempt, resp.Usage, false,
+			latency, time.Since(requestStarted), save, fellBack)
 		p.cacheStore(ctx, vec, resp)
 		// Confirm budget reservation — usage is now recorded in DB.
 		p.budgetConfirm(scope, cost)
@@ -375,9 +395,13 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 	if lastErr == nil {
 		lastErr = &core.ProviderError{Kind: core.ErrInternal, Message: "pipeline: no attempts executed"}
 	}
-	p.recordFinalFailureTelemetry(req.Metadata, lastErr, fellBack)
-	p.budgetRelease(scope)
-	return nil, lastErr
+	if lastAttempt.Target.Provider == "" && lastAttempt.Target.Model == "" {
+		lastAttempt = attemptForTargets(opts.Targets)
+	}
+	pe, cost := p.recordAttemptTerminal(ctx, req.Metadata, lastAttempt, lastErr, core.Usage{},
+		lastLatency, time.Since(requestStarted), 0, nil, fellBack)
+	p.budgetConfirm(scope, cost)
+	return nil, pe
 }
 
 // StreamResult is delivered before chunks start flowing, identifying the chosen
@@ -416,14 +440,17 @@ const maxRateLimitRetries = 3
 // expire) and retries up to maxRateLimitRetries times. This prevents transient
 // 429s from being fatal when only a single account is configured.
 func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Options) (*StreamResult, error) {
+	requestStarted := time.Now()
 	if err := p.preflight(ctx, req, opts); err != nil {
 		p.log.Debug("stream preflight rejected", "err", err)
+		p.recordLocalTerminal(ctx, req.Metadata, opts.Targets, err, requestStarted)
 		return nil, err
 	}
 	release, err := p.acquireLimit(ctx, req, opts)
 	if err != nil {
 		scope := budget.Scope{TenantID: req.Metadata.TenantID, ProjectID: req.Metadata.ProjectID, APIKeyID: req.Metadata.APIKeyID}
 		p.budgetRelease(scope)
+		p.recordLocalTerminal(ctx, req.Metadata, opts.Targets, err, requestStarted)
 		return nil, err
 	}
 
@@ -434,7 +461,9 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 	if gres := p.guardrails.Inbound(ctx, req); gres.Action == guardrails.ActionBlock {
 		p.log.Debug("guardrails blocked inbound stream", "reason", gres.Reason)
 		release(0)
-		return nil, &core.ProviderError{Kind: core.ErrPolicyBlocked, Message: gres.Reason}
+		err := &core.ProviderError{Kind: core.ErrPolicyBlocked, Message: gres.Reason}
+		p.recordLocalTerminal(ctx, req.Metadata, opts.Targets, err, requestStarted)
+		return nil, err
 	}
 
 	slimStats, hrStats := p.applyTokenSaving(ctx, req, opts)
@@ -450,6 +479,7 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 		p.log.Debug("stream dispatcher plan failed", "err", err)
 		release(0)
 		p.budgetRelease(scope)
+		p.recordLocalTerminal(ctx, req.Metadata, opts.Targets, err, requestStarted)
 		return nil, err
 	}
 	p.log.Debug("stream dispatcher planned", "attempts", len(attempts))
@@ -457,19 +487,23 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 	// Outer rate-limit retry loop: re-plan and retry when all attempts hit 429.
 	rlRetries := 0
 	for {
-		sr, sErr, budgetReleased := p.streamExec(ctx, req, opts, attempts, slimStats, save, required, scope, release)
+		sr, sErr, budgetReleased, lastAttempt, lastLatency, fellBack := p.streamExec(
+			ctx, req, opts, attempts, slimStats, save, required, scope, release, requestStarted)
 		if sErr == nil {
 			return sr, nil
 		}
 
 		// Only retry on rate-limit errors that are still fallbackable.
-		pe := core.AsProviderError(sErr)
+		pe := providerErrorForAttempt(sErr, lastAttempt)
 		if pe.Kind != core.ErrRateLimit || !pe.Fallbackable() || rlRetries >= maxRateLimitRetries {
 			release(0)
 			if !budgetReleased {
 				p.budgetRelease(scope)
 			}
-			return nil, sErr
+			pe, cost := p.recordAttemptTerminal(ctx, req.Metadata, lastAttempt, pe, core.Usage{},
+				lastLatency, time.Since(requestStarted), 0, nil, fellBack || rlRetries > 0)
+			p.budgetConfirm(scope, cost)
+			return nil, pe
 		}
 		rlRetries++
 		// Wait for the cooldown to expire before re-planning. The dispatcher
@@ -484,11 +518,18 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 			if !budgetReleased {
 				p.budgetRelease(scope)
 			}
+			status, errorKind := terminalStatusAndKind(ctx.Err())
+			cost := p.recordOutcomeWithTTFT(context.WithoutCancel(ctx), req.Metadata, lastAttempt,
+				core.Usage{}, status, errorKind, false, lastLatency, time.Since(requestStarted), 0, nil)
+			p.budgetConfirm(scope, cost)
 			return nil, ctx.Err()
 		}
 		// Re-reserve budget if it was released by streamExec (not-fallbackable path).
 		if budgetReleased {
 			if rerr := p.budget.Reserve(ctx, scope, 0); rerr != nil {
+				status, errorKind := terminalStatusAndKind(rerr)
+				p.recordOutcomeWithTTFT(context.WithoutCancel(ctx), req.Metadata, lastAttempt, core.Usage{},
+					status, errorKind, false, lastLatency, time.Since(requestStarted), 0, nil)
 				return nil, rerr
 			}
 		}
@@ -496,7 +537,10 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 		if err != nil {
 			p.log.Debug("stream re-plan after rate-limit failed", "err", err)
 			p.budgetRelease(scope)
-			return nil, sErr
+			pe, cost := p.recordAttemptTerminal(ctx, req.Metadata, lastAttempt, sErr, core.Usage{},
+				lastLatency, time.Since(requestStarted), 0, nil, true)
+			p.budgetConfirm(scope, cost)
+			return nil, pe
 		}
 		p.log.Debug("stream re-planned after rate-limit", "attempts", len(attempts))
 	} // end outer rate-limit retry loop
@@ -508,11 +552,15 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 // released inside (non-fallbackable errors).
 func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts Options,
 	attempts []dispatch.Attempt, slimStats *slimmer.Stats, save *saveState,
-	required core.CapabilitySet, scope budget.Scope, release limits.ReleaseFunc) (*StreamResult, error, bool) {
+	required core.CapabilitySet, scope budget.Scope, release limits.ReleaseFunc,
+	requestStarted time.Time) (*StreamResult, error, bool, dispatch.Attempt, time.Duration, bool) {
 
 	var lastErr error
+	var lastAttempt dispatch.Attempt
+	var lastLatency time.Duration
 	fellBack := false // tracks whether the current request triggered ≥1 fallback
 	for i, attempt := range attempts {
+		lastAttempt = attempt
 		attemptReq := cloneForAttempt(req, attempt.Target.Model)
 		started := time.Now()
 		p.log.Debug("stream attempt start", "i", i, "provider", attempt.Target.Provider,
@@ -575,11 +623,13 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 					if p.metrics != nil {
 						p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
 					}
-					p.recordFailureTelemetry(req.Metadata, attempt, pe, time.Since(started), pe.Fallbackable())
+					attemptLatency := time.Since(started)
+					lastLatency = attemptLatency
+					p.recordFailureTelemetry(req.Metadata, attempt, pe, attemptLatency, pe.Fallbackable())
 					if !pe.Fallbackable() {
 						release(0)
 						p.budgetRelease(scope)
-						return nil, pe, true
+						return nil, pe, true, attempt, attemptLatency, fellBack
 					}
 					if p.metrics != nil {
 						p.metrics.RecordFallback(string(pe.Kind))
@@ -619,20 +669,26 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 					completeOnce.Do(func() {
 						defer release(0)
 						recordCtx := context.WithoutCancel(ctx)
+						usage := capturedStreamUsage(req, capture.Bytes())
 						if errors.Is(streamErr, context.Canceled) {
-							p.budgetRelease(budgetScope)
+							usage = partialStreamUsage(req, usage, 0)
+							status, errorKind := terminalStatusAndKind(streamErr)
+							cost := p.recordOutcomeWithTTFT(recordCtx, meta, acc, usage, status, errorKind, false,
+								time.Since(started), time.Since(requestStarted), ttft, saveCopy)
+							p.budgetConfirm(budgetScope, cost)
 							return
 						}
 						if streamErr != nil {
-							pe := p.recordTerminalStreamFailure(recordCtx, meta, acc, streamErr, started, fellBack, budgetScope)
+							pe := p.recordTerminalStreamFailure(recordCtx, req, meta, acc, streamErr,
+								started, requestStarted, usage, 0, ttft, saveCopy, fellBack, budgetScope)
 							p.log.Warn("direct stream terminated with upstream error",
 								"provider", acc.Target.Provider, "model", acc.Target.Model, "kind", pe.Kind)
 							return
 						}
 
 						totalLatency := time.Since(started)
-						usage := extractUsageFromStream(capture.Bytes())
-						cost := p.recordWithTTFT(recordCtx, meta, acc, usage, false, totalLatency, ttft, saveCopy, fellBack)
+						cost := p.recordWithTTFT(recordCtx, meta, acc, usage, false,
+							totalLatency, time.Since(requestStarted), ttft, saveCopy, fellBack)
 						p.budgetConfirm(budgetScope, cost)
 					})
 				}
@@ -642,7 +698,7 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 					Model:              attempt.Target.Model,
 					AccountID:          attempt.Account.ID,
 					DirectCompleteFunc: completeFunc,
-				}, nil, false
+				}, nil, false, attempt, 0, fellBack
 			}
 		}
 
@@ -657,12 +713,14 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 			if p.metrics != nil {
 				p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
 			}
-			p.recordFailureTelemetry(req.Metadata, attempt, pe, time.Since(started), pe.Fallbackable())
+			attemptLatency := time.Since(started)
+			lastLatency = attemptLatency
+			p.recordFailureTelemetry(req.Metadata, attempt, pe, attemptLatency, pe.Fallbackable())
 			if !pe.Fallbackable() {
 				p.log.Debug("stream attempt not fallbackable, aborting", "kind", pe.Kind)
 				release(0)
 				p.budgetRelease(scope)
-				return nil, pe, true
+				return nil, pe, true, attempt, attemptLatency, fellBack
 			}
 			if p.metrics != nil {
 				p.metrics.RecordFallback(string(pe.Kind))
@@ -682,23 +740,26 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 		out := make(chan core.StreamChunk, 16)
 		meta := req.Metadata
 		acc := attempt
-		go p.pumpStream(ctx, req, upstream, out, meta, acc, started, &ttft, save, scope, release, fellBack, cancelUpstream)
+		go p.pumpStream(ctx, req, upstream, out, meta, acc, started, requestStarted,
+			&ttft, save, scope, release, fellBack, cancelUpstream)
 
 		return &StreamResult{
 			Chunks:    out,
 			Provider:  attempt.Target.Provider,
 			Model:     attempt.Target.Model,
 			AccountID: attempt.Account.ID,
-		}, nil, false
+		}, nil, false, attempt, 0, fellBack
 	}
 
 	if lastErr == nil {
 		lastErr = &core.ProviderError{Kind: core.ErrInternal, Message: "pipeline: no attempts executed"}
 	}
-	p.recordFinalFailureTelemetry(req.Metadata, lastErr, fellBack)
+	if lastAttempt.Target.Provider == "" && lastAttempt.Target.Model == "" {
+		lastAttempt = attemptForTargets(opts.Targets)
+	}
 	release(0)
 	p.budgetRelease(scope)
-	return nil, lastErr, true
+	return nil, lastErr, true, lastAttempt, lastLatency, fellBack
 }
 
 // pumpStream forwards chunks to the client channel while capturing usage for
@@ -715,7 +776,9 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 // tail before forwarding; on a Block decision the stream is cancelled and an
 // error chunk is delivered to the client.
 func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-chan core.StreamChunk, out chan<- core.StreamChunk,
-	meta core.RequestMetadata, attempt dispatch.Attempt, started time.Time, ttft *time.Duration, save *saveState, scope budget.Scope, release limits.ReleaseFunc, fellBack bool, cancelUpstream context.CancelFunc) {
+	meta core.RequestMetadata, attempt dispatch.Attempt, attemptStarted, requestStarted time.Time,
+	ttft *time.Duration, save *saveState, scope budget.Scope, release limits.ReleaseFunc,
+	fellBack bool, cancelUpstream context.CancelFunc) {
 	defer close(out)
 	defer release(0)
 	defer cancelUpstream()
@@ -751,9 +814,17 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 	}
 	defer stopStall()
 
+	var usage core.Usage
+	var sawUsage bool
+	var completionChars int
+
 	settleClientCancellation := func() {
 		cancelUpstream()
-		p.budgetRelease(scope)
+		usage = partialStreamUsage(req, usage, completionChars)
+		status, errorKind := terminalStatusAndKind(context.Canceled)
+		cost := p.recordOutcomeWithTTFT(context.WithoutCancel(ctx), meta, attempt, usage,
+			status, errorKind, false, time.Since(attemptStarted), time.Since(requestStarted), *ttft, save)
+		p.budgetConfirm(scope, cost)
 	}
 	settleStall := func() {
 		if ctx.Err() != nil {
@@ -765,7 +836,8 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 			Kind: core.ErrTimeout, Provider: attempt.Target.Provider, Model: attempt.Target.Model,
 			Message: "stream stall: no data received for " + stallTimeout.String(),
 		}
-		pe := p.recordTerminalStreamFailure(ctx, meta, attempt, stallErr, started, fellBack, scope)
+		pe := p.recordTerminalStreamFailure(ctx, req, meta, attempt, stallErr,
+			attemptStarted, requestStarted, usage, completionChars, *ttft, save, fellBack, scope)
 		select {
 		case out <- core.StreamChunk{Type: core.ChunkError, Err: pe}:
 		case <-ctx.Done():
@@ -782,13 +854,10 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 	const chunkScanWindow = 256
 	var streamBuf strings.Builder
 
-	var usage core.Usage
 	// sawUsage tracks whether the upstream ever emitted a usage event with real
 	// token counts. completionChars accumulates the assistant's streamed output
-	// (text + reasoning) length so we can synthesize a usage estimate when the
-	// client requested include_usage but the provider reported nothing.
-	var sawUsage bool
-	var completionChars int
+	// (text + reasoning) length so we can synthesize an explicit estimate when
+	// the provider reported nothing.
 	for {
 		select {
 		case chunk, ok := <-in:
@@ -798,27 +867,23 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 					return
 				}
 				stopStall()
-				// Upstream closed — stream complete.
-				// If the client opted into a usage event (stream_options.
-				// include_usage) but the provider never sent one, synthesize an
-				// estimate so the client still receives a final usage event.
-				// Mirrors the estimateUsage/addBufferToUsage behavior.
-				if req.IncludeUsage && !sawUsage {
+				// Always synthesize an auditable estimate when the provider omits
+				// usage. Only emit it to the client when include_usage was requested.
+				if !sawUsage {
 					est := estimateStreamUsage(req, completionChars)
-					if est.TotalTokens > 0 {
+					usage = est
+					if req.IncludeUsage && est.TotalTokens > 0 {
 						select {
 						case out <- core.StreamChunk{Type: core.ChunkUsage, Usage: &est}:
-							usage = est
 						case <-ctx.Done():
 							settleClientCancellation()
 							return
 						}
 					}
 				}
-				// Record actual total upstream duration as latency; TTFT is
-				// stored separately in ttft_ms by recordWithTTFT.
-				totalLatency := time.Since(started)
-				cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, totalLatency, *ttft, save, fellBack)
+				upstreamLatency := time.Since(attemptStarted)
+				cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, upstreamLatency,
+					time.Since(requestStarted), *ttft, save, fellBack)
 				p.budgetConfirm(scope, cost)
 				return
 			}
@@ -832,7 +897,8 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 				if streamErr == nil {
 					streamErr = &core.ProviderError{Kind: core.ErrUpstream, Message: "provider stream failed"}
 				}
-				pe := p.recordTerminalStreamFailure(ctx, meta, attempt, streamErr, started, fellBack, scope)
+				pe := p.recordTerminalStreamFailure(ctx, req, meta, attempt, streamErr,
+					attemptStarted, requestStarted, usage, completionChars, *ttft, save, fellBack, scope)
 				chunk.Err = pe
 				select {
 				case out <- chunk:
@@ -877,8 +943,12 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 							return
 						}
 						cancelUpstream()
-						totalLatency := time.Since(started)
-						cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, totalLatency, *ttft, save, fellBack)
+						blockedUsage := partialStreamUsage(req, usage, completionChars)
+						upstreamLatency := time.Since(attemptStarted)
+						cost := p.recordOutcomeWithTTFT(context.WithoutCancel(ctx), meta, attempt, blockedUsage,
+							"blocked", string(core.ErrPolicyBlocked), false, upstreamLatency,
+							time.Since(requestStarted), *ttft, save)
+						p.recordSuccessTelemetry(meta, attempt, blockedUsage, upstreamLatency, *ttft, fellBack, cost)
 						p.budgetConfirm(scope, cost)
 						return
 					}
@@ -919,6 +989,7 @@ func estimateStreamUsage(req *core.ChatRequest, completionChars int) core.Usage 
 		PromptTokens:     prompt,
 		CompletionTokens: completion,
 		TotalTokens:      prompt + completion,
+		Source:           core.UsageSourceEstimated,
 	}
 }
 
@@ -944,6 +1015,12 @@ func mergeUsage(old, new core.Usage) core.Usage {
 	}
 	if new.ReasoningTokens != 0 {
 		old.ReasoningTokens = new.ReasoningTokens
+	}
+	if new.Source != "" {
+		old.Source = new.Source
+	}
+	if old.PromptTokens+old.CompletionTokens > 0 {
+		old.TotalTokens = old.PromptTokens + old.CompletionTokens
 	}
 	return old
 }
@@ -1205,10 +1282,17 @@ func buildSaveState(stats *slimmer.Stats, hr *headroom.Stats, opts Options) *sav
 	return save
 }
 
-// record meters a completed attempt; failures to record are logged, not fatal.
+// record retains the original internal compatibility signature; callers that
+// know the full request duration use recordWithEndToEnd.
 func (p *Pipeline) record(ctx context.Context, meta core.RequestMetadata, attempt dispatch.Attempt,
-	usage core.Usage, cacheHit bool, latency time.Duration, save *saveState, fellBack bool) int64 {
-	return p.recordWithTTFT(ctx, meta, attempt, usage, cacheHit, latency, 0, save, fellBack)
+	usage core.Usage, cacheHit bool, upstreamLatency time.Duration, save *saveState, fellBack bool) int64 {
+	return p.recordWithTTFT(ctx, meta, attempt, usage, cacheHit, upstreamLatency, upstreamLatency, 0, save, fellBack)
+}
+
+func (p *Pipeline) recordWithEndToEnd(ctx context.Context, meta core.RequestMetadata, attempt dispatch.Attempt,
+	usage core.Usage, cacheHit bool, upstreamLatency, endToEndLatency time.Duration,
+	save *saveState, fellBack bool) int64 {
+	return p.recordWithTTFT(ctx, meta, attempt, usage, cacheHit, upstreamLatency, endToEndLatency, 0, save, fellBack)
 }
 
 // recordSuccessTelemetry emits a best-effort health telemetry event for a
@@ -1216,7 +1300,7 @@ func (p *Pipeline) record(ctx context.Context, meta core.RequestMetadata, attemp
 // at least one fallback before succeeding, so the chain-impact view computes
 // an accurate fallback rate per request (not per attempt).
 func (p *Pipeline) recordSuccessTelemetry(meta core.RequestMetadata, attempt dispatch.Attempt,
-	usage core.Usage, latency, ttft time.Duration, fellBack bool) {
+	usage core.Usage, latency, ttft time.Duration, fellBack bool, costMicros int64) {
 	if p.telemetry == nil {
 		return
 	}
@@ -1231,34 +1315,32 @@ func (p *Pipeline) recordSuccessTelemetry(meta core.RequestMetadata, attempt dis
 		TTFTMs:            int(ttft.Milliseconds()),
 		InputTokens:       usage.PromptTokens,
 		OutputTokens:      usage.CompletionTokens,
+		CostMicroUSD:      costMicros,
 		ChainID:           meta.ChainID,
 		FallbackTriggered: fellBack,
 	}
 	p.telemetry.Record(ev)
 }
 
-// recordTerminalStreamFailure updates routing cooldowns, metrics, health, and
-// budget state when an upstream fails after response headers were committed.
-// At that point fallback is no longer possible, so the attempt is also the
-// request's final failure.
-func (p *Pipeline) recordTerminalStreamFailure(ctx context.Context, meta core.RequestMetadata,
-	attempt dispatch.Attempt, streamErr error, started time.Time, fellBack bool, scope budget.Scope) *core.ProviderError {
-	pe := core.AsProviderError(streamErr)
-	peCopy := *pe
-	pe = &peCopy
-	if pe.Provider == "" {
-		pe.Provider = attempt.Target.Provider
-	}
-	if pe.Model == "" {
-		pe.Model = attempt.Target.Model
-	}
+// recordTerminalStreamFailure updates routing cooldowns, metrics, health, usage,
+// and budget state when an upstream fails after response headers were committed.
+// Partial provider usage is retained; if absent, input/output are explicitly
+// estimated from the canonical request and streamed text seen so far.
+func (p *Pipeline) recordTerminalStreamFailure(ctx context.Context, req *core.ChatRequest,
+	meta core.RequestMetadata, attempt dispatch.Attempt, streamErr error,
+	attemptStarted, requestStarted time.Time, usage core.Usage, completionChars int,
+	ttft time.Duration, save *saveState, fellBack bool, scope budget.Scope) *core.ProviderError {
+	pe := providerErrorForAttempt(streamErr, attempt)
 	p.dispatcher.NoteFailure(context.WithoutCancel(ctx), attempt.Account.ID, pe)
 	if p.metrics != nil {
 		p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
 	}
-	p.recordFailureTelemetry(meta, attempt, pe, time.Since(started), false)
-	p.recordFinalFailureTelemetry(meta, pe, fellBack)
-	p.budgetRelease(scope)
+	upstreamLatency := time.Since(attemptStarted)
+	p.recordFailureTelemetry(meta, attempt, pe, upstreamLatency, false)
+	usage = partialStreamUsage(req, usage, completionChars)
+	pe, cost := p.recordAttemptTerminal(ctx, meta, attempt, pe, usage, upstreamLatency,
+		time.Since(requestStarted), ttft, save, fellBack)
+	p.budgetConfirm(scope, cost)
 	return pe
 }
 
@@ -1290,7 +1372,8 @@ func (p *Pipeline) recordFailureTelemetry(meta core.RequestMetadata, attempt dis
 // recordFinalFailureTelemetry emits a best-effort health telemetry event when
 // all attempts in a chain have failed, so the chain-impact view can count
 // final failures (requests lost after every fallback).
-func (p *Pipeline) recordFinalFailureTelemetry(meta core.RequestMetadata, lastErr error, fellBack bool) {
+func (p *Pipeline) recordFinalFailureTelemetry(meta core.RequestMetadata, attempt dispatch.Attempt,
+	lastErr error, fellBack bool) {
 	if p.telemetry == nil || lastErr == nil {
 		return
 	}
@@ -1298,11 +1381,19 @@ func (p *Pipeline) recordFinalFailureTelemetry(meta core.RequestMetadata, lastEr
 	if pe == nil {
 		pe = core.AsProviderError(lastErr)
 	}
+	provider, model := attempt.Target.Provider, attempt.Target.Model
+	if provider == "" {
+		provider = pe.Provider
+	}
+	if model == "" {
+		model = pe.Model
+	}
 	ev := health.ProviderTelemetryEvent{
 		Timestamp:         time.Now(),
-		Provider:          pe.Provider,
-		Model:             pe.Model,
-		Capability:        capabilityOf(pe.Provider, pe.Model),
+		Provider:          provider,
+		ProviderAccountID: attempt.Account.ID,
+		Model:             model,
+		Capability:        capabilityOf(provider, model),
 		Status:            "failed",
 		HTTPStatus:        pe.StatusCode,
 		ErrorType:         health.ClassifyError(pe),
@@ -1314,6 +1405,72 @@ func (p *Pipeline) recordFinalFailureTelemetry(meta core.RequestMetadata, lastEr
 	p.telemetry.Record(ev)
 }
 
+func terminalStatusAndKind(err error) (string, string) {
+	if errors.Is(err, context.Canceled) {
+		return "cancelled", "cancelled"
+	}
+	pe := core.AsProviderError(err)
+	if pe != nil && pe.Kind == core.ErrPolicyBlocked {
+		return "blocked", string(pe.Kind)
+	}
+	if pe != nil {
+		return "failed", string(pe.Kind)
+	}
+	return "failed", "internal"
+}
+
+func providerErrorForAttempt(err error, attempt dispatch.Attempt) *core.ProviderError {
+	if err == nil {
+		err = &core.ProviderError{Kind: core.ErrInternal, Message: "request failed"}
+	}
+	pe := core.AsProviderError(err)
+	copy := *pe
+	pe = &copy
+	if pe.Provider == "" {
+		pe.Provider = attempt.Target.Provider
+	}
+	if pe.Model == "" {
+		pe.Model = attempt.Target.Model
+	}
+	return pe
+}
+
+func attemptForTargets(targets []dispatch.Target) dispatch.Attempt {
+	provider, model := firstTarget(targets)
+	return dispatch.Attempt{Target: dispatch.Target{Provider: provider, Model: model}}
+}
+
+// recordLocalTerminal records requests rejected before an upstream attempt
+// exists (limits, budgets, policy, planning, or client cancellation). These do
+// not affect provider health because no provider was contacted.
+func (p *Pipeline) recordLocalTerminal(ctx context.Context, meta core.RequestMetadata,
+	targets []dispatch.Target, err error, requestStarted time.Time) {
+	status, errorKind := terminalStatusAndKind(err)
+	p.recordOutcomeWithTTFT(context.WithoutCancel(ctx), meta, attemptForTargets(targets), core.Usage{},
+		status, errorKind, false, 0, time.Since(requestStarted), 0, nil)
+}
+
+// recordAttemptTerminal persists the single terminal row for a request whose
+// final provider attempt failed. Per-attempt health telemetry is emitted by the
+// caller; this helper emits only the chain-level final-failure marker.
+func (p *Pipeline) recordAttemptTerminal(ctx context.Context, meta core.RequestMetadata,
+	attempt dispatch.Attempt, err error, usage core.Usage, upstreamLatency, endToEndLatency,
+	ttft time.Duration, save *saveState, fellBack bool) (*core.ProviderError, int64) {
+	pe := providerErrorForAttempt(err, attempt)
+	status, errorKind := terminalStatusAndKind(pe)
+	cost := p.recordOutcomeWithTTFT(context.WithoutCancel(ctx), meta, attempt, usage,
+		status, errorKind, false, upstreamLatency, endToEndLatency, ttft, save)
+	p.recordFinalFailureTelemetry(meta, attempt, pe, fellBack)
+	return pe, cost
+}
+
+func partialStreamUsage(req *core.ChatRequest, usage core.Usage, completionChars int) core.Usage {
+	if usage.PromptTokens+usage.CompletionTokens > 0 {
+		return usage
+	}
+	return estimateStreamUsage(req, completionChars)
+}
+
 // capabilityOf derives the capability label for a target. KeiRouter routes by
 // service kind, but telemetry keys on a stable capability string; default to
 // chat_completions for LLM models.
@@ -1323,24 +1480,49 @@ func capabilityOf(provider, model string) string {
 	return "chat_completions"
 }
 
-// recordWithTTFT is like record but also records time-to-first-token.
+// recordWithTTFT records a successful upstream attempt and emits provider
+// health telemetry. endToEndLatency includes routing, fallback, and transforms;
+// upstreamLatency covers only the winning provider attempt.
 func (p *Pipeline) recordWithTTFT(ctx context.Context, meta core.RequestMetadata, attempt dispatch.Attempt,
-	usage core.Usage, cacheHit bool, latency, ttft time.Duration, save *saveState, fellBack bool) int64 {
-	if p.meter == nil {
-		return 0
+	usage core.Usage, cacheHit bool, upstreamLatency, endToEndLatency, ttft time.Duration,
+	save *saveState, fellBack bool) int64 {
+	cost := p.recordOutcomeWithTTFT(ctx, meta, attempt, usage, "success", "", cacheHit,
+		upstreamLatency, endToEndLatency, ttft, save)
+	if !cacheHit {
+		p.recordSuccessTelemetry(meta, attempt, usage, upstreamLatency, ttft, fellBack, cost)
+	}
+	return cost
+}
+
+// recordOutcomeWithTTFT is the single persistence path for every terminal
+// request status. It deliberately does not emit provider-health telemetry:
+// callers know whether a blocked/failed request reflects provider behavior.
+func (p *Pipeline) recordOutcomeWithTTFT(ctx context.Context, meta core.RequestMetadata, attempt dispatch.Attempt,
+	usage core.Usage, status, errorKind string, cacheHit bool,
+	upstreamLatency, endToEndLatency, ttft time.Duration, save *saveState) int64 {
+	if status == "" {
+		status = "success"
+	}
+	if usage.Source == "" && usage.PromptTokens+usage.CompletionTokens > 0 {
+		usage.Source = core.UsageSourceProvider
 	}
 	ev := meter.Event{
-		TenantID:  meta.TenantID,
-		ProjectID: meta.ProjectID,
-		APIKeyID:  meta.APIKeyID,
-		Provider:  attempt.Target.Provider,
-		Model:     attempt.Target.Model,
-		AccountID: attempt.Account.ID,
-		Client:    meta.ClientKind,
-		Usage:     usage,
-		CacheHit:  cacheHit,
-		Latency:   latency,
-		TTFT:      ttft,
+		RequestID:       meta.RequestID,
+		TenantID:        meta.TenantID,
+		ProjectID:       meta.ProjectID,
+		APIKeyID:        meta.APIKeyID,
+		Provider:        attempt.Target.Provider,
+		Model:           attempt.Target.Model,
+		AccountID:       attempt.Account.ID,
+		Client:          meta.ClientKind,
+		Status:          status,
+		ErrorKind:       errorKind,
+		Usage:           usage,
+		UsageSource:     string(usage.Source),
+		CacheHit:        cacheHit,
+		Latency:         upstreamLatency,
+		EndToEndLatency: endToEndLatency,
+		TTFT:            ttft,
 	}
 	if save != nil {
 		ev.SlimStats = save.slimSnap
@@ -1350,26 +1532,26 @@ func (p *Pipeline) recordWithTTFT(ctx context.Context, meta core.RequestMetadata
 		ev.HeadroomStats = save.headroomSnap
 		ev.PonytailActive = save.ponytail
 	}
-	cost, err := p.meter.Record(ctx, ev)
-	if err != nil {
-		p.log.Error("failed to record usage", "err", err)
-	}
-	// Best-effort provider health telemetry (non-blocking, never fails).
-	if !cacheHit {
-		p.recordSuccessTelemetry(meta, attempt, usage, latency, ttft, fellBack)
+
+	var cost int64
+	if p.meter != nil {
+		var err error
+		cost, err = p.meter.Record(ctx, ev)
+		if err != nil {
+			p.log.Error("failed to record usage", "status", status, "err", err)
+		}
 	}
 
 	if p.metrics != nil {
 		p.metrics.RecordRequest(
-			attempt.Target.Provider, attempt.Target.Model, "success",
-			latency.Seconds(),
+			attempt.Target.Provider, attempt.Target.Model, status,
+			upstreamLatency.Seconds(),
 			usage.PromptTokens, usage.CompletionTokens, usage.CachedTokens, cost,
 			ttft.Seconds(),
 		)
 		if cacheHit {
 			p.metrics.RecordCache(true)
 		}
-		// Record token-saving metrics.
 		if save != nil {
 			if save.slimSnap != nil {
 				for _, rule := range splitRuleNames(save.slimSnap.Rules) {
@@ -1737,24 +1919,46 @@ func (t *teeReadCloser) Close() error {
 // (output_tokens), with usage nested under "message" or at the top level.
 type sseUsageEnvelope struct {
 	Usage *struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
-		TotalTokens      int `json:"total_tokens"`
-		InputTokens      int `json:"input_tokens"`
-		OutputTokens     int `json:"output_tokens"`
+		PromptTokens             int `json:"prompt_tokens"`
+		CompletionTokens         int `json:"completion_tokens"`
+		TotalTokens              int `json:"total_tokens"`
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+		PromptTokensDetails      *struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+		CompletionTokensDetails *struct {
+			ReasoningTokens int `json:"reasoning_tokens"`
+		} `json:"completion_tokens_details"`
 	} `json:"usage"`
 	Message *struct {
 		Usage *struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
+			InputTokens              int `json:"input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 		} `json:"usage"`
 	} `json:"message"`
+	UsageMetadata *struct {
+		PromptTokenCount        int `json:"promptTokenCount"`
+		CandidatesTokenCount    int `json:"candidatesTokenCount"`
+		ThoughtsTokenCount      int `json:"thoughtsTokenCount"`
+		TotalTokenCount         int `json:"totalTokenCount"`
+		CachedContentTokenCount int `json:"cachedContentTokenCount"`
+	} `json:"usageMetadata"`
+	PromptEvalCount int `json:"prompt_eval_count"`
+	EvalCount       int `json:"eval_count"`
 }
 
 // extractUsageFromSSEData tries to parse a single SSE data payload for usage
 // tokens. Returns nil when the payload contains no usage information.
 func extractUsageFromSSEData(data []byte) *core.Usage {
-	if !bytes.Contains(data, []byte(`"usage"`)) {
+	if !bytes.Contains(data, []byte(`"usage"`)) &&
+		!bytes.Contains(data, []byte(`"usageMetadata"`)) &&
+		!bytes.Contains(data, []byte(`"prompt_eval_count"`)) &&
+		!bytes.Contains(data, []byte(`"eval_count"`)) {
 		return nil
 	}
 	var env sseUsageEnvelope
@@ -1773,6 +1977,20 @@ func extractUsageFromSSEData(data []byte) *core.Usage {
 		if env.Usage.OutputTokens > 0 {
 			u.CompletionTokens = env.Usage.OutputTokens
 		}
+		u.CachedTokens = env.Usage.CacheReadInputTokens
+		u.CacheWriteTokens = env.Usage.CacheCreationInputTokens
+		// Anthropic reports regular, cache-read, and cache-creation input as
+		// separate categories. Canonical prompt usage includes all three; cache
+		// counters remain subsets used to apply their component rates.
+		if env.Usage.InputTokens > 0 || u.CachedTokens > 0 || u.CacheWriteTokens > 0 {
+			u.PromptTokens = env.Usage.InputTokens + u.CachedTokens + u.CacheWriteTokens
+		}
+		if env.Usage.PromptTokensDetails != nil && env.Usage.PromptTokensDetails.CachedTokens > 0 {
+			u.CachedTokens = env.Usage.PromptTokensDetails.CachedTokens
+		}
+		if env.Usage.CompletionTokensDetails != nil {
+			u.ReasoningTokens = env.Usage.CompletionTokensDetails.ReasoningTokens
+		}
 	}
 	// Anthropic message_start wraps usage under "message".
 	if env.Message != nil && env.Message.Usage != nil {
@@ -1782,9 +2000,32 @@ func extractUsageFromSSEData(data []byte) *core.Usage {
 		if env.Message.Usage.OutputTokens > 0 {
 			u.CompletionTokens = env.Message.Usage.OutputTokens
 		}
+		u.CachedTokens = env.Message.Usage.CacheReadInputTokens
+		u.CacheWriteTokens = env.Message.Usage.CacheCreationInputTokens
+		if env.Message.Usage.InputTokens > 0 || u.CachedTokens > 0 || u.CacheWriteTokens > 0 {
+			u.PromptTokens = env.Message.Usage.InputTokens + u.CachedTokens + u.CacheWriteTokens
+		}
+	}
+	// Gemini streams usageMetadata instead of an OpenAI-style usage object.
+	if env.UsageMetadata != nil {
+		u.PromptTokens = env.UsageMetadata.PromptTokenCount
+		u.CompletionTokens = env.UsageMetadata.CandidatesTokenCount + env.UsageMetadata.ThoughtsTokenCount
+		u.TotalTokens = env.UsageMetadata.TotalTokenCount
+		u.CachedTokens = env.UsageMetadata.CachedContentTokenCount
+		u.ReasoningTokens = env.UsageMetadata.ThoughtsTokenCount
+	}
+	// Ollama's final NDJSON object exposes counters at the top level.
+	if env.PromptEvalCount > 0 || env.EvalCount > 0 {
+		u.PromptTokens = env.PromptEvalCount
+		u.CompletionTokens = env.EvalCount
+		u.TotalTokens = env.PromptEvalCount + env.EvalCount
 	}
 	if u.PromptTokens == 0 && u.CompletionTokens == 0 && u.TotalTokens == 0 {
 		return nil
+	}
+	u.Source = core.UsageSourceProvider
+	if u.PromptTokens+u.CompletionTokens > 0 {
+		u.TotalTokens = u.PromptTokens + u.CompletionTokens
 	}
 	return u
 }
@@ -1797,12 +2038,8 @@ func extractUsageFromStream(raw []byte) core.Usage {
 	var usage core.Usage
 	scanner := bufio.NewScanner(bytes.NewReader(raw))
 	for scanner.Scan() {
-		line := strings.TrimRight(scanner.Text(), "\r")
-		if !strings.HasPrefix(line, "data:") {
-			continue
-		}
-		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-		if payload == "[DONE]" || payload == "" {
+		payload, ok := streamJSONPayload(scanner.Text())
+		if !ok {
 			continue
 		}
 		if u := extractUsageFromSSEData([]byte(payload)); u != nil {
@@ -1810,4 +2047,91 @@ func extractUsageFromStream(raw []byte) core.Usage {
 		}
 	}
 	return usage
+}
+
+func capturedStreamUsage(req *core.ChatRequest, raw []byte) core.Usage {
+	if usage := extractUsageFromStream(raw); usage.PromptTokens+usage.CompletionTokens > 0 {
+		return usage
+	}
+	return estimateStreamUsage(req, completionCharsFromStream(raw))
+}
+
+func completionCharsFromStream(raw []byte) int {
+	var chars int
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	for scanner.Scan() {
+		payload, ok := streamJSONPayload(scanner.Text())
+		if !ok {
+			continue
+		}
+		var envelope struct {
+			Delta   json.RawMessage `json:"delta"`
+			Message struct {
+				Content  json.RawMessage `json:"content"`
+				Thinking json.RawMessage `json:"thinking"`
+			} `json:"message"`
+			Choices []struct {
+				Delta struct {
+					Content          string `json:"content"`
+					ReasoningContent string `json:"reasoning_content"`
+				} `json:"delta"`
+			} `json:"choices"`
+			Candidates []struct {
+				Content struct {
+					Parts []struct {
+						Text string `json:"text"`
+					} `json:"parts"`
+				} `json:"content"`
+			} `json:"candidates"`
+		}
+		if json.Unmarshal([]byte(payload), &envelope) != nil {
+			continue
+		}
+		for _, choice := range envelope.Choices {
+			chars += len(choice.Delta.Content) + len(choice.Delta.ReasoningContent)
+		}
+		for _, candidate := range envelope.Candidates {
+			for _, part := range candidate.Content.Parts {
+				chars += len(part.Text)
+			}
+		}
+		chars += rawJSONStringLen(envelope.Message.Content) + rawJSONStringLen(envelope.Message.Thinking)
+		if len(envelope.Delta) > 0 {
+			var delta string
+			if json.Unmarshal(envelope.Delta, &delta) == nil {
+				chars += len(delta)
+			} else {
+				var antDelta struct {
+					Text     string `json:"text"`
+					Thinking string `json:"thinking"`
+				}
+				if json.Unmarshal(envelope.Delta, &antDelta) == nil {
+					chars += len(antDelta.Text) + len(antDelta.Thinking)
+				}
+			}
+		}
+	}
+	return chars
+}
+
+func rawJSONStringLen(raw json.RawMessage) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return 0
+	}
+	return len(value)
+}
+
+func streamJSONPayload(line string) (string, bool) {
+	line = strings.TrimSpace(strings.TrimRight(line, "\r"))
+	if strings.HasPrefix(line, "data:") {
+		line = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+	}
+	if line == "" || line == "[DONE]" || !strings.HasPrefix(line, "{") {
+		return "", false
+	}
+	return line, true
 }

--- a/backend/internal/pipeline/pipeline_test.go
+++ b/backend/internal/pipeline/pipeline_test.go
@@ -52,6 +52,29 @@ data: {"type":"message_stop"}
 	}
 }
 
+func TestExtractUsageFromStream_AnthropicIncludesCachedInput(t *testing.T) {
+	raw := []byte(`event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":25,"cache_read_input_tokens":900}}}
+
+event: message_delta
+data: {"type":"message_delta","usage":{"output_tokens":15}}
+`)
+
+	usage := extractUsageFromStream(raw)
+	if usage.PromptTokens != 1025 {
+		t.Errorf("PromptTokens = %d, want 1025", usage.PromptTokens)
+	}
+	if usage.CachedTokens != 900 {
+		t.Errorf("CachedTokens = %d, want 900", usage.CachedTokens)
+	}
+	if usage.CacheWriteTokens != 25 {
+		t.Errorf("CacheWriteTokens = %d, want 25", usage.CacheWriteTokens)
+	}
+	if usage.TotalTokens != 1040 {
+		t.Errorf("TotalTokens = %d, want 1040", usage.TotalTokens)
+	}
+}
+
 func TestExtractUsageFromStream_Empty(t *testing.T) {
 	raw := []byte(`data: {"choices":[{"delta":{"content":"no usage here"}}]}
 

--- a/backend/internal/store/migrations/0027_usage_accounting_accuracy.sql
+++ b/backend/internal/store/migrations/0027_usage_accounting_accuracy.sql
@@ -1,0 +1,56 @@
+-- Canonical request accounting and immutable pricing snapshots.
+-- cost_nanos is authoritative so small per-request charges do not round to zero.
+ALTER TABLE usage_records ADD COLUMN request_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN status TEXT NOT NULL DEFAULT 'success';
+ALTER TABLE usage_records ADD COLUMN error_kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN usage_source TEXT NOT NULL DEFAULT 'provider';
+ALTER TABLE usage_records ADD COLUMN reasoning_tokens BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE usage_records ADD COLUMN cost_nanos BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN input_cost_nanos BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN cached_cost_nanos BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN cache_write_cost_nanos BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN output_cost_nanos BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN reasoning_cost_nanos BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN avoided_cost_nanos BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN saved_cost_nanos BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE usage_records ADD COLUMN pricing_status TEXT NOT NULL DEFAULT 'legacy';
+ALTER TABLE usage_records ADD COLUMN pricing_source TEXT NOT NULL DEFAULT 'legacy';
+ALTER TABLE usage_records ADD COLUMN pricing_key TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN pricing_match_kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN pricing_source_url TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN pricing_as_of TEXT;
+ALTER TABLE usage_records ADD COLUMN pricing_backfilled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN input_rate_per_m DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN cached_rate_per_m DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN cache_write_rate_per_m DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN output_rate_per_m DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN reasoning_rate_per_m DOUBLE PRECISION NOT NULL DEFAULT 0;
+
+ALTER TABLE usage_records ADD COLUMN upstream_latency_ms INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE usage_records ADD COLUMN end_to_end_latency_ms INTEGER NOT NULL DEFAULT 0;
+
+UPDATE usage_records
+SET cost_nanos = cost_micros * 1000,
+    upstream_latency_ms = latency_ms,
+    end_to_end_latency_ms = latency_ms,
+    status = CASE WHEN cache_hit = 1 THEN 'cache_hit' ELSE 'success' END,
+    usage_source = CASE
+        WHEN cache_hit = 1 THEN 'cache'
+        WHEN prompt_tokens + completion_tokens > 0 THEN 'legacy'
+        ELSE 'none'
+    END,
+    pricing_status = CASE
+        WHEN prompt_tokens + completion_tokens = 0 THEN 'none'
+        WHEN cost_micros > 0 OR cache_hit = 1 THEN 'legacy'
+        ELSE 'missing'
+    END,
+    pricing_match_kind = CASE WHEN prompt_tokens + completion_tokens > 0 THEN 'legacy' ELSE 'none' END;
+
+CREATE INDEX IF NOT EXISTS idx_usage_tenant_time_status
+    ON usage_records(tenant_id, created_at, status);
+CREATE INDEX IF NOT EXISTS idx_usage_tenant_time_pricing
+    ON usage_records(tenant_id, created_at, pricing_status);
+CREATE INDEX IF NOT EXISTS idx_usage_request_id
+    ON usage_records(request_id);

--- a/backend/internal/store/migrations/0028_usage_pricing_provenance.postgres.sql
+++ b/backend/internal/store/migrations/0028_usage_pricing_provenance.postgres.sql
@@ -1,0 +1,65 @@
+-- Forward-compatible pricing provenance for databases that already applied an
+-- earlier 0027 before these columns existed. Duplicate ADD COLUMN statements
+-- are intentionally tolerated by the migration runner for fresh databases.
+ALTER TABLE usage_records ADD COLUMN pricing_match_kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN pricing_source_url TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN pricing_as_of TEXT;
+ALTER TABLE usage_records ADD COLUMN pricing_backfilled INTEGER NOT NULL DEFAULT 0;
+
+-- Historical repricing performed by the earlier implementation can be
+-- recognized by its retained key/rates/components. Mark it as a backfilled
+-- estimate so analytics keep the recovered cost while hard budgets exclude it.
+UPDATE usage_records
+SET pricing_backfilled = 1,
+    pricing_status = CASE WHEN pricing_status = 'free' THEN 'free' ELSE 'estimated' END,
+    pricing_match_kind = 'legacy',
+    pricing_as_of = TO_CHAR(CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+WHERE request_id = ''
+  AND prompt_tokens + completion_tokens > 0
+  AND pricing_status IN ('priced', 'estimated', 'free')
+  AND (
+      pricing_key <> ''
+      OR input_cost_nanos + cached_cost_nanos + cache_write_cost_nanos + output_cost_nanos + reasoning_cost_nanos > 0
+      OR input_rate_per_m <> 0 OR cached_rate_per_m <> 0 OR cache_write_rate_per_m <> 0
+      OR output_rate_per_m <> 0 OR reasoning_rate_per_m <> 0
+  );
+
+-- Rows migrated from the pre-accounting schema have no request id. Preserve
+-- that uncertainty instead of calling their usage provider-measured.
+UPDATE usage_records
+SET usage_source = CASE
+        WHEN cache_hit = 1 THEN 'cache'
+        WHEN prompt_tokens + completion_tokens > 0 THEN 'legacy'
+        ELSE 'none'
+    END
+WHERE request_id = '';
+
+-- Retain positive legacy totals without inventing components. Cache rows are
+-- legacy avoided-cost facts, while unknown zero-cost token rows stay missing.
+UPDATE usage_records
+SET pricing_status = CASE
+        WHEN prompt_tokens + completion_tokens = 0 THEN 'none'
+        WHEN cost_nanos > 0 OR cost_micros > 0 OR cache_hit = 1 THEN 'legacy'
+        ELSE 'missing'
+    END,
+    pricing_source = CASE WHEN prompt_tokens + completion_tokens = 0 THEN 'none' ELSE 'legacy' END,
+    pricing_key = '',
+    pricing_match_kind = CASE
+        WHEN prompt_tokens + completion_tokens = 0 THEN 'none'
+        WHEN cost_nanos > 0 OR cost_micros > 0 OR cache_hit = 1 THEN 'legacy'
+        ELSE 'none'
+    END
+WHERE request_id = '' AND pricing_backfilled = 0;
+
+-- Requests recorded by an intermediate accounting build already captured
+-- rates at request time but lacked the new provenance columns.
+UPDATE usage_records
+SET pricing_match_kind = CASE
+        WHEN pricing_status IN ('priced', 'estimated', 'free') THEN 'legacy'
+        ELSE 'none'
+    END,
+    pricing_as_of = CASE
+        WHEN pricing_status IN ('priced', 'estimated', 'free') THEN created_at
+        ELSE pricing_as_of
+    END
+WHERE request_id <> '' AND pricing_match_kind = '';

--- a/backend/internal/store/migrations/0028_usage_pricing_provenance.sqlite.sql
+++ b/backend/internal/store/migrations/0028_usage_pricing_provenance.sqlite.sql
@@ -1,0 +1,65 @@
+-- Forward-compatible pricing provenance for databases that already applied an
+-- earlier 0027 before these columns existed. Duplicate ADD COLUMN statements
+-- are intentionally tolerated by the migration runner for fresh databases.
+ALTER TABLE usage_records ADD COLUMN pricing_match_kind TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN pricing_source_url TEXT NOT NULL DEFAULT '';
+ALTER TABLE usage_records ADD COLUMN pricing_as_of TEXT;
+ALTER TABLE usage_records ADD COLUMN pricing_backfilled INTEGER NOT NULL DEFAULT 0;
+
+-- Historical repricing performed by the earlier implementation can be
+-- recognized by its retained key/rates/components. Mark it as a backfilled
+-- estimate so analytics keep the recovered cost while hard budgets exclude it.
+UPDATE usage_records
+SET pricing_backfilled = 1,
+    pricing_status = CASE WHEN pricing_status = 'free' THEN 'free' ELSE 'estimated' END,
+    pricing_match_kind = 'legacy',
+    pricing_as_of = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE request_id = ''
+  AND prompt_tokens + completion_tokens > 0
+  AND pricing_status IN ('priced', 'estimated', 'free')
+  AND (
+      pricing_key <> ''
+      OR input_cost_nanos + cached_cost_nanos + cache_write_cost_nanos + output_cost_nanos + reasoning_cost_nanos > 0
+      OR input_rate_per_m <> 0 OR cached_rate_per_m <> 0 OR cache_write_rate_per_m <> 0
+      OR output_rate_per_m <> 0 OR reasoning_rate_per_m <> 0
+  );
+
+-- Rows migrated from the pre-accounting schema have no request id. Preserve
+-- that uncertainty instead of calling their usage provider-measured.
+UPDATE usage_records
+SET usage_source = CASE
+        WHEN cache_hit = 1 THEN 'cache'
+        WHEN prompt_tokens + completion_tokens > 0 THEN 'legacy'
+        ELSE 'none'
+    END
+WHERE request_id = '';
+
+-- Retain positive legacy totals without inventing components. Cache rows are
+-- legacy avoided-cost facts, while unknown zero-cost token rows stay missing.
+UPDATE usage_records
+SET pricing_status = CASE
+        WHEN prompt_tokens + completion_tokens = 0 THEN 'none'
+        WHEN cost_nanos > 0 OR cost_micros > 0 OR cache_hit = 1 THEN 'legacy'
+        ELSE 'missing'
+    END,
+    pricing_source = CASE WHEN prompt_tokens + completion_tokens = 0 THEN 'none' ELSE 'legacy' END,
+    pricing_key = '',
+    pricing_match_kind = CASE
+        WHEN prompt_tokens + completion_tokens = 0 THEN 'none'
+        WHEN cost_nanos > 0 OR cost_micros > 0 OR cache_hit = 1 THEN 'legacy'
+        ELSE 'none'
+    END
+WHERE request_id = '' AND pricing_backfilled = 0;
+
+-- Requests recorded by an intermediate accounting build already captured
+-- rates at request time but lacked the new provenance columns.
+UPDATE usage_records
+SET pricing_match_kind = CASE
+        WHEN pricing_status IN ('priced', 'estimated', 'free') THEN 'legacy'
+        ELSE 'none'
+    END,
+    pricing_as_of = CASE
+        WHEN pricing_status IN ('priced', 'estimated', 'free') THEN created_at
+        ELSE pricing_as_of
+    END
+WHERE request_id <> '' AND pricing_match_kind = '';

--- a/backend/internal/store/models.go
+++ b/backend/internal/store/models.go
@@ -120,32 +120,68 @@ type ChainStep struct {
 	CreatedAt time.Time
 }
 
-// UsageRecord meters one completed request.
+// UsageRecord is the terminal accounting fact for one inbound request.
+// Token counts, pricing provenance, and cost components are snapshotted so
+// historical reports never depend on whichever catalog happens to be current.
 type UsageRecord struct {
-	ID               string
-	TenantID         string
-	ProjectID        string
-	APIKeyID         string
-	Provider         string
-	Model            string
-	AccountID        string
-	Client           string // detected calling tool (claude-code, codex, ...) or "unknown"
+	ID        string
+	RequestID string
+	TenantID  string
+	ProjectID string
+	APIKeyID  string
+
+	Provider  string
+	Model     string
+	AccountID string
+	Client    string // detected calling tool (claude-code, codex, ...) or "unknown"
+	Status    string // success | cache_hit | blocked | failed | cancelled
+	ErrorKind string
+
 	PromptTokens     int
 	CompletionTokens int
 	CachedTokens     int
 	CacheWriteTokens int
-	CostMicros       int64
-	CacheHit         bool
-	LatencyMS        int
-	TTFTMS           int    // time-to-first-token in ms (0 for non-streaming or cache hits)
-	SlimBytesSaved   int    // bytes removed by RTK slimmer (input-side compression)
-	SlimTokensSaved  int    // estimated tokens saved by RTK (bytes/4)
-	SlimRules        string // comma-separated rule names that fired (e.g. "git-diff,grep")
-	SlimActive       bool   // RTK slimmer was enabled for this request
-	CavemanActive    bool   // caveman output compression was active
-	TerseActive      bool   // terse output compression was active
+	ReasoningTokens  int
+	UsageSource      string // provider | estimated | cache | none
 
-	HeadroomTokensSaved int  // estimated tokens saved by Headroom (input-side compression)
+	// CostMicros remains for budget/backward compatibility. CostNanos is the
+	// authoritative value and avoids each small request being rounded to zero.
+	CostMicros          int64
+	CostNanos           int64
+	InputCostNanos      int64
+	CachedCostNanos     int64
+	CacheWriteCostNanos int64
+	OutputCostNanos     int64
+	ReasoningCostNanos  int64
+	AvoidedCostNanos    int64 // semantic-cache retail-equivalent cost avoided
+	SavedCostNanos      int64 // input compression retail-equivalent saving
+
+	PricingStatus      string // priced | estimated | free | missing | legacy | none
+	PricingSource      string // official | custom | retail_equivalent | legacy
+	PricingKey         string
+	PricingMatchKind   string // exact | provider_alias | canonical_model | provider | legacy | none
+	PricingSourceURL   string
+	PricingAsOf        *time.Time
+	PricingBackfilled  bool
+	InputRatePerM      float64
+	CachedRatePerM     float64
+	CacheWriteRatePerM float64
+	OutputRatePerM     float64
+	ReasoningRatePerM  float64
+
+	CacheHit          bool
+	LatencyMS         int // retained compatibility alias for end-to-end latency
+	UpstreamLatencyMS int
+	EndToEndLatencyMS int
+	TTFTMS            int    // time-to-first-token in ms (0 for non-streaming or cache hits)
+	SlimBytesSaved    int    // bytes removed by RTK slimmer (input-side compression)
+	SlimTokensSaved   int    // estimated tokens saved by RTK (bytes/4)
+	SlimRules         string // comma-separated rule names that fired (e.g. "git-diff,grep")
+	SlimActive        bool   // RTK slimmer was enabled for this request
+	CavemanActive     bool   // caveman output compression was active
+	TerseActive       bool   // terse output compression was active
+
+	HeadroomTokensSaved int  // tokens saved by Headroom (input-side compression)
 	HeadroomBytesSaved  int  // bytes removed by Headroom (input-side compression)
 	HeadroomActive      bool // Headroom achieved real (non-phantom) savings
 	PonytailActive      bool // ponytail output injection was active
@@ -373,8 +409,8 @@ type ProviderHealthCurrent struct {
 	Capability          string     `json:"capability"`
 	HealthStatus        string     `json:"health_status"` // healthy | degraded | unhealthy | unknown | disabled
 	HealthScore         int        `json:"health_score"`
-	SuccessRate         float64    `json:"success_rate"`  // 0-1
-	ErrorRate           float64    `json:"error_rate"`    // 0-1
+	SuccessRate         float64    `json:"success_rate"` // 0-1
+	ErrorRate           float64    `json:"error_rate"`   // 0-1
 	RequestCount        int64      `json:"request_count"`
 	FallbackCount       int64      `json:"fallback_count"`
 	LatencyP95Ms        *int       `json:"latency_p95_ms"`
@@ -391,58 +427,58 @@ type ProviderHealthCurrent struct {
 // ProviderHealthSnapshot is one aggregated time bucket of provider health,
 // stored for historical charts and trend analysis.
 type ProviderHealthSnapshot struct {
-	ID                  string     `json:"id"`
-	BucketStart         time.Time  `json:"bucket_start"`
-	BucketSizeSeconds   int        `json:"bucket_size_seconds"`
-	Provider            string     `json:"provider"`
-	ProviderAccountID   string     `json:"provider_account_id"`
-	Model               string     `json:"model"`
-	Capability          string     `json:"capability"`
-	RequestCount        int64      `json:"request_count"`
-	SuccessCount        int64      `json:"success_count"`
-	FailureCount        int64      `json:"failure_count"`
-	FallbackCount       int64      `json:"fallback_count"`
-	FinalFailureCount   int64      `json:"final_failure_count"`
-	InputTokens         int64      `json:"input_tokens"`
-	OutputTokens        int64      `json:"output_tokens"`
-	EstimatedCostMicros int64      `json:"estimated_cost_microusd"`
-	LatencyP50Ms        *int       `json:"latency_p50_ms"`
-	LatencyP95Ms        *int       `json:"latency_p95_ms"`
-	LatencyP99Ms        *int       `json:"latency_p99_ms"`
-	TTFTP50Ms           *int       `json:"ttft_p50_ms"`
-	TTFTP95Ms           *int       `json:"ttft_p95_ms"`
-	TTFTP99Ms           *int       `json:"ttft_p99_ms"`
-	RateLimitedCount    int64      `json:"rate_limited_count"`
-	AuthErrorCount      int64      `json:"auth_error_count"`
-	QuotaExceededCount  int64      `json:"quota_exceeded_count"`
-	TimeoutCount        int64      `json:"timeout_count"`
-	Provider5xxCount    int64      `json:"provider_5xx_count"`
-	BadRequestCount     int64      `json:"bad_request_count"`
-	NetworkErrorCount   int64      `json:"network_error_count"`
-	UnsupportedCount    int64      `json:"unsupported_count"`
-	UnknownErrorCount   int64      `json:"unknown_error_count"`
-	HealthScore         int        `json:"health_score"`
-	HealthStatus        string     `json:"health_status"`
-	MainIssue           *string    `json:"main_issue"`
-	CreatedAt           time.Time  `json:"created_at"`
+	ID                  string    `json:"id"`
+	BucketStart         time.Time `json:"bucket_start"`
+	BucketSizeSeconds   int       `json:"bucket_size_seconds"`
+	Provider            string    `json:"provider"`
+	ProviderAccountID   string    `json:"provider_account_id"`
+	Model               string    `json:"model"`
+	Capability          string    `json:"capability"`
+	RequestCount        int64     `json:"request_count"`
+	SuccessCount        int64     `json:"success_count"`
+	FailureCount        int64     `json:"failure_count"`
+	FallbackCount       int64     `json:"fallback_count"`
+	FinalFailureCount   int64     `json:"final_failure_count"`
+	InputTokens         int64     `json:"input_tokens"`
+	OutputTokens        int64     `json:"output_tokens"`
+	EstimatedCostMicros int64     `json:"estimated_cost_microusd"`
+	LatencyP50Ms        *int      `json:"latency_p50_ms"`
+	LatencyP95Ms        *int      `json:"latency_p95_ms"`
+	LatencyP99Ms        *int      `json:"latency_p99_ms"`
+	TTFTP50Ms           *int      `json:"ttft_p50_ms"`
+	TTFTP95Ms           *int      `json:"ttft_p95_ms"`
+	TTFTP99Ms           *int      `json:"ttft_p99_ms"`
+	RateLimitedCount    int64     `json:"rate_limited_count"`
+	AuthErrorCount      int64     `json:"auth_error_count"`
+	QuotaExceededCount  int64     `json:"quota_exceeded_count"`
+	TimeoutCount        int64     `json:"timeout_count"`
+	Provider5xxCount    int64     `json:"provider_5xx_count"`
+	BadRequestCount     int64     `json:"bad_request_count"`
+	NetworkErrorCount   int64     `json:"network_error_count"`
+	UnsupportedCount    int64     `json:"unsupported_count"`
+	UnknownErrorCount   int64     `json:"unknown_error_count"`
+	HealthScore         int       `json:"health_score"`
+	HealthStatus        string    `json:"health_status"`
+	MainIssue           *string   `json:"main_issue"`
+	CreatedAt           time.Time `json:"created_at"`
 }
 
 // ProviderProbeResult is one synthetic probe outcome (scheduled or manual).
 type ProviderProbeResult struct {
-	ID                  string     `json:"id"`
-	Provider            string     `json:"provider"`
-	ProviderAccountID   string     `json:"provider_account_id"`
-	Model               string     `json:"model"`
-	Capability          string     `json:"capability"`
-	Status              string     `json:"status"` // success | failed
-	HTTPStatus          *int       `json:"http_status"`
-	LatencyMs           *int       `json:"latency_ms"`
-	TTFTMs              *int       `json:"ttft_ms"`
-	ErrorType           *string    `json:"error_type"`
-	ErrorMessage        *string    `json:"error_message"`
-	PromptTokens        *int       `json:"prompt_tokens"`
-	CompletionTokens    *int       `json:"completion_tokens"`
-	EstimatedCostMicros *int64     `json:"estimated_cost_microusd"`
-	TriggeredBy         string     `json:"triggered_by"` // scheduled | manual | after_failure | startup
-	CreatedAt           time.Time  `json:"created_at"`
+	ID                  string    `json:"id"`
+	Provider            string    `json:"provider"`
+	ProviderAccountID   string    `json:"provider_account_id"`
+	Model               string    `json:"model"`
+	Capability          string    `json:"capability"`
+	Status              string    `json:"status"` // success | failed
+	HTTPStatus          *int      `json:"http_status"`
+	LatencyMs           *int      `json:"latency_ms"`
+	TTFTMs              *int      `json:"ttft_ms"`
+	ErrorType           *string   `json:"error_type"`
+	ErrorMessage        *string   `json:"error_message"`
+	PromptTokens        *int      `json:"prompt_tokens"`
+	CompletionTokens    *int      `json:"completion_tokens"`
+	EstimatedCostMicros *int64    `json:"estimated_cost_microusd"`
+	TriggeredBy         string    `json:"triggered_by"` // scheduled | manual | after_failure | startup
+	CreatedAt           time.Time `json:"created_at"`
 }

--- a/backend/internal/store/repo_provider_health.go
+++ b/backend/internal/store/repo_provider_health.go
@@ -21,7 +21,7 @@ const providerHealthCurrentColumns = `id, provider, provider_account_id, model, 
 	last_probe_at, last_updated_at`
 
 // HealthKey builds the deterministic unique key for a health dimension tuple.
-// Empty dimensions collapse to '' so SQLite and PostgreSQL treat NULLs
+// Empty dimensions collapse to ” so SQLite and PostgreSQL treat NULLs
 // identically under the UNIQUE constraint.
 func HealthKey(provider, account, model, capability string) string {
 	return provider + ":" + account + ":" + model + ":" + capability
@@ -130,6 +130,30 @@ func (r *ProviderHealthRepo) ListCurrentByProvider(ctx context.Context, provider
 	return out, rows.Err()
 }
 
+// DeleteTrafficCurrent removes a traffic-derived current row only when it has
+// not been refreshed after the supplied cutoff. Probe-only rows have zero
+// requests and are intentionally preserved.
+func (r *ProviderHealthRepo) DeleteTrafficCurrent(ctx context.Context, provider, account, model, capability string, updatedBefore time.Time) error {
+	q := r.db.rebind(`DELETE FROM provider_health_current
+		WHERE health_key = ? AND request_count > 0 AND last_updated_at <= ?`)
+	if _, err := r.db.sql.ExecContext(ctx, q,
+		HealthKey(provider, account, model, capability), formatTime(updatedBefore)); err != nil {
+		return fmt.Errorf("store: delete provider health current: %w", err)
+	}
+	return nil
+}
+
+// DeleteStaleTrafficCurrent removes persisted traffic windows left behind by a
+// previous process once their collector window has elapsed.
+func (r *ProviderHealthRepo) DeleteStaleTrafficCurrent(ctx context.Context, updatedBefore time.Time) error {
+	q := r.db.rebind(`DELETE FROM provider_health_current
+		WHERE request_count > 0 AND last_updated_at < ?`)
+	if _, err := r.db.sql.ExecContext(ctx, q, formatTime(updatedBefore)); err != nil {
+		return fmt.Errorf("store: delete stale provider health current: %w", err)
+	}
+	return nil
+}
+
 // UpdateProbeTimestamp marks the last probe time for a health key without
 // clobbering traffic-derived fields. Used when real traffic already populates
 // the row and a probe merely refreshes last_probe_at.
@@ -143,12 +167,38 @@ func (r *ProviderHealthRepo) UpdateProbeTimestamp(ctx context.Context, provider,
 	return nil
 }
 
-// InsertSnapshot writes one aggregated historical bucket.
+// InsertSnapshot writes one aggregated historical bucket. The bucket identity
+// is its start time and provider dimensions; replacing that identity lets late
+// telemetry correct a completed minute without creating duplicate snapshots.
 func (r *ProviderHealthRepo) InsertSnapshot(ctx context.Context, s ProviderHealthSnapshot) error {
 	if s.ID == "" {
 		return fmt.Errorf("store: provider health snapshot: missing id")
 	}
-	q := r.db.rebind(`INSERT INTO provider_health_snapshots (id, bucket_start, bucket_size_seconds,
+	tx, err := r.db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("store: begin provider health snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	deleteQuery := r.db.rebind(`DELETE FROM provider_health_snapshots
+		WHERE bucket_start = ? AND provider = ? AND provider_account_id = ? AND model = ? AND capability = ?`)
+	if _, err := tx.ExecContext(ctx, deleteQuery, formatTime(s.BucketStart), s.Provider,
+		s.ProviderAccountID, s.Model, s.Capability); err != nil {
+		return fmt.Errorf("store: replace provider health snapshot: %w", err)
+	}
+	if err := insertProviderHealthSnapshot(ctx, tx, r.db.rebind, s); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("store: commit provider health snapshot: %w", err)
+	}
+	return nil
+}
+
+func insertProviderHealthSnapshot(ctx context.Context, exec interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}, rebind func(string) string, s ProviderHealthSnapshot) error {
+	q := rebind(`INSERT INTO provider_health_snapshots (id, bucket_start, bucket_size_seconds,
 		provider, provider_account_id, model, capability,
 		request_count, success_count, failure_count, fallback_count, final_failure_count,
 		input_tokens, output_tokens, estimated_cost_microusd,
@@ -158,7 +208,7 @@ func (r *ProviderHealthRepo) InsertSnapshot(ctx context.Context, s ProviderHealt
 		provider_5xx_count, bad_request_count, network_error_count, unsupported_count, unknown_error_count,
 		health_score, health_status, main_issue, created_at)
 		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
-	_, err := r.db.sql.ExecContext(ctx, q,
+	_, err := exec.ExecContext(ctx, q,
 		s.ID, formatTime(s.BucketStart), s.BucketSizeSeconds,
 		s.Provider, s.ProviderAccountID, s.Model, s.Capability,
 		s.RequestCount, s.SuccessCount, s.FailureCount, s.FallbackCount, s.FinalFailureCount,
@@ -300,7 +350,7 @@ func scanProviderHealthCurrent(scan func(dest ...any) error) (ProviderHealthCurr
 		latencyP95, ttftP95                 sql.NullInt64
 		mainIssue, recommendation           sql.NullString
 		lastSuccess, lastFailure, lastProbe sql.NullString
-		lastUpdated                          string
+		lastUpdated                         string
 	)
 	if err := scan(
 		&c.ID, &c.Provider, &c.ProviderAccountID, &c.Model, &c.Capability,
@@ -344,9 +394,9 @@ func scanProviderHealthCurrent(scan func(dest ...any) error) (ProviderHealthCurr
 
 func scanProviderHealthSnapshot(scan func(dest ...any) error) (ProviderHealthSnapshot, error) {
 	var (
-		s                            ProviderHealthSnapshot
-		bucketStart, createdAt       string
-		mainIssue                    sql.NullString
+		s                                  ProviderHealthSnapshot
+		bucketStart, createdAt             string
+		mainIssue                          sql.NullString
 		lp50, lp95, lp99, tp50, tp95, tp99 sql.NullInt64
 	)
 	if err := scan(
@@ -378,11 +428,11 @@ func scanProviderHealthSnapshot(scan func(dest ...any) error) (ProviderHealthSna
 
 func scanProviderProbeResult(scan func(dest ...any) error) (ProviderProbeResult, error) {
 	var (
-		p                                                  ProviderProbeResult
-		httpStatus, latencyMs, ttftMs, promptTok, compTok  sql.NullInt64
-		costMicros                                         sql.NullInt64
-		errType, errMsg                                    sql.NullString
-		createdAt                                          string
+		p                                                 ProviderProbeResult
+		httpStatus, latencyMs, ttftMs, promptTok, compTok sql.NullInt64
+		costMicros                                        sql.NullInt64
+		errType, errMsg                                   sql.NullString
+		createdAt                                         string
 	)
 	if err := scan(
 		&p.ID, &p.Provider, &p.ProviderAccountID, &p.Model, &p.Capability,

--- a/backend/internal/store/repo_provider_health_test.go
+++ b/backend/internal/store/repo_provider_health_test.go
@@ -15,24 +15,24 @@ func TestProviderHealthCurrent_UpsertAndGet(t *testing.T) {
 
 	now := time.Now().UTC()
 	cur := ProviderHealthCurrent{
-		ID:                "h1",
-		Provider:          "openai",
-		ProviderAccountID: "acc_1",
-		Model:             "gpt-4o",
-		Capability:        "chat_completions",
-		HealthStatus:      "degraded",
-		HealthScore:       72,
-		SuccessRate:       0.912,
-		ErrorRate:         0.088,
-		RequestCount:      1000,
-		FallbackCount:     37,
-		LatencyP95Ms:      intPtr9400(),
+		ID:                  "h1",
+		Provider:            "openai",
+		ProviderAccountID:   "acc_1",
+		Model:               "gpt-4o",
+		Capability:          "chat_completions",
+		HealthStatus:        "degraded",
+		HealthScore:         72,
+		SuccessRate:         0.912,
+		ErrorRate:           0.088,
+		RequestCount:        1000,
+		FallbackCount:       37,
+		LatencyP95Ms:        intPtr9400(),
 		ConsecutiveFailures: 2,
-		MainIssue:         strPtr("rate_limited"),
-		Recommendation:    strPtr("lower concurrency"),
-		LastSuccessAt:     &now,
-		LastFailureAt:     &now,
-		LastUpdatedAt:     now,
+		MainIssue:           strPtr("rate_limited"),
+		Recommendation:      strPtr("lower concurrency"),
+		LastSuccessAt:       &now,
+		LastFailureAt:       &now,
+		LastUpdatedAt:       now,
 	}
 	require.NoError(t, repo.UpsertCurrent(ctx, cur))
 
@@ -138,10 +138,44 @@ func TestProviderHealthSnapshot_InsertAndList(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, snaps, 1)
 	require.Equal(t, int64(100), snaps[0].RequestCount)
+
+	// A late event corrects the same bucket identity instead of appending a
+	// duplicate historical row.
+	snap.ID = "s2"
+	snap.RequestCount = 125
+	snap.SuccessCount = 117
+	require.NoError(t, repo.InsertSnapshot(ctx, snap))
+	snaps, err = repo.ListSnapshots(ctx, "openai", "", "gpt-4o", "", now.Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, snaps, 1)
+	require.Equal(t, "s2", snaps[0].ID)
+	require.Equal(t, int64(125), snaps[0].RequestCount)
+}
+
+func TestProviderHealthCurrent_DeleteTrafficPreservesProbeOnlyRow(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t)
+	repo := db.ProviderHealth()
+	now := time.Now().UTC()
+
+	require.NoError(t, repo.UpsertCurrent(ctx, ProviderHealthCurrent{
+		ID: "traffic", Provider: "openai", Model: "gpt-4o", Capability: "chat_completions",
+		HealthStatus: "healthy", HealthScore: 100, RequestCount: 4, LastUpdatedAt: now.Add(-time.Minute),
+	}))
+	require.NoError(t, repo.UpsertCurrent(ctx, ProviderHealthCurrent{
+		ID: "probe", Provider: "anthropic", Model: "claude", Capability: "chat_completions",
+		HealthStatus: "healthy", HealthScore: 100, RequestCount: 0, LastProbeAt: &now, LastUpdatedAt: now,
+	}))
+
+	require.NoError(t, repo.DeleteTrafficCurrent(ctx, "openai", "", "gpt-4o", "chat_completions", now))
+	_, err := repo.GetCurrent(ctx, "openai", "", "gpt-4o", "chat_completions")
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = repo.GetCurrent(ctx, "anthropic", "", "claude", "chat_completions")
+	require.NoError(t, err)
 }
 
 // helpers local to this test file to avoid touching repo helpers.
-func intPtr9400() *int   { v := 9400; return &v }
-func intPtr200() *int    { v := 200; return &v }
-func intPtr1200() *int   { v := 1200; return &v }
+func intPtr9400() *int        { v := 9400; return &v }
+func intPtr200() *int         { v := 200; return &v }
+func intPtr1200() *int        { v := 1200; return &v }
 func strPtr(s string) *string { return &s }

--- a/backend/internal/store/repo_usage.go
+++ b/backend/internal/store/repo_usage.go
@@ -54,22 +54,30 @@ func (r *UsageRepo) RecordBatch(ctx context.Context, records []UsageRecord) erro
 	return nil
 }
 
+const usageColumns = `id, request_id, tenant_id, project_id, api_key_id, provider, model, account_id, client,
+	status, error_kind, prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
+	reasoning_tokens, usage_source, cost_micros, cost_nanos, input_cost_nanos, cached_cost_nanos,
+	cache_write_cost_nanos, output_cost_nanos, reasoning_cost_nanos, avoided_cost_nanos, saved_cost_nanos,
+	pricing_status, pricing_source, pricing_key, pricing_match_kind, pricing_source_url,
+	pricing_as_of, pricing_backfilled, input_rate_per_m, cached_rate_per_m,
+	cache_write_rate_per_m, output_rate_per_m, reasoning_rate_per_m, cache_hit, latency_ms,
+	upstream_latency_ms, end_to_end_latency_ms, ttft_ms, slim_bytes_saved, slim_tokens_saved,
+	slim_rules, slim_active, caveman_active, terse_active, headroom_tokens_saved,
+	headroom_bytes_saved, headroom_active, ponytail_active, created_at`
+
 func insertUsageBatch(ctx context.Context, tx *sql.Tx, rebind func(string) string, records []UsageRecord) error {
-	const cols = 27
+	argsPerRow := len(usageArgs(UsageRecord{}))
+	rowPlaceholders := "(" + strings.TrimSuffix(strings.Repeat("?,", argsPerRow), ",") + ")"
 	var b strings.Builder
-	b.WriteString(`INSERT INTO usage_records
-		(id, tenant_id, project_id, api_key_id, provider, model, account_id, client,
-		 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
-		 cost_micros, cache_hit, latency_ms, ttft_ms,
-		 slim_bytes_saved, slim_tokens_saved, slim_rules, slim_active, caveman_active, terse_active,
-		 headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active,
-		 created_at) VALUES `)
-	args := make([]any, 0, len(records)*cols)
+	b.WriteString("INSERT INTO usage_records (")
+	b.WriteString(usageColumns)
+	b.WriteString(") VALUES ")
+	args := make([]any, 0, len(records)*argsPerRow)
 	for i, u := range records {
 		if i > 0 {
 			b.WriteString(",")
 		}
-		b.WriteString("(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+		b.WriteString(rowPlaceholders)
 		args = append(args, usageArgs(u)...)
 	}
 	if _, err := tx.ExecContext(ctx, rebind(b.String()), args...); err != nil {
@@ -81,26 +89,35 @@ func insertUsageBatch(ctx context.Context, tx *sql.Tx, rebind func(string) strin
 func insertUsage(ctx context.Context, exec interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }, rebind func(string) string, u UsageRecord) error {
-	q := rebind(`
-		INSERT INTO usage_records
-			(id, tenant_id, project_id, api_key_id, provider, model, account_id, client,
-			 prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens,
-			 cost_micros, cache_hit, latency_ms, ttft_ms,
-			 slim_bytes_saved, slim_tokens_saved, slim_rules, slim_active, caveman_active, terse_active,
-			 headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active,
-			 created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-	_, err := exec.ExecContext(ctx, q, usageArgs(u)...)
+	args := usageArgs(u)
+	placeholders := "(" + strings.TrimSuffix(strings.Repeat("?,", len(args)), ",") + ")"
+	q := rebind("INSERT INTO usage_records (" + usageColumns + ") VALUES " + placeholders)
+	_, err := exec.ExecContext(ctx, q, args...)
 	return err
 }
 
 func usageArgs(u UsageRecord) []any {
+	// Keep legacy direct callers lossless while cost_nanos is the authoritative
+	// storage unit. Rounding happens once at the compatibility boundary.
+	if u.CostNanos == 0 && u.CostMicros != 0 {
+		u.CostNanos = u.CostMicros * 1000
+	}
+	if u.CostMicros == 0 && u.CostNanos != 0 {
+		u.CostMicros = (u.CostNanos + 500) / 1000
+	}
 	return []any{
-		u.ID, u.TenantID, nullString(u.ProjectID), nullString(u.APIKeyID),
-		u.Provider, u.Model, nullString(u.AccountID), u.Client,
+		u.ID, u.RequestID, u.TenantID, nullString(u.ProjectID), nullString(u.APIKeyID),
+		u.Provider, u.Model, nullString(u.AccountID), u.Client, u.Status, u.ErrorKind,
 		u.PromptTokens, u.CompletionTokens, u.CachedTokens, u.CacheWriteTokens,
-		u.CostMicros, boolToInt(u.CacheHit), u.LatencyMS, u.TTFTMS,
-		u.SlimBytesSaved, u.SlimTokensSaved, u.SlimRules, boolToInt(u.SlimActive), boolToInt(u.CavemanActive), boolToInt(u.TerseActive),
+		u.ReasoningTokens, u.UsageSource, u.CostMicros, u.CostNanos,
+		u.InputCostNanos, u.CachedCostNanos, u.CacheWriteCostNanos, u.OutputCostNanos,
+		u.ReasoningCostNanos, u.AvoidedCostNanos, u.SavedCostNanos,
+		u.PricingStatus, u.PricingSource, u.PricingKey, u.PricingMatchKind, u.PricingSourceURL,
+		nullTime(u.PricingAsOf), boolToInt(u.PricingBackfilled),
+		u.InputRatePerM, u.CachedRatePerM, u.CacheWriteRatePerM, u.OutputRatePerM, u.ReasoningRatePerM,
+		boolToInt(u.CacheHit), u.LatencyMS, u.UpstreamLatencyMS, u.EndToEndLatencyMS, u.TTFTMS,
+		u.SlimBytesSaved, u.SlimTokensSaved, u.SlimRules,
+		boolToInt(u.SlimActive), boolToInt(u.CavemanActive), boolToInt(u.TerseActive),
 		u.HeadroomTokensSaved, u.HeadroomBytesSaved, boolToInt(u.HeadroomActive), boolToInt(u.PonytailActive),
 		formatTime(u.CreatedAt),
 	}
@@ -115,7 +132,7 @@ func (r *UsageRepo) SpendSince(ctx context.Context, scope BudgetScope, scopeID s
 	}
 
 	q := r.db.rebind(fmt.Sprintf(
-		`SELECT COALESCE(SUM(cost_micros), 0) FROM usage_records WHERE %s = ? AND created_at >= ?`,
+		`SELECT (COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000 FROM usage_records WHERE %s = ? AND created_at >= ?`,
 		column))
 	var total int64
 	if err := r.db.sql.QueryRowContext(ctx, q, scopeID, formatTime(since)).Scan(&total); err != nil {
@@ -134,7 +151,7 @@ func (r *UsageRepo) SpendAndTokens(ctx context.Context, scope BudgetScope, scope
 	}
 
 	q := r.db.rebind(fmt.Sprintf(
-		`SELECT COALESCE(SUM(cost_micros), 0), COALESCE(SUM(prompt_tokens + completion_tokens), 0)
+		`SELECT (COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000, COALESCE(SUM(prompt_tokens + completion_tokens), 0)
 		 FROM usage_records WHERE %s = ? AND created_at >= ?`,
 		column))
 	if err := r.db.sql.QueryRowContext(ctx, q, scopeID, formatTime(since)).Scan(&costMicros, &tokens); err != nil {
@@ -177,7 +194,7 @@ func (r *UsageRepo) SpendAndTokensBatch(ctx context.Context, scopes []SpendScope
 			query += " UNION ALL "
 		}
 		query += fmt.Sprintf(
-			"SELECT COALESCE(SUM(cost_micros), 0), COALESCE(SUM(prompt_tokens + completion_tokens), 0) FROM usage_records WHERE %s = ? AND created_at >= ?",
+			"SELECT (COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000, COALESCE(SUM(prompt_tokens + completion_tokens), 0) FROM usage_records WHERE %s = ? AND created_at >= ?",
 			column)
 		args = append(args, s.ScopeID, formatTime(s.Since))
 	}
@@ -244,7 +261,7 @@ func (r *UsageRepo) Summarize(ctx context.Context, tenantID string, since time.T
 			COALESCE(SUM(completion_tokens), 0),
 			COALESCE(SUM(cached_tokens), 0),
 			COALESCE(SUM(cache_write_tokens), 0),
-			COALESCE(SUM(cost_micros), 0),
+			(COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000,
 			COALESCE(SUM(cache_hit), 0),
 			COALESCE(CAST(AVG(CASE WHEN ttft_ms > 0 THEN ttft_ms END) AS INTEGER), 0),
 			COALESCE(CAST(AVG(CASE WHEN latency_ms > 0 THEN latency_ms END) AS INTEGER), 0),
@@ -281,7 +298,7 @@ func (r *UsageRepo) SummarizeByKey(ctx context.Context, keyID string, since time
 			COALESCE(SUM(completion_tokens), 0),
 			COALESCE(SUM(cached_tokens), 0),
 			COALESCE(SUM(cache_write_tokens), 0),
-			COALESCE(SUM(cost_micros), 0),
+			(COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000,
 			COALESCE(SUM(cache_hit), 0),
 			COALESCE(CAST(AVG(CASE WHEN ttft_ms > 0 THEN ttft_ms END) AS INTEGER), 0),
 			COALESCE(CAST(AVG(CASE WHEN latency_ms > 0 THEN latency_ms END) AS INTEGER), 0),
@@ -327,7 +344,7 @@ func (r *UsageRepo) Breakdown(ctx context.Context, tenantID string, since time.T
 			COUNT(*),
 			COALESCE(SUM(prompt_tokens), 0),
 			COALESCE(SUM(completion_tokens), 0),
-			COALESCE(SUM(cost_micros), 0)
+			(COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000
 		FROM usage_records
 		WHERE tenant_id = ? AND created_at >= ?
 		GROUP BY provider
@@ -450,7 +467,7 @@ func (r *UsageRepo) ByAccount(ctx context.Context, tenantID string, since time.T
 			COALESCE(SUM(completion_tokens), 0),
 			COALESCE(SUM(cached_tokens), 0),
 			COALESCE(SUM(cache_write_tokens), 0),
-			COALESCE(SUM(cost_micros), 0)
+			(COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000
 		FROM usage_records
 		WHERE tenant_id = ? AND created_at >= ?
 		GROUP BY account_id`)
@@ -493,7 +510,7 @@ func (r *UsageRepo) ByModel(ctx context.Context, tenantID string, since time.Tim
 			COUNT(*),
 			COALESCE(SUM(prompt_tokens), 0),
 			COALESCE(SUM(completion_tokens), 0),
-			COALESCE(SUM(cost_micros), 0)
+			(COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000
 		FROM usage_records
 		WHERE tenant_id = ? AND created_at >= ?
 		GROUP BY provider, model
@@ -526,7 +543,7 @@ func (r *UsageRepo) ByModelByKey(ctx context.Context, keyID string, since time.T
 			COUNT(*),
 			COALESCE(SUM(prompt_tokens), 0),
 			COALESCE(SUM(completion_tokens), 0),
-			COALESCE(SUM(cost_micros), 0)
+			(COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000
 		FROM usage_records
 		WHERE api_key_id = ? AND created_at >= ?
 		GROUP BY provider, model
@@ -622,7 +639,7 @@ func (r *UsageRepo) DailyByKey(ctx context.Context, keyID string, since time.Tim
 			COUNT(*),
 			COALESCE(SUM(prompt_tokens), 0),
 			COALESCE(SUM(completion_tokens), 0),
-			COALESCE(SUM(cost_micros), 0)
+			(COALESCE(SUM(CASE WHEN pricing_backfilled=0 THEN cost_nanos ELSE 0 END), 0) + 500) / 1000
 		FROM usage_records
 		WHERE api_key_id = ? AND created_at >= ?
 		GROUP BY day
@@ -714,6 +731,9 @@ type ClientSavings struct {
 
 	HeadroomTokensSaved int64 // tokens saved by Headroom
 	PonytailRequests    int64 // requests where Ponytail was active
+	OptimizedRequests   int64 // distinct rows where any optimization was active
+	SavedCostNanos      int64 // input compression savings from immutable snapshots
+	AvoidedCostNanos    int64 // semantic-cache avoided cost from immutable snapshots
 }
 
 // SavingsByClient returns per-client optimization savings for a tenant since
@@ -729,11 +749,14 @@ func (r *UsageRepo) SavingsByClient(ctx context.Context, tenantID string, since 
 			COALESCE(SUM(caveman_active), 0),
 			COALESCE(SUM(terse_active), 0),
 			COALESCE(SUM(headroom_tokens_saved), 0),
-			COALESCE(SUM(ponytail_active), 0)
+			COALESCE(SUM(ponytail_active), 0),
+			COALESCE(SUM(CASE WHEN slim_active=1 OR headroom_active=1 OR caveman_active=1 OR terse_active=1 OR ponytail_active=1 THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(saved_cost_nanos), 0),
+			COALESCE(SUM(avoided_cost_nanos), 0)
 		FROM usage_records
 		WHERE tenant_id = ? AND created_at >= ?
 		GROUP BY client
-		ORDER BY COALESCE(SUM(slim_tokens_saved), 0) DESC`)
+		ORDER BY COALESCE(SUM(slim_tokens_saved + headroom_tokens_saved), 0) DESC`)
 	rows, err := r.db.sql.QueryContext(ctx, q, tenantID, formatTime(since))
 	if err != nil {
 		return nil, fmt.Errorf("store: savings by client: %w", err)
@@ -745,7 +768,8 @@ func (r *UsageRepo) SavingsByClient(ctx context.Context, tenantID string, since 
 		var c ClientSavings
 		if err := rows.Scan(&c.Client, &c.Requests, &c.SlimBytesSaved,
 			&c.SlimTokensSaved, &c.CavemanRequests, &c.TerseRequests,
-			&c.HeadroomTokensSaved, &c.PonytailRequests); err != nil {
+			&c.HeadroomTokensSaved, &c.PonytailRequests, &c.OptimizedRequests,
+			&c.SavedCostNanos, &c.AvoidedCostNanos); err != nil {
 			return nil, err
 		}
 		out = append(out, c)

--- a/backend/internal/store/repo_usage.go
+++ b/backend/internal/store/repo_usage.go
@@ -38,9 +38,17 @@ func (r *UsageRepo) RecordBatch(ctx context.Context, records []UsageRecord) erro
 	// PostgreSQL accepts at most 65,535 bind parameters; SQLite builds used by
 	// KeiRouter allow 32,766. Keep each statement below both limits while one
 	// transaction preserves all-or-nothing batch semantics.
-	maxRows := 1000
+	const (
+		postgresBindLimit = 65535
+		sqliteBindLimit   = 32766
+	)
+	argsPerRow := len(usageArgs(UsageRecord{}))
+	maxRows := sqliteBindLimit / argsPerRow
 	if r.db.dialect == DialectPostgres {
-		maxRows = 2400
+		maxRows = postgresBindLimit / argsPerRow
+	}
+	if maxRows < 1 {
+		maxRows = 1
 	}
 	for start := 0; start < len(records); start += maxRows {
 		end := min(start+maxRows, len(records))

--- a/backend/internal/store/repo_usage_accuracy.go
+++ b/backend/internal/store/repo_usage_accuracy.go
@@ -1,0 +1,206 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// AccurateSummary is the authoritative request, token, cost, latency, pricing
+// coverage, usage provenance, and optimization rollup used by the Usage page.
+type AccurateSummary struct {
+	TotalRequests, SuccessCount, FailureCount                           int64
+	PromptTokens, CompletionTokens, CachedTokens, CacheWriteTokens      int64
+	ReasoningTokens, CostNanos, CacheHits                               int64
+	AvgTTFTMS, AvgLatencyMS                                             int64
+	PricedRequests, UnpricedRequests, UnpricedTokens, EstimatedRequests int64
+	EstimatedUsageRequests, EstimatedUsageTokens                        int64
+	LegacyUsageRequests, LegacyUsageTokens, BackfilledRequests          int64
+	SlimBytesSaved, SlimTokensSaved, HeadroomTokensSaved                int64
+	HeadroomRequests, CavemanRequests, TerseRequests, PonytailRequests  int64
+	OptimizedRequests, SavedCostNanos, AvoidedCostNanos                 int64
+}
+
+// SummarizeAccurate uses explicit terminal status instead of inferring success
+// from latency. Pricing coverage only considers token-bearing requests and
+// treats legacy totals without rate snapshots as uncovered.
+func (r *UsageRepo) SummarizeAccurate(ctx context.Context, tenantID string, since time.Time) (AccurateSummary, error) {
+	q := r.db.rebind(`
+		SELECT COUNT(*),
+			COALESCE(SUM(CASE WHEN status IN ('success','cache_hit') THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN status NOT IN ('success','cache_hit') THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(completion_tokens),0),
+			COALESCE(SUM(cached_tokens),0), COALESCE(SUM(cache_write_tokens),0),
+			COALESCE(SUM(reasoning_tokens),0), COALESCE(SUM(cost_nanos),0),
+			COALESCE(SUM(cache_hit),0),
+			COALESCE(CAST(AVG(CASE WHEN ttft_ms > 0 THEN ttft_ms END) AS INTEGER),0),
+			COALESCE(CAST(AVG(CASE WHEN end_to_end_latency_ms > 0 THEN end_to_end_latency_ms END) AS INTEGER),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND pricing_status IN ('priced','estimated','free') THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND pricing_status IN ('missing','legacy') THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN pricing_status IN ('missing','legacy') THEN prompt_tokens+completion_tokens ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND pricing_status='estimated' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND usage_source='estimated' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN usage_source='estimated' THEN prompt_tokens+completion_tokens ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND usage_source='legacy' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN usage_source='legacy' THEN prompt_tokens+completion_tokens ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN pricing_backfilled=1 THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(slim_bytes_saved),0), COALESCE(SUM(slim_tokens_saved),0),
+			COALESCE(SUM(headroom_tokens_saved),0), COALESCE(SUM(headroom_active),0),
+			COALESCE(SUM(caveman_active),0), COALESCE(SUM(terse_active),0),
+			COALESCE(SUM(ponytail_active),0),
+			COALESCE(SUM(CASE WHEN slim_active=1 OR headroom_active=1 OR caveman_active=1 OR terse_active=1 OR ponytail_active=1 THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(saved_cost_nanos),0), COALESCE(SUM(avoided_cost_nanos),0)
+		FROM usage_records WHERE tenant_id=? AND created_at>=?`)
+	var s AccurateSummary
+	err := r.db.sql.QueryRowContext(ctx, q, tenantID, formatTime(since)).Scan(
+		&s.TotalRequests, &s.SuccessCount, &s.FailureCount,
+		&s.PromptTokens, &s.CompletionTokens, &s.CachedTokens, &s.CacheWriteTokens,
+		&s.ReasoningTokens, &s.CostNanos, &s.CacheHits, &s.AvgTTFTMS, &s.AvgLatencyMS,
+		&s.PricedRequests, &s.UnpricedRequests, &s.UnpricedTokens, &s.EstimatedRequests,
+		&s.EstimatedUsageRequests, &s.EstimatedUsageTokens,
+		&s.LegacyUsageRequests, &s.LegacyUsageTokens, &s.BackfilledRequests,
+		&s.SlimBytesSaved, &s.SlimTokensSaved, &s.HeadroomTokensSaved, &s.HeadroomRequests,
+		&s.CavemanRequests, &s.TerseRequests, &s.PonytailRequests, &s.OptimizedRequests,
+		&s.SavedCostNanos, &s.AvoidedCostNanos)
+	if err != nil {
+		return AccurateSummary{}, fmt.Errorf("store: accurate usage summary: %w", err)
+	}
+	return s, nil
+}
+
+type AccurateProviderUsage struct {
+	Provider                                                        string
+	TotalRequests, SuccessCount                                     int64
+	PromptTokens, CompletionTokens, CachedTokens, CacheWriteTokens  int64
+	ReasoningTokens, CostNanos, SavedCostNanos, AvoidedCostNanos    int64
+	AvgLatencyMS, AvgTTFTMS                                         int64
+	PricingEligibleRequests, UnpricedRequests, EstimatedRequests    int64
+	EstimatedUsageRequests, LegacyUsageRequests, BackfilledRequests int64
+}
+
+func (r *UsageRepo) BreakdownAccurate(ctx context.Context, tenantID string, since time.Time) ([]AccurateProviderUsage, error) {
+	q := r.db.rebind(`
+		SELECT provider, COUNT(*),
+			COALESCE(SUM(CASE WHEN status IN ('success','cache_hit') THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(completion_tokens),0),
+			COALESCE(SUM(cached_tokens),0), COALESCE(SUM(cache_write_tokens),0),
+			COALESCE(SUM(reasoning_tokens),0), COALESCE(SUM(cost_nanos),0),
+			COALESCE(SUM(saved_cost_nanos),0), COALESCE(SUM(avoided_cost_nanos),0),
+			COALESCE(CAST(AVG(CASE WHEN end_to_end_latency_ms>0 THEN end_to_end_latency_ms END) AS INTEGER),0),
+			COALESCE(CAST(AVG(CASE WHEN ttft_ms>0 THEN ttft_ms END) AS INTEGER),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND pricing_status IN ('missing','legacy') THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND pricing_status='estimated' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND usage_source='estimated' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND usage_source='legacy' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN pricing_backfilled=1 THEN 1 ELSE 0 END),0)
+		FROM usage_records WHERE tenant_id=? AND created_at>=?
+		GROUP BY provider ORDER BY COUNT(*) DESC`)
+	rows, err := r.db.sql.QueryContext(ctx, q, tenantID, formatTime(since))
+	if err != nil {
+		return nil, fmt.Errorf("store: accurate provider breakdown: %w", err)
+	}
+	defer rows.Close()
+	var out []AccurateProviderUsage
+	for rows.Next() {
+		var p AccurateProviderUsage
+		if err := rows.Scan(&p.Provider, &p.TotalRequests, &p.SuccessCount,
+			&p.PromptTokens, &p.CompletionTokens, &p.CachedTokens, &p.CacheWriteTokens,
+			&p.ReasoningTokens, &p.CostNanos, &p.SavedCostNanos, &p.AvoidedCostNanos,
+			&p.AvgLatencyMS, &p.AvgTTFTMS, &p.PricingEligibleRequests, &p.UnpricedRequests,
+			&p.EstimatedRequests, &p.EstimatedUsageRequests, &p.LegacyUsageRequests,
+			&p.BackfilledRequests); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+type AccurateModelUsage struct {
+	Provider, Model                                                  string
+	TotalRequests, SuccessCount                                      int64
+	PromptTokens, CompletionTokens, CachedTokens, CacheWriteTokens   int64
+	ReasoningTokens, CostNanos, SavedCostNanos, AvoidedCostNanos     int64
+	AvgLatencyMS, AvgTTFTMS                                          int64
+	PricingEligibleRequests, UnpricedRequests                        int64
+	MissingPricingRequests, LegacyPricingRequests, EstimatedRequests int64
+	EstimatedUsageRequests, LegacyUsageRequests, BackfilledRequests  int64
+	PricingStatus, PricingSource, PricingKey                         string
+	InputRatePerM, CachedRatePerM, CacheWriteRatePerM                float64
+	OutputRatePerM, ReasoningRatePerM                                float64
+	PricingMixed                                                     bool
+}
+
+func (r *UsageRepo) ByModelAccurate(ctx context.Context, tenantID string, since time.Time) ([]AccurateModelUsage, error) {
+	q := r.db.rebind(`
+		SELECT provider, model, COUNT(*),
+			COALESCE(SUM(CASE WHEN status IN ('success','cache_hit') THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(completion_tokens),0),
+			COALESCE(SUM(cached_tokens),0), COALESCE(SUM(cache_write_tokens),0),
+			COALESCE(SUM(reasoning_tokens),0), COALESCE(SUM(cost_nanos),0),
+			COALESCE(SUM(saved_cost_nanos),0), COALESCE(SUM(avoided_cost_nanos),0),
+			COALESCE(CAST(AVG(CASE WHEN end_to_end_latency_ms>0 THEN end_to_end_latency_ms END) AS INTEGER),0),
+			COALESCE(CAST(AVG(CASE WHEN ttft_ms>0 THEN ttft_ms END) AS INTEGER),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND pricing_status IN ('missing','legacy') THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND pricing_status='missing' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND pricing_status='legacy' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND pricing_status='estimated' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND usage_source='estimated' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN prompt_tokens+completion_tokens>0 AND usage_source='legacy' THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(CASE WHEN pricing_backfilled=1 THEN 1 ELSE 0 END),0),
+			COALESCE(MIN(CASE WHEN pricing_status<>'none' THEN pricing_status END),'none'),
+			COALESCE(MAX(CASE WHEN pricing_status<>'none' THEN pricing_status END),'none'),
+			COALESCE(MIN(CASE WHEN pricing_status<>'none' THEN pricing_source END),''),
+			COALESCE(MAX(CASE WHEN pricing_status<>'none' THEN pricing_source END),''),
+			COALESCE(MIN(CASE WHEN pricing_status<>'none' THEN pricing_key END),''),
+			COALESCE(MAX(CASE WHEN pricing_status<>'none' THEN pricing_key END),''),
+			COALESCE(MIN(CASE WHEN pricing_status<>'none' THEN input_rate_per_m END),0),
+			COALESCE(MAX(CASE WHEN pricing_status<>'none' THEN input_rate_per_m END),0),
+			COALESCE(MIN(CASE WHEN pricing_status<>'none' THEN cached_rate_per_m END),0),
+			COALESCE(MAX(CASE WHEN pricing_status<>'none' THEN cached_rate_per_m END),0),
+			COALESCE(MIN(CASE WHEN pricing_status<>'none' THEN cache_write_rate_per_m END),0),
+			COALESCE(MAX(CASE WHEN pricing_status<>'none' THEN cache_write_rate_per_m END),0),
+			COALESCE(MIN(CASE WHEN pricing_status<>'none' THEN output_rate_per_m END),0),
+			COALESCE(MAX(CASE WHEN pricing_status<>'none' THEN output_rate_per_m END),0),
+			COALESCE(MIN(CASE WHEN pricing_status<>'none' THEN reasoning_rate_per_m END),0),
+			COALESCE(MAX(CASE WHEN pricing_status<>'none' THEN reasoning_rate_per_m END),0)
+		FROM usage_records WHERE tenant_id=? AND created_at>=?
+		GROUP BY provider, model ORDER BY COUNT(*) DESC`)
+	rows, err := r.db.sql.QueryContext(ctx, q, tenantID, formatTime(since))
+	if err != nil {
+		return nil, fmt.Errorf("store: accurate model breakdown: %w", err)
+	}
+	defer rows.Close()
+	var out []AccurateModelUsage
+	for rows.Next() {
+		var m AccurateModelUsage
+		var minStatus, maxStatus, minSource, maxSource, minKey, maxKey string
+		var minInput, maxInput, minCached, maxCached, minWrite, maxWrite float64
+		var minOutput, maxOutput, minReasoning, maxReasoning float64
+		if err := rows.Scan(&m.Provider, &m.Model, &m.TotalRequests, &m.SuccessCount,
+			&m.PromptTokens, &m.CompletionTokens, &m.CachedTokens, &m.CacheWriteTokens,
+			&m.ReasoningTokens, &m.CostNanos, &m.SavedCostNanos, &m.AvoidedCostNanos,
+			&m.AvgLatencyMS, &m.AvgTTFTMS, &m.PricingEligibleRequests, &m.UnpricedRequests,
+			&m.MissingPricingRequests, &m.LegacyPricingRequests, &m.EstimatedRequests,
+			&m.EstimatedUsageRequests, &m.LegacyUsageRequests,
+			&m.BackfilledRequests, &minStatus, &maxStatus, &minSource, &maxSource, &minKey, &maxKey,
+			&minInput, &maxInput, &minCached, &maxCached, &minWrite, &maxWrite,
+			&minOutput, &maxOutput, &minReasoning, &maxReasoning); err != nil {
+			return nil, err
+		}
+		m.PricingMixed = minStatus != maxStatus || minSource != maxSource || minKey != maxKey ||
+			minInput != maxInput || minCached != maxCached || minWrite != maxWrite ||
+			minOutput != maxOutput || minReasoning != maxReasoning
+		if m.PricingMixed {
+			m.PricingStatus, m.PricingSource, m.PricingKey = "mixed", "mixed", ""
+		} else {
+			m.PricingStatus, m.PricingSource, m.PricingKey = minStatus, minSource, minKey
+			m.InputRatePerM, m.CachedRatePerM, m.CacheWriteRatePerM = minInput, minCached, minWrite
+			m.OutputRatePerM, m.ReasoningRatePerM = minOutput, minReasoning
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}

--- a/backend/internal/store/repo_usage_accuracy_test.go
+++ b/backend/internal/store/repo_usage_accuracy_test.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestByModelAccurateSeparatesLegacyAndMissingPricing(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	records := []UsageRecord{
+		{
+			ID: "legacy-1", TenantID: DefaultTenantID, Provider: "anthropic", Model: "claude-legacy",
+			Status: "success", PromptTokens: 100, CompletionTokens: 20, UsageSource: "legacy",
+			CostNanos: 42_000_000, PricingStatus: "legacy", PricingSource: "legacy", CreatedAt: now,
+		},
+		{
+			ID: "legacy-2", TenantID: DefaultTenantID, Provider: "anthropic", Model: "claude-legacy",
+			Status: "success", PromptTokens: 80, CompletionTokens: 10, UsageSource: "legacy",
+			CostNanos: 21_000_000, PricingStatus: "legacy", PricingSource: "legacy", CreatedAt: now,
+		},
+		{
+			ID: "missing-1", TenantID: DefaultTenantID, Provider: "custom", Model: "unknown-model",
+			Status: "success", PromptTokens: 40, CompletionTokens: 5, UsageSource: "provider",
+			PricingStatus: "missing", CreatedAt: now,
+		},
+	}
+	require.NoError(t, db.Usage().RecordBatch(ctx, records))
+
+	models, err := db.Usage().ByModelAccurate(ctx, DefaultTenantID, now.Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, models, 2)
+
+	byModel := make(map[string]AccurateModelUsage, len(models))
+	for _, model := range models {
+		byModel[model.Model] = model
+	}
+	legacy := byModel["claude-legacy"]
+	require.Equal(t, int64(2), legacy.PricingEligibleRequests)
+	require.Equal(t, int64(2), legacy.UnpricedRequests)
+	require.Equal(t, int64(0), legacy.MissingPricingRequests)
+	require.Equal(t, int64(2), legacy.LegacyPricingRequests)
+	require.Equal(t, int64(63_000_000), legacy.CostNanos)
+
+	missing := byModel["unknown-model"]
+	require.Equal(t, int64(1), missing.MissingPricingRequests)
+	require.Equal(t, int64(0), missing.LegacyPricingRequests)
+}

--- a/backend/internal/store/repo_usage_details.go
+++ b/backend/internal/store/repo_usage_details.go
@@ -1,0 +1,216 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// AccurateRecentRecord retains exact token classes, status, latency, and price
+// provenance for the request detail drawer.
+type AccurateRecentRecord struct {
+	ID, RequestID, Provider, Model, Status, ErrorKind, UsageSource string
+	PromptTokens, CompletionTokens, CachedTokens, CacheWriteTokens int
+	ReasoningTokens                                                int
+	CostNanos, InputCostNanos, CachedCostNanos                     int64
+	CacheWriteCostNanos, OutputCostNanos, ReasoningCostNanos       int64
+	AvoidedCostNanos, SavedCostNanos                               int64
+	PricingStatus, PricingSource, PricingKey                       string
+	PricingMatchKind, PricingSourceURL                             string
+	PricingAsOf                                                    *time.Time
+	PricingBackfilled                                              bool
+	InputRatePerM, CachedRatePerM, CacheWriteRatePerM              float64
+	OutputRatePerM, ReasoningRatePerM                              float64
+	CacheHit                                                       bool
+	LatencyMS, UpstreamLatencyMS, EndToEndLatencyMS, TTFTMS        int
+	SlimBytesSaved, SlimTokensSaved                                int
+	SlimRules                                                      string
+	SlimActive, CavemanActive, TerseActive                         bool
+	HeadroomTokensSaved, HeadroomBytesSaved                        int
+	HeadroomActive, PonytailActive                                 bool
+	CreatedAt                                                      time.Time
+}
+
+func (r *UsageRepo) RecentAccurate(ctx context.Context, tenantID string, since time.Time, limit int) ([]AccurateRecentRecord, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 50
+	}
+	q := r.db.rebind(`
+		SELECT id, request_id, provider, model, status, error_kind, usage_source,
+			prompt_tokens, completion_tokens, cached_tokens, cache_write_tokens, reasoning_tokens,
+			cost_nanos, input_cost_nanos, cached_cost_nanos, cache_write_cost_nanos,
+			output_cost_nanos, reasoning_cost_nanos, avoided_cost_nanos, saved_cost_nanos,
+			pricing_status, pricing_source, pricing_key, pricing_match_kind, pricing_source_url,
+			pricing_as_of, pricing_backfilled, input_rate_per_m, cached_rate_per_m,
+			cache_write_rate_per_m, output_rate_per_m, reasoning_rate_per_m,
+			cache_hit, latency_ms, upstream_latency_ms, end_to_end_latency_ms, ttft_ms,
+			slim_bytes_saved, slim_tokens_saved, slim_rules, slim_active, caveman_active, terse_active,
+			headroom_tokens_saved, headroom_bytes_saved, headroom_active, ponytail_active, created_at
+		FROM usage_records
+		WHERE tenant_id=? AND created_at>=?
+		ORDER BY created_at DESC LIMIT ?`)
+	rows, err := r.db.sql.QueryContext(ctx, q, tenantID, formatTime(since), limit)
+	if err != nil {
+		return nil, fmt.Errorf("store: accurate recent usage: %w", err)
+	}
+	defer rows.Close()
+	var out []AccurateRecentRecord
+	for rows.Next() {
+		var rec AccurateRecentRecord
+		var cacheHit, pricingBackfilled, slim, caveman, terse, headroom, ponytail int
+		var pricingAsOf sql.NullString
+		var createdAt string
+		if err := rows.Scan(
+			&rec.ID, &rec.RequestID, &rec.Provider, &rec.Model, &rec.Status, &rec.ErrorKind, &rec.UsageSource,
+			&rec.PromptTokens, &rec.CompletionTokens, &rec.CachedTokens, &rec.CacheWriteTokens, &rec.ReasoningTokens,
+			&rec.CostNanos, &rec.InputCostNanos, &rec.CachedCostNanos, &rec.CacheWriteCostNanos,
+			&rec.OutputCostNanos, &rec.ReasoningCostNanos, &rec.AvoidedCostNanos, &rec.SavedCostNanos,
+			&rec.PricingStatus, &rec.PricingSource, &rec.PricingKey,
+			&rec.PricingMatchKind, &rec.PricingSourceURL, &pricingAsOf, &pricingBackfilled,
+			&rec.InputRatePerM, &rec.CachedRatePerM, &rec.CacheWriteRatePerM,
+			&rec.OutputRatePerM, &rec.ReasoningRatePerM,
+			&cacheHit, &rec.LatencyMS, &rec.UpstreamLatencyMS, &rec.EndToEndLatencyMS, &rec.TTFTMS,
+			&rec.SlimBytesSaved, &rec.SlimTokensSaved, &rec.SlimRules, &slim, &caveman, &terse,
+			&rec.HeadroomTokensSaved, &rec.HeadroomBytesSaved, &headroom, &ponytail, &createdAt); err != nil {
+			return nil, err
+		}
+		rec.CacheHit = cacheHit != 0
+		rec.PricingBackfilled = pricingBackfilled != 0
+		if pricingAsOf.Valid {
+			parsed := parseTime(pricingAsOf.String)
+			rec.PricingAsOf = &parsed
+		}
+		rec.SlimActive, rec.CavemanActive, rec.TerseActive = slim != 0, caveman != 0, terse != 0
+		rec.HeadroomActive, rec.PonytailActive = headroom != 0, ponytail != 0
+		rec.CreatedAt = parseTime(createdAt)
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+// AccurateTimeBucket powers a multi-series request/token/cost trend chart.
+type AccurateTimeBucket struct {
+	Bucket                                           int
+	Requests, Failed, PromptTokens, CompletionTokens int64
+	CostNanos                                        int64
+}
+
+func (r *UsageRepo) TimelineAccurate(ctx context.Context, tenantID string, since, to time.Time, buckets int) ([]AccurateTimeBucket, error) {
+	if buckets <= 0 {
+		buckets = 24
+	}
+	span := to.Sub(since)
+	if span <= 0 {
+		span = time.Hour
+	}
+	slotSecs := int64(span.Seconds()) / int64(buckets)
+	if slotSecs <= 0 {
+		slotSecs = 60
+	}
+	epochCreated, epochSince := r.db.epochExpr("created_at"), r.db.epochExpr("?")
+	q := r.db.rebind(fmt.Sprintf(`
+		SELECT CAST((%s-%s)/? AS INTEGER), COUNT(*),
+			COALESCE(SUM(CASE WHEN status NOT IN ('success','cache_hit') THEN 1 ELSE 0 END),0),
+			COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(completion_tokens),0),
+			COALESCE(SUM(cost_nanos),0)
+		FROM usage_records
+		WHERE tenant_id=? AND created_at>=? AND created_at<=?
+		GROUP BY 1 ORDER BY 1`, epochCreated, epochSince))
+	rows, err := r.db.sql.QueryContext(ctx, q, formatTime(since), slotSecs, tenantID, formatTime(since), formatTime(to))
+	if err != nil {
+		return nil, fmt.Errorf("store: accurate usage timeline: %w", err)
+	}
+	defer rows.Close()
+	var out []AccurateTimeBucket
+	for rows.Next() {
+		var b AccurateTimeBucket
+		if err := rows.Scan(&b.Bucket, &b.Requests, &b.Failed, &b.PromptTokens, &b.CompletionTokens, &b.CostNanos); err != nil {
+			return nil, err
+		}
+		if b.Bucket >= 0 && b.Bucket < buckets {
+			out = append(out, b)
+		}
+	}
+	return out, rows.Err()
+}
+
+// UnpricedUsageRecord is the minimum historical fact needed by Meter to apply
+// a newly available deterministic catalog price.
+type UnpricedUsageRecord struct {
+	ID, Provider, Model                                                             string
+	PromptTokens, CompletionTokens, CachedTokens, CacheWriteTokens, ReasoningTokens int
+	CacheHit                                                                        bool
+	SlimTokensSaved, HeadroomTokensSaved                                            int
+	CreatedAt                                                                       time.Time
+}
+
+func (r *UsageRepo) ListUnpriced(ctx context.Context, after time.Time, afterID string, limit int) ([]UnpricedUsageRecord, error) {
+	if limit <= 0 || limit > 10000 {
+		limit = 1000
+	}
+	q := r.db.rebind(`
+		SELECT id, provider, model, prompt_tokens, completion_tokens, cached_tokens,
+			cache_write_tokens, reasoning_tokens, cache_hit, slim_tokens_saved, headroom_tokens_saved,
+			created_at
+		FROM usage_records
+		WHERE cost_nanos=0 AND prompt_tokens+completion_tokens>0
+			AND pricing_status IN ('missing','legacy')
+			AND (created_at>? OR (created_at=? AND id>?))
+		ORDER BY created_at ASC, id ASC LIMIT ?`)
+	cursor := formatTime(after)
+	rows, err := r.db.sql.QueryContext(ctx, q, cursor, cursor, afterID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("store: list unpriced usage: %w", err)
+	}
+	defer rows.Close()
+	var out []UnpricedUsageRecord
+	for rows.Next() {
+		var u UnpricedUsageRecord
+		var cacheHit int
+		var createdAt string
+		if err := rows.Scan(&u.ID, &u.Provider, &u.Model, &u.PromptTokens, &u.CompletionTokens,
+			&u.CachedTokens, &u.CacheWriteTokens, &u.ReasoningTokens, &cacheHit,
+			&u.SlimTokensSaved, &u.HeadroomTokensSaved, &createdAt); err != nil {
+			return nil, err
+		}
+		u.CacheHit = cacheHit != 0
+		u.CreatedAt = parseTime(createdAt)
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
+// UsagePricingUpdate is an immutable pricing snapshot computed by Meter.
+type UsagePricingUpdate struct {
+	CostMicros, CostNanos                                 int64
+	InputCostNanos, CachedCostNanos, CacheWriteCostNanos  int64
+	OutputCostNanos, ReasoningCostNanos, AvoidedCostNanos int64
+	SavedCostNanos                                        int64
+	PricingStatus, PricingSource, PricingKey              string
+	PricingMatchKind, PricingSourceURL                    string
+	PricingAsOf                                           *time.Time
+	PricingBackfilled                                     bool
+	InputRatePerM, CachedRatePerM, CacheWriteRatePerM     float64
+	OutputRatePerM, ReasoningRatePerM                     float64
+}
+
+func (r *UsageRepo) UpdateUsagePricing(ctx context.Context, id string, p UsagePricingUpdate) error {
+	q := r.db.rebind(`UPDATE usage_records SET
+		cost_micros=?, cost_nanos=?, input_cost_nanos=?, cached_cost_nanos=?,
+		cache_write_cost_nanos=?, output_cost_nanos=?, reasoning_cost_nanos=?,
+		avoided_cost_nanos=?, saved_cost_nanos=?, pricing_status=?, pricing_source=?, pricing_key=?,
+		pricing_match_kind=?, pricing_source_url=?, pricing_as_of=?, pricing_backfilled=?,
+		input_rate_per_m=?, cached_rate_per_m=?, cache_write_rate_per_m=?, output_rate_per_m=?, reasoning_rate_per_m=?
+		WHERE id=?`)
+	_, err := r.db.sql.ExecContext(ctx, q,
+		p.CostMicros, p.CostNanos, p.InputCostNanos, p.CachedCostNanos,
+		p.CacheWriteCostNanos, p.OutputCostNanos, p.ReasoningCostNanos,
+		p.AvoidedCostNanos, p.SavedCostNanos, p.PricingStatus, p.PricingSource, p.PricingKey,
+		p.PricingMatchKind, p.PricingSourceURL, nullTime(p.PricingAsOf), boolToInt(p.PricingBackfilled),
+		p.InputRatePerM, p.CachedRatePerM, p.CacheWriteRatePerM, p.OutputRatePerM, p.ReasoningRatePerM, id)
+	if err != nil {
+		return fmt.Errorf("store: update usage pricing: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/transform/anthropic.go
+++ b/backend/internal/transform/anthropic.go
@@ -439,11 +439,13 @@ func (AnthropicCodec) ParseResponse(body []byte, model string) (*core.ChatRespon
 		Message:      msg,
 		FinishReason: mapAntStop(raw.StopReason),
 		Usage: core.Usage{
-			PromptTokens:     raw.Usage.InputTokens,
+			PromptTokens:     raw.Usage.InputTokens + raw.Usage.CacheReadInputTokens + raw.Usage.CacheCreationInputTokens,
 			CompletionTokens: raw.Usage.OutputTokens,
-			TotalTokens:      raw.Usage.InputTokens + raw.Usage.OutputTokens,
+			TotalTokens: raw.Usage.InputTokens + raw.Usage.CacheReadInputTokens +
+				raw.Usage.CacheCreationInputTokens + raw.Usage.OutputTokens,
 			CachedTokens:     raw.Usage.CacheReadInputTokens,
 			CacheWriteTokens: raw.Usage.CacheCreationInputTokens,
+			Source:           core.UsageSourceProvider,
 		},
 	}, nil
 }

--- a/backend/internal/transform/anthropic_stream.go
+++ b/backend/internal/transform/anthropic_stream.go
@@ -2,8 +2,9 @@ package transform
 
 import (
 	"bytes"
-	json "github.com/mydisha/keirouter/backend/internal/fastjson"
 	"fmt"
+
+	json "github.com/mydisha/keirouter/backend/internal/fastjson"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
@@ -28,10 +29,10 @@ type antStreamEvent struct {
 		StopReason  string `json:"stop_reason"`
 	} `json:"delta"`
 	ContentBlock struct {
-		Type  string `json:"type"`
-		ID    string `json:"id"`
-		Name  string `json:"name"`
-		Text  string `json:"text"`
+		Type string `json:"type"`
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Text string `json:"text"`
 	} `json:"content_block"`
 	Usage *struct {
 		InputTokens              int `json:"input_tokens"`
@@ -100,13 +101,16 @@ func (AnthropicCodec) ParseStreamLine(line []byte, _ string) ([]core.StreamChunk
 			})
 		}
 		if ev.Usage != nil {
+			promptTokens := ev.Usage.InputTokens + ev.Usage.CacheReadInputTokens + ev.Usage.CacheCreationInputTokens
 			chunks = append(chunks, core.StreamChunk{
 				Type: core.ChunkUsage,
 				Usage: &core.Usage{
-					CompletionTokens:  ev.Usage.OutputTokens,
-					PromptTokens:      ev.Usage.InputTokens,
-					CachedTokens:      ev.Usage.CacheReadInputTokens,
-					CacheWriteTokens:  ev.Usage.CacheCreationInputTokens,
+					CompletionTokens: ev.Usage.OutputTokens,
+					PromptTokens:     promptTokens,
+					TotalTokens:      promptTokens + ev.Usage.OutputTokens,
+					CachedTokens:     ev.Usage.CacheReadInputTokens,
+					CacheWriteTokens: ev.Usage.CacheCreationInputTokens,
+					Source:           core.UsageSourceProvider,
 				},
 			})
 		}
@@ -114,13 +118,16 @@ func (AnthropicCodec) ParseStreamLine(line []byte, _ string) ([]core.StreamChunk
 
 	case "message_start":
 		if ev.Message != nil {
+			promptTokens := ev.Message.Usage.InputTokens + ev.Message.Usage.CacheReadInputTokens + ev.Message.Usage.CacheCreationInputTokens
 			return []core.StreamChunk{{
 				Type: core.ChunkUsage,
 				Usage: &core.Usage{
-					PromptTokens:      ev.Message.Usage.InputTokens,
-					CompletionTokens:  ev.Message.Usage.OutputTokens,
-					CachedTokens:      ev.Message.Usage.CacheReadInputTokens,
-					CacheWriteTokens:  ev.Message.Usage.CacheCreationInputTokens,
+					PromptTokens:     promptTokens,
+					CompletionTokens: ev.Message.Usage.OutputTokens,
+					TotalTokens:      promptTokens + ev.Message.Usage.OutputTokens,
+					CachedTokens:     ev.Message.Usage.CacheReadInputTokens,
+					CacheWriteTokens: ev.Message.Usage.CacheCreationInputTokens,
+					Source:           core.UsageSourceProvider,
 				},
 			}}, nil
 		}

--- a/backend/internal/transform/commandcode.go
+++ b/backend/internal/transform/commandcode.go
@@ -3,9 +3,10 @@ package transform
 import (
 	"bytes"
 	"fmt"
-	json "github.com/mydisha/keirouter/backend/internal/fastjson"
 	"strings"
 	"time"
+
+	json "github.com/mydisha/keirouter/backend/internal/fastjson"
 
 	"github.com/google/uuid"
 
@@ -331,6 +332,7 @@ func ccUsageChunk(u *ccUsage) core.StreamChunk {
 			PromptTokens:     u.InputTokens,
 			CompletionTokens: u.OutputTokens,
 			TotalTokens:      total,
+			Source:           core.UsageSourceProvider,
 		},
 	}
 }

--- a/backend/internal/transform/gemini.go
+++ b/backend/internal/transform/gemini.go
@@ -281,6 +281,7 @@ type gemResponse struct {
 	UsageMetadata struct {
 		PromptTokenCount        int `json:"promptTokenCount"`
 		CandidatesTokenCount    int `json:"candidatesTokenCount"`
+		ThoughtsTokenCount      int `json:"thoughtsTokenCount"`
 		TotalTokenCount         int `json:"totalTokenCount"`
 		CachedContentTokenCount int `json:"cachedContentTokenCount"`
 	} `json:"usageMetadata"`
@@ -298,15 +299,21 @@ func (GeminiCodec) ParseResponse(body []byte, model string) (*core.ChatResponse,
 	msg := parseGemContent(cand.Content)
 	msg.Role = core.RoleAssistant
 
+	completionTokens := raw.UsageMetadata.CandidatesTokenCount + raw.UsageMetadata.ThoughtsTokenCount
+	if completionTokens == 0 && raw.UsageMetadata.TotalTokenCount > raw.UsageMetadata.PromptTokenCount {
+		completionTokens = raw.UsageMetadata.TotalTokenCount - raw.UsageMetadata.PromptTokenCount
+	}
 	return &core.ChatResponse{
 		Model:        model,
 		Message:      msg,
 		FinishReason: mapGemFinish(cand.FinishReason),
 		Usage: core.Usage{
 			PromptTokens:     raw.UsageMetadata.PromptTokenCount,
-			CompletionTokens: raw.UsageMetadata.CandidatesTokenCount,
+			CompletionTokens: completionTokens,
 			TotalTokens:      raw.UsageMetadata.TotalTokenCount,
 			CachedTokens:     raw.UsageMetadata.CachedContentTokenCount,
+			ReasoningTokens:  raw.UsageMetadata.ThoughtsTokenCount,
+			Source:           core.UsageSourceProvider,
 		},
 	}, nil
 }

--- a/backend/internal/transform/gemini_stream.go
+++ b/backend/internal/transform/gemini_stream.go
@@ -24,6 +24,7 @@ type gemStreamChunk struct {
 	UsageMetadata *struct {
 		PromptTokenCount        int `json:"promptTokenCount"`
 		CandidatesTokenCount    int `json:"candidatesTokenCount"`
+		ThoughtsTokenCount      int `json:"thoughtsTokenCount"`
 		TotalTokenCount         int `json:"totalTokenCount"`
 		CachedContentTokenCount int `json:"cachedContentTokenCount"`
 	} `json:"usageMetadata"`
@@ -69,13 +70,19 @@ func (GeminiCodec) ParseStreamLine(line []byte, _ string) ([]core.StreamChunk, e
 	}
 
 	if raw.UsageMetadata != nil {
+		completionTokens := raw.UsageMetadata.CandidatesTokenCount + raw.UsageMetadata.ThoughtsTokenCount
+		if completionTokens == 0 && raw.UsageMetadata.TotalTokenCount > raw.UsageMetadata.PromptTokenCount {
+			completionTokens = raw.UsageMetadata.TotalTokenCount - raw.UsageMetadata.PromptTokenCount
+		}
 		chunks = append(chunks, core.StreamChunk{
 			Type: core.ChunkUsage,
 			Usage: &core.Usage{
 				PromptTokens:     raw.UsageMetadata.PromptTokenCount,
-				CompletionTokens: raw.UsageMetadata.CandidatesTokenCount,
+				CompletionTokens: completionTokens,
 				TotalTokens:      raw.UsageMetadata.TotalTokenCount,
 				CachedTokens:     raw.UsageMetadata.CachedContentTokenCount,
+				ReasoningTokens:  raw.UsageMetadata.ThoughtsTokenCount,
+				Source:           core.UsageSourceProvider,
 			},
 		})
 	}

--- a/backend/internal/transform/ollama.go
+++ b/backend/internal/transform/ollama.go
@@ -283,6 +283,7 @@ func (OllamaCodec) ParseResponse(body []byte, model string) (*core.ChatResponse,
 			PromptTokens:     raw.PromptEvalCount,
 			CompletionTokens: raw.EvalCount,
 			TotalTokens:      raw.PromptEvalCount + raw.EvalCount,
+			Source:           core.UsageSourceProvider,
 		},
 	}, nil
 }
@@ -384,6 +385,7 @@ func (OllamaCodec) ParseStreamLine(line []byte, model string) ([]core.StreamChun
 				PromptTokens:     raw.PromptEvalCount,
 				CompletionTokens: raw.EvalCount,
 				TotalTokens:      raw.PromptEvalCount + raw.EvalCount,
+				Source:           core.UsageSourceProvider,
 			},
 		})
 	}

--- a/backend/internal/transform/openai.go
+++ b/backend/internal/transform/openai.go
@@ -835,6 +835,9 @@ type oaiUsage struct {
 	PromptTokensDetails *struct {
 		CachedTokens int `json:"cached_tokens"`
 	} `json:"prompt_tokens_details,omitempty"`
+	CompletionTokensDetails *struct {
+		ReasoningTokens int `json:"reasoning_tokens"`
+	} `json:"completion_tokens_details,omitempty"`
 }
 
 func (c OpenAICodec) ParseResponse(body []byte, model string) (*core.ChatResponse, error) {
@@ -902,15 +905,20 @@ func (OpenAICodec) buildResponse(raw oaiResponse, model string) (*core.ChatRespo
 		FinishReason: mapOAIFinish(choice.FinishReason),
 	}
 	if raw.Usage != nil {
-		var cached int
+		var cached, reasoning int
 		if raw.Usage.PromptTokensDetails != nil {
 			cached = raw.Usage.PromptTokensDetails.CachedTokens
+		}
+		if raw.Usage.CompletionTokensDetails != nil {
+			reasoning = raw.Usage.CompletionTokensDetails.ReasoningTokens
 		}
 		resp.Usage = core.Usage{
 			PromptTokens:     raw.Usage.PromptTokens,
 			CompletionTokens: raw.Usage.CompletionTokens,
 			TotalTokens:      raw.Usage.TotalTokens,
 			CachedTokens:     cached,
+			ReasoningTokens:  reasoning,
+			Source:           core.UsageSourceProvider,
 		}
 	}
 	return resp, nil

--- a/backend/internal/transform/openai_responses.go
+++ b/backend/internal/transform/openai_responses.go
@@ -476,6 +476,9 @@ type respUnary struct {
 		InputTokensDetails struct {
 			CachedTokens int `json:"cached_tokens"`
 		} `json:"input_tokens_details"`
+		OutputTokensDetails struct {
+			ReasoningTokens int `json:"reasoning_tokens"`
+		} `json:"output_tokens_details"`
 	} `json:"usage"`
 }
 
@@ -528,6 +531,8 @@ func (OpenAIResponsesCodec) ParseResponse(body []byte, model string) (*core.Chat
 			CompletionTokens: raw.Usage.OutputTokens,
 			TotalTokens:      raw.Usage.InputTokens + raw.Usage.OutputTokens,
 			CachedTokens:     cached,
+			ReasoningTokens:  raw.Usage.OutputTokensDetails.ReasoningTokens,
+			Source:           core.UsageSourceProvider,
 		}
 	}
 	return resp, nil

--- a/backend/internal/transform/openai_responses_stream.go
+++ b/backend/internal/transform/openai_responses_stream.go
@@ -36,6 +36,9 @@ type respStreamEvent struct {
 			InputTokensDetails struct {
 				CachedTokens int `json:"cached_tokens"`
 			} `json:"input_tokens_details"`
+			OutputTokensDetails struct {
+				ReasoningTokens int `json:"reasoning_tokens"`
+			} `json:"output_tokens_details"`
 		} `json:"usage"`
 		Error *struct {
 			Message string `json:"message"`
@@ -112,6 +115,8 @@ func (OpenAIResponsesCodec) ParseStreamLine(line []byte, _ string) ([]core.Strea
 					CompletionTokens: u.OutputTokens,
 					TotalTokens:      u.InputTokens + u.OutputTokens,
 					CachedTokens:     u.InputTokensDetails.CachedTokens,
+					ReasoningTokens:  u.OutputTokensDetails.ReasoningTokens,
+					Source:           core.UsageSourceProvider,
 				},
 			})
 		}

--- a/backend/internal/transform/openai_stream.go
+++ b/backend/internal/transform/openai_stream.go
@@ -2,8 +2,9 @@ package transform
 
 import (
 	"bytes"
-	json "github.com/mydisha/keirouter/backend/internal/fastjson"
 	"fmt"
+
+	json "github.com/mydisha/keirouter/backend/internal/fastjson"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
@@ -14,13 +15,13 @@ type oaiStreamChunk struct {
 	Model   string `json:"model"`
 	Choices []struct {
 		Delta struct {
-			Role      string `json:"role"`
-			Content   string `json:"content"`
+			Role    string `json:"role"`
+			Content string `json:"content"`
 			// ReasoningContent carries thinking/reasoning text from models
 			// that expose it as a structured field (DeepSeek, some MiMo
 			// versions). The JSON field name varies by provider.
-			ReasoningContent string `json:"reasoning_content"`
-			ToolCalls []oaiStreamToolCall `json:"tool_calls"`
+			ReasoningContent string              `json:"reasoning_content"`
+			ToolCalls        []oaiStreamToolCall `json:"tool_calls"`
 		} `json:"delta"`
 		FinishReason *string `json:"finish_reason"`
 	} `json:"choices"`
@@ -88,9 +89,12 @@ func (OpenAICodec) ParseStreamLine(line []byte, model string) ([]core.StreamChun
 	}
 
 	if raw.Usage != nil {
-		var cached int
+		var cached, reasoning int
 		if raw.Usage.PromptTokensDetails != nil {
 			cached = raw.Usage.PromptTokensDetails.CachedTokens
+		}
+		if raw.Usage.CompletionTokensDetails != nil {
+			reasoning = raw.Usage.CompletionTokensDetails.ReasoningTokens
 		}
 		chunks = append(chunks, core.StreamChunk{
 			Type: core.ChunkUsage,
@@ -99,6 +103,8 @@ func (OpenAICodec) ParseStreamLine(line []byte, model string) ([]core.StreamChun
 				CompletionTokens: raw.Usage.CompletionTokens,
 				TotalTokens:      raw.Usage.TotalTokens,
 				CachedTokens:     cached,
+				ReasoningTokens:  reasoning,
+				Source:           core.UsageSourceProvider,
 			},
 		})
 	}

--- a/frontend/src/components/SavingsBreakdown.tsx
+++ b/frontend/src/components/SavingsBreakdown.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Scissors, Coins, FileText, Gauge, Sparkles, Layers } from "lucide-react";
+import { ChevronDown, FileText, Scissors } from "lucide-react";
 import type { ClientSaving, TokenSavings, UsageInsights } from "../lib/api";
 import { SavingsCardShareButton } from "./SavingsCard";
 
@@ -85,39 +85,21 @@ function ClientAvatar({ id, className = "h-6 w-6" }: { id: string; className?: s
   );
 }
 
-// StatTile renders a hero metric with a soft colored accent.
-function StatTile({ label, value, unit, icon: Icon, tint }: {
-  label: string; value: string; unit?: string; icon: any; tint: string;
-}) {
-  return (
-    <div className="relative flex flex-col gap-2 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] p-3.5">
-      <div className="absolute inset-0 opacity-[0.07]" style={{ background: `radial-gradient(120% 120% at 100% 0%, ${tint} 0%, transparent 60%)` }} />
-      <div className="relative flex items-center gap-1.5">
-        <Icon className="h-3.5 w-3.5" style={{ color: tint }} />
-        <span className="text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">{label}</span>
-      </div>
-      <div className="relative flex items-baseline gap-1">
-        <span className="text-xl font-light tabular-nums leading-none text-[var(--text)]">{value}</span>
-        {unit && <span className="text-[11px] font-medium text-[var(--text-muted)]">{unit}</span>}
-      </div>
-    </div>
-  );
-}
-
 export function TokenSavingsBreakdown({ savings, totalRequests, insights, period }: { savings: TokenSavings; totalRequests: number; insights: UsageInsights; period: string }) {
+  const [expanded, setExpanded] = useState(false);
   const rules = (savings.rules || []).slice().sort((a, b) => b.bytes_saved - a.bytes_saved);
   const maxBytes = Math.max(...rules.map((r) => r.bytes_saved), 1);
   const totalCavemanPct = totalRequests > 0 ? ((savings.caveman_requests / totalRequests) * 100).toFixed(1) : "0";
   const totalTersePct = totalRequests > 0 ? ((savings.terse_requests / totalRequests) * 100).toFixed(0) : "0";
-  // New savers. Old payloads predate these fields, so coalesce missing to 0.
-  const headroomTokensSaved = savings.headroom_tokens_saved ?? 0;
-  const ponytailRequests = savings.ponytail_requests ?? 0;
+  const headroomTokensSaved = savings.headroom_tokens_saved;
+  const ponytailRequests = savings.ponytail_requests;
   const totalPonytailPct = totalRequests > 0 ? ((ponytailRequests / totalRequests) * 100).toFixed(0) : "0";
-  const hasSavings = savings.slim_bytes_saved > 0 || savings.caveman_requests > 0 || savings.terse_requests > 0 || headroomTokensSaved > 0 || ponytailRequests > 0 || rules.length > 0;
-  // Prefer the backend's blended USD estimate; fall back to a rough $3/M rate
-  // for older payloads that predate the usd_saved field.
-  const usdSaved = savings.usd_saved ?? (savings.slim_tokens_saved / 1_000_000) * 3;
-  const optimizedRequests = savings.caveman_requests + savings.terse_requests;
+  const hasSavings = savings.total_tokens_saved > 0 || savings.optimized_requests > 0 || savings.usd_saved > 0 || rules.length > 0;
+  // USD savings and optimized request count are authoritative backend values.
+  // They must not be reconstructed from overlapping optimizer activations or a
+  // hard-coded blended token rate.
+  const usdSaved = savings.usd_saved;
+  const optimizedRequests = savings.optimized_requests;
 
   const badges: { label: string; pct: string; color: string }[] = [];
   if (savings.caveman_requests > 0) badges.push({ label: "CVMN", pct: totalCavemanPct, color: "#a855f7" });
@@ -126,35 +108,45 @@ export function TokenSavingsBreakdown({ savings, totalRequests, insights, period
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm overflow-hidden">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--border)] px-5 py-3 bg-[var(--bg-subtle)]">
-        <div className="flex items-center gap-2">
-          <span className="flex h-6 w-6 items-center justify-center rounded-lg bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
-            <Scissors className="h-3.5 w-3.5" />
+      <div className="flex items-stretch bg-[var(--bg-subtle)]">
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((current) => !current)}
+          className="flex min-w-0 flex-1 flex-wrap items-center gap-x-5 gap-y-2 px-5 py-3 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-400/60"
+        >
+          <span className="flex min-w-[180px] items-center gap-2">
+            <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
+              <Scissors className="h-3.5 w-3.5" />
+            </span>
+            <span>
+              <span className="block text-sm font-semibold tracking-tight">Optimization</span>
+              <span className="block text-[10px] text-[var(--text-muted)]">Open rules and client attribution</span>
+            </span>
           </span>
-          <h3 className="text-sm font-semibold tracking-tight">Optimization Engine</h3>
-        </div>
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2.5 text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
-            {badges.map((b) => (
-              <span key={b.label} className="flex items-center gap-1.5">
-                <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: b.color }} />
-                {b.label} {b.pct}%
-              </span>
-            ))}
-          </div>
+          <span className="flex flex-1 flex-wrap items-center gap-x-5 gap-y-1 text-xs tabular-nums">
+            <span><strong className="text-[var(--text)]">{fmtUSD(usdSaved)}</strong> <span className="text-[var(--text-muted)]">saved</span></span>
+            <span><strong className="text-[var(--text)]">{fmtNum(savings.total_tokens_saved)}</strong> <span className="text-[var(--text-muted)]">tokens</span></span>
+            <span><strong className="text-[var(--text)]">{fmtNum(optimizedRequests)}</strong> <span className="text-[var(--text-muted)]">optimized</span></span>
+            <span className="hidden xl:inline"><strong className="text-[var(--text)]">{fmtBytes(savings.slim_bytes_saved)}</strong> <span className="text-[var(--text-muted)]">prompt reduced</span></span>
+          </span>
+          <ChevronDown className={`h-4 w-4 shrink-0 text-[var(--text-muted)] transition-transform ${expanded ? "rotate-180" : ""}`} />
+        </button>
+        <div className="flex shrink-0 items-center border-l border-[var(--border)] px-3">
           <SavingsCardShareButton insights={insights} period={period} />
         </div>
       </div>
 
-      <div className="p-5">
-        {/* Hero stat tiles */}
-        <div className="mb-6 grid grid-cols-2 gap-3 lg:grid-cols-4">
-          <StatTile label="Total Saved" value={fmtBytes(savings.slim_bytes_saved)} icon={Sparkles} tint="#10b981" />
-          <StatTile label="Tokens Saved" value={fmtNum(savings.slim_tokens_saved)} unit="tok" icon={Coins} tint="#f59e0b" />
-          <StatTile label="Est. Value" value={fmtUSD(usdSaved)} unit="est" icon={Gauge} tint="#0ea5e9" />
-          <StatTile label="Optimized" value={fmtNum(optimizedRequests)} unit="req" icon={Layers} tint="#a855f7" />
+      {expanded && <div className="border-t border-[var(--border)] p-5">
+        <div className="mb-4 flex flex-wrap items-center gap-2 text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
+          {badges.map((badge) => (
+            <span key={badge.label} className="flex items-center gap-1.5 rounded-full border border-[var(--border)] px-2 py-1">
+              <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: badge.color }} />
+              {badge.label} {badge.pct}%
+            </span>
+          ))}
+          {savings.usd_saved_estimate && <span className="rounded-full border border-amber-300/60 px-2 py-1 text-amber-700 dark:text-amber-300">Estimated value</span>}
         </div>
-
         {/* Rules */}
         <div>
           <div className="mb-3 flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-[var(--text-muted)]">
@@ -180,7 +172,7 @@ export function TokenSavingsBreakdown({ savings, totalRequests, insights, period
                         className="h-full rounded-full transition-all"
                         style={{
                           width: `${Math.max(3, (r.bytes_saved / maxBytes) * 100)}%`,
-                          background: "linear-gradient(90deg, var(--color-accent-500), #10b981)",
+                          background: "var(--color-accent-500)",
                         }}
                       />
                     </div>
@@ -215,7 +207,7 @@ export function TokenSavingsBreakdown({ savings, totalRequests, insights, period
         )}
 
         <ClientBreakdown clients={savings.by_client || []} />
-      </div>
+      </div>}
     </div>
   );
 }
@@ -244,12 +236,12 @@ function ClientBreakdown({ clients }: { clients: ClientSaving[] }) {
               <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[var(--bg-subtle)]">
                 <div
                   className="h-full rounded-full"
-                  style={{ width: `${Math.max(3, (c.tokens_saved / maxTokens) * 100)}%`, background: "linear-gradient(90deg, var(--color-accent-500), #10b981)" }}
+                  style={{ width: `${Math.max(3, (c.tokens_saved / maxTokens) * 100)}%`, background: "var(--color-accent-500)" }}
                 />
               </div>
               <div className="mt-1 flex items-center justify-between text-[10px] font-medium tabular-nums text-[var(--text-muted)]">
                 <span>{fmtNum(c.tokens_saved)} tok saved</span>
-                <span>{c.requests}× requests</span>
+                <span>{fmtNum(c.optimized_requests)} optimized / {fmtNum(c.requests)} total</span>
               </div>
             </div>
           </div>

--- a/frontend/src/components/SavingsCard.tsx
+++ b/frontend/src/components/SavingsCard.tsx
@@ -42,6 +42,7 @@ const cardAccents = ["#059669", "#C45F3A", "#2563eb", "#9a978c"];
 
 interface SavingsCardData {
   costSaved: number;
+  costSavedEstimated: boolean;
   tokensSaved: number;
   savingsPct: number;
   totalRequests: number;
@@ -61,6 +62,7 @@ function formatCost(cost: number): string {
 function SavingsCardContent({ data }: { data: SavingsCardData }) {
   const {
     costSaved,
+    costSavedEstimated,
     tokensSaved,
     savingsPct,
     totalRequests,
@@ -78,8 +80,9 @@ function SavingsCardContent({ data }: { data: SavingsCardData }) {
   ].filter(Boolean) as { name: string; desc: string }[];
 
   return (
-    <div
-      style={{
+		<div
+			aria-hidden="true"
+			style={{
         width: 1200,
         height: 630,
         position: "relative",
@@ -236,7 +239,7 @@ function SavingsCardContent({ data }: { data: SavingsCardData }) {
                 letterSpacing: "0.08em",
               }}
             >
-              Total Cost Saved
+              {costSavedEstimated ? "Estimated Cost Saved" : "Total Cost Saved"}
             </span>
             <span
               style={{
@@ -270,7 +273,7 @@ function SavingsCardContent({ data }: { data: SavingsCardData }) {
                     <line x1="12" y1="5" x2="12" y2="19"></line>
                     <polyline points="19 12 12 19 5 12"></polyline>
                   </svg>
-                  {savingsPct.toFixed(1)}% Reduction
+                  {savingsPct.toFixed(1)}% {costSavedEstimated ? "Estimated Reduction" : "Reduction"}
                 </div>
               </div>
             )}
@@ -424,15 +427,15 @@ export function SavingsCardShareButton({
 
   const { summary, savings } = insights;
 
-  const avgRate = 3;
-  const tokensSaved = savings?.slim_tokens_saved ?? 0;
-  const costSaved = (tokensSaved / 1_000_000) * avgRate;
+  const tokensSaved = savings.total_tokens_saved;
+  const costSaved = savings.usd_saved;
   const actualCost = summary.cost_usd;
   const originalCost = actualCost + costSaved;
   const savingsPct = originalCost > 0 ? (costSaved / originalCost) * 100 : 0;
 
   const cardData: SavingsCardData = {
     costSaved,
+    costSavedEstimated: savings.usd_saved_estimate,
     tokensSaved,
     savingsPct,
     totalRequests: summary.total_requests,
@@ -487,8 +490,11 @@ export function SavingsCardShareButton({
       </div>
 
       {/* Download button */}
-      <button
-        onClick={handleShare}
+		<button
+			type="button"
+			aria-label={done ? "Savings card downloaded" : generating ? "Generating savings card" : "Download savings card"}
+			title="Download savings card"
+			onClick={handleShare}
         disabled={generating || summary.total_requests === 0}
         className="inline-flex h-8 items-center gap-1.5 whitespace-nowrap rounded-lg bg-accent-600 px-3 text-xs font-medium text-white shadow-sm transition-all hover:bg-accent-700 active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-accent-500 dark:hover:bg-accent-400"
       >

--- a/frontend/src/components/ui.tsx
+++ b/frontend/src/components/ui.tsx
@@ -1,6 +1,6 @@
 // Reusable UI primitives styled with the KeiRouter design system. Calm,
 // generously spaced, soft shadows and rounded surfaces — no gradients or neon.
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
 import type {
   ButtonHTMLAttributes,
   InputHTMLAttributes,
@@ -360,39 +360,105 @@ export function Modal({
   title: ReactNode;
   subtitle?: string;
   children: ReactNode;
-  maxWidth?: string;
+	maxWidth?: string;
 }) {
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const onCloseRef = useRef(onClose);
+	const titleId = useId();
+
+	useEffect(() => {
+		onCloseRef.current = onClose;
+	}, [onClose]);
+
+	useEffect(() => {
+		if (!open) return;
+		const previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+		const dialog = dialogRef.current;
+		const focusableSelector = [
+			"button:not([disabled])",
+			"[href]",
+			"input:not([disabled])",
+			"select:not([disabled])",
+			"textarea:not([disabled])",
+			"[tabindex]:not([tabindex='-1'])",
+			"[contenteditable='true']",
+		].join(",");
+		const focusableElements = () =>
+			Array.from(dialog?.querySelectorAll<HTMLElement>(focusableSelector) ?? [])
+				.filter((element) => element.getAttribute("aria-hidden") !== "true");
+
+		const frame = window.requestAnimationFrame(() => {
+			const initial = dialog?.querySelector<HTMLElement>("[data-modal-autofocus]")
+				?? focusableElements()[0]
+				?? dialog;
+			initial?.focus();
+		});
+
+		const onKey = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				onCloseRef.current();
+				return;
+			}
+			if (event.key !== "Tab" || !dialog) return;
+			const elements = focusableElements();
+			if (elements.length === 0) {
+				event.preventDefault();
+				dialog.focus();
+				return;
+			}
+			const first = elements[0];
+			const last = elements[elements.length - 1];
+			const active = document.activeElement;
+			if (event.shiftKey && (active === first || !dialog.contains(active))) {
+				event.preventDefault();
+				last.focus();
+			} else if (!event.shiftKey && (active === last || !dialog.contains(active))) {
+				event.preventDefault();
+				first.focus();
+			}
+		};
+		const onFocusIn = (event: FocusEvent) => {
+			if (dialog && event.target instanceof Node && !dialog.contains(event.target)) {
+				dialog.focus();
+			}
+		};
+		document.addEventListener("keydown", onKey);
+		document.addEventListener("focusin", onFocusIn);
+		return () => {
+			window.cancelAnimationFrame(frame);
+			document.removeEventListener("keydown", onKey);
+			document.removeEventListener("focusin", onFocusIn);
+			if (previousFocus?.isConnected) previousFocus.focus();
+		};
+	}, [open]);
 
   if (!open) return null;
 
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
-      onClick={onClose}
-      role="dialog"
-      aria-modal="true"
-      aria-label={typeof title === "string" ? title : undefined}
-    >
-      <div
-        className={`w-full ${maxWidth} rounded-2xl border border-[var(--border)] bg-[var(--bg-elevated)] shadow-[var(--shadow-float)]`}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between border-b border-[var(--border)] px-6 py-4">
-          <div>
-            <h2 className="text-base font-semibold tracking-tight">{title}</h2>
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+			onClick={onClose}
+		>
+			<div
+				ref={dialogRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={titleId}
+				tabIndex={-1}
+				className={`w-full ${maxWidth} rounded-2xl border border-[var(--border)] bg-[var(--bg-elevated)] shadow-[var(--shadow-float)]`}
+				onClick={(e) => e.stopPropagation()}
+			>
+				<div className="flex items-center justify-between border-b border-[var(--border)] px-6 py-4">
+					<div>
+						<h2 id={titleId} className="text-base font-semibold tracking-tight">{title}</h2>
             {subtitle && <p className="mt-0.5 text-sm text-[var(--text-muted)]">{subtitle}</p>}
           </div>
-          <button
-            onClick={onClose}
-            aria-label="Close"
+					<button
+						type="button"
+						onClick={onClose}
+						aria-label="Close"
+						data-modal-autofocus
             className="flex h-9 w-9 items-center justify-center rounded-xl text-[var(--text-muted)] transition-colors hover:bg-ink-100 hover:text-[var(--text)] dark:hover:bg-ink-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/60"
           >
             <X className="h-4 w-4" />
@@ -421,6 +487,7 @@ export function TabBar<T extends string>({
         return (
           <button
             key={tab.value}
+            type="button"
             role="tab"
             aria-selected={isActive}
             onClick={() => onChange(tab.value)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -340,33 +340,94 @@ export interface UsageSummary {
   since: string;
 }
 
+export type UsageTerminalStatus = "success" | "cache_hit" | "blocked" | "failed" | "cancelled";
+export type UsageSource = "provider" | "estimated" | "cache" | "legacy" | "none";
+export type PricingStatus = "priced" | "estimated" | "free" | "missing" | "partial" | "legacy" | "none" | "mixed";
+
 export interface ProviderUsage {
   provider: string;
   display_name: string;
   color: string;
   icon: string;
   total_requests: number;
+  successful_requests: number;
+  failed_requests: number;
+  success_rate: number;
   prompt_tokens: number;
   completion_tokens: number;
+  cached_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
+  total_tokens: number;
   cost_usd: number;
+  saved_cost_usd: number;
+  avoided_cost_usd: number;
+  avg_latency_ms: number;
+  avg_ttft_ms: number;
+  pricing_eligible_requests: number;
+  unpriced_requests: number;
+  estimated_requests: number;
+  estimated_usage_requests: number;
+  legacy_usage_requests: number;
+  backfilled_requests: number;
+	pricing_request_coverage: number | null;
   share_pct: number;
+  token_share_pct: number;
 }
 
 export interface RecentActivity {
   id: string;
+  request_id: string;
   provider: string;
+  provider_name: string;
+  provider_color: string;
+  provider_icon: string;
   model: string;
+  status: UsageTerminalStatus;
+  error_kind: string;
+  usage_source: UsageSource;
+  prompt_tokens: number;
+  completion_tokens: number;
+  cached_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
   tokens: number;
   cost_usd: number;
+  input_cost_usd: number;
+  cached_cost_usd: number;
+  cache_write_cost_usd: number;
+  output_cost_usd: number;
+  reasoning_cost_usd: number;
+  saved_cost_usd: number;
+  avoided_cost_usd: number;
+  pricing_status: PricingStatus;
+  pricing_source: string;
+  pricing_key: string;
+  pricing_match_kind: string;
+  pricing_source_url: string;
+  pricing_as_of: string | null;
+  pricing_backfilled: boolean;
+  input_rate_per_m: number;
+  cached_rate_per_m: number;
+  cache_write_rate_per_m: number;
+  output_rate_per_m: number;
+  reasoning_rate_per_m: number;
   cache_hit: boolean;
   latency_ms: number;
+  upstream_latency_ms: number;
+  end_to_end_latency_ms: number;
+  ttft_ms: number;
+  slim_bytes_saved: number;
+  slim_tokens_saved: number;
+  slim_rules: string;
+  slim_active: boolean;
+  caveman_active: boolean;
+  terse_active: boolean;
+  headroom_tokens_saved: number;
+  headroom_bytes_saved: number;
+  headroom_active: boolean;
+  ponytail_active: boolean;
   created_at: string;
-  ttft_ms?: number;
-  slim_bytes_saved?: number;
-  slim_tokens_saved?: number;
-  slim_rules?: string;
-  caveman_active?: boolean;
-  terse_active?: boolean;
 }
 
 export interface RuleSaving {
@@ -379,69 +440,140 @@ export interface RuleSaving {
 export interface ClientSaving {
   client: string;
   requests: number;
+  optimized_requests: number;
   bytes_saved: number;
   tokens_saved: number;
-  usd_saved: number;
+  slim_tokens_saved: number;
   caveman_requests: number;
   terse_requests: number;
-  // Headroom/Ponytail per-client savings. Optional for backward-compat with
-  // payloads recorded before these savers existed; treat missing as 0.
-  headroom_tokens_saved?: number;
-  ponytail_requests?: number;
+  headroom_tokens_saved: number;
+  ponytail_requests: number;
+  saved_cost_usd: number;
+  avoided_cost_usd: number;
+  usd_saved: number;
 }
 
 export interface TokenSavings {
   slim_bytes_saved: number;
   slim_tokens_saved: number;
+  headroom_tokens_saved: number;
+  total_tokens_saved: number;
+  saved_tokens_per_request: number;
+  saved_tokens_per_optimized_request: number;
+  optimized_requests: number;
   caveman_requests: number;
   terse_requests: number;
-  usd_saved?: number;
-  usd_saved_estimate?: boolean;
-  // Headroom/Ponytail summary savings. Optional for backward-compat with
-  // payloads recorded before these savers existed; treat missing as 0.
-  headroom_tokens_saved?: number;
-  ponytail_requests?: number;
-  headroom_requests?: number;
+  headroom_requests: number;
+  ponytail_requests: number;
+  saved_cost_usd: number;
+  avoided_cost_usd: number;
+  usd_saved: number;
+  usd_saved_estimate: boolean;
   rules: RuleSaving[];
-  by_client?: ClientSaving[];
+  by_client: ClientSaving[];
 }
 
 export interface ModelUsage {
   provider: string;
   provider_name: string;
+  provider_color: string;
+  provider_icon: string;
   model: string;
   total_requests: number;
+  successful_requests: number;
+  failed_requests: number;
+  success_rate: number;
   prompt_tokens: number;
   completion_tokens: number;
+  cached_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
+  total_tokens: number;
   cost_usd: number;
-  input_per_m?: number;
-  output_per_m?: number;
-  cached_input_per_m?: number;
+  saved_cost_usd: number;
+  avoided_cost_usd: number;
+  avg_latency_ms: number;
+  avg_ttft_ms: number;
+  pricing_eligible_requests: number;
+	unpriced_requests: number;
+	missing_pricing_requests: number;
+	legacy_pricing_requests: number;
+  estimated_requests: number;
+  estimated_usage_requests: number;
+  legacy_usage_requests: number;
+  backfilled_requests: number;
+	pricing_request_coverage: number | null;
+  pricing_status: PricingStatus;
+  pricing_mixed: boolean;
+  pricing_source: string;
+  pricing_key: string;
+  input_per_m: number;
+  cached_input_per_m: number;
+  cache_write_per_m: number;
+  output_per_m: number;
+  reasoning_per_m: number;
 }
 
 export interface SeriesPoint {
   label: string;
+  start: string;
   count: number;
+  requests: number;
+  failures: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  cost_usd: number;
+}
+
+export interface UsageInsightsSummary {
+  total_requests: number;
+  successful_requests: number;
+  failed_requests: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  cached_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
+  total_tokens: number;
+  cost_usd: number;
+  cost_per_request_usd: number;
+  tokens_per_request: number;
+  cache_hits: number;
+  success_rate: number;
+  avg_latency_ms: number;
+  avg_ttft_ms: number;
+  pricing_eligible_requests: number;
+  priced_requests: number;
+  unpriced_requests: number;
+  unpriced_tokens: number;
+  estimated_requests: number;
+  estimated_usage_requests: number;
+  estimated_usage_tokens: number;
+  legacy_usage_requests: number;
+  legacy_usage_tokens: number;
+  backfilled_requests: number;
+	pricing_request_coverage: number | null;
+	pricing_token_coverage: number | null;
+  since: string;
 }
 
 export interface UsageInsights {
-  summary: {
-    total_requests: number;
-    prompt_tokens: number;
-    completion_tokens: number;
-    cached_tokens: number;
-    cost_usd: number;
-    cache_hits: number;
-    success_rate: number;
-    avg_latency_ms: number;
-    avg_ttft_ms: number;
-    since: string;
-  };
+  period: string;
+  since: string;
+  generated_at: string;
+  summary: UsageInsightsSummary;
   savings: TokenSavings;
   providers: ProviderUsage[];
   recent: RecentActivity[];
   series: SeriesPoint[];
   busiest: string;
+}
+
+export interface ModelUsageResponse {
+  period: string;
+  since: string;
+  generated_at: string;
+  models: ModelUsage[];
 }
 
 export interface UpstreamQuota {
@@ -503,7 +635,9 @@ export interface QuotaAccount {
   auth_kind: string;
   priority: number;
   status: string; // active | paused | needs_attention
-  usage_type: string; // token | credit
+  usage_type: string; // compatibility field; not a paid/free classification
+  quota_supported?: boolean;
+  quota_state?: "reported" | "pending" | "paused" | "unavailable" | "error" | "usage_only";
   total_requests: number;
   prompt_tokens: number;
   completion_tokens: number;
@@ -1179,7 +1313,7 @@ export const api = {
   usageInsights: (period: string) =>
     request<UsageInsights>("GET", `/usage/insights?period=${period}&tz=${browserTZ()}`),
   modelUsage: (period: string) =>
-    request<{ models: ModelUsage[] }>("GET", `/usage/models?period=${period}&tz=${browserTZ()}`),
+    request<ModelUsageResponse>("GET", `/usage/models?period=${period}&tz=${browserTZ()}`),
 
   quota: (period: string) =>
     request<{ accounts: QuotaAccount[]; since: string }>("GET", `/quota?period=${period}&tz=${browserTZ()}`),
@@ -1509,6 +1643,8 @@ export interface HealthSummary {
   disabled: number;
   fallbacks: number;
   avg_p95_latency_ms: number;
+  telemetry_dropped: number;
+  telemetry_dropped_scope: "process_lifetime";
 }
 
 export interface HealthProviderRow {
@@ -1527,7 +1663,16 @@ export interface HealthProviderRow {
   recommendation?: string;
 }
 
+export interface HealthOverviewWindow {
+  kind: "rolling_current";
+  duration_seconds: number;
+  requested_range: string;
+  generated_at: string;
+  since?: string;
+}
+
 export interface HealthOverview {
+  window: HealthOverviewWindow;
   summary: HealthSummary;
   providers: HealthProviderRow[];
 }

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -1,28 +1,54 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
 import {
   Activity,
-  DollarSign,
+  AlertTriangle,
+  ArrowUpRight,
   Database,
-  Zap,
-  Calendar,
-  Clock,
-  CheckCircle2,
+  DollarSign,
+  Layers3,
+  RefreshCw,
+  ShieldCheck,
   Timer,
   TrendingUp,
-  AlertTriangle,
   Wallet,
+  type LucideIcon,
 } from "lucide-react";
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from "recharts";
-import { api, type UsageInsights, type RecentActivity, type ProviderUsage } from "../lib/api";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  api,
+  type ProviderUsage,
+  type RecentActivity,
+  type SeriesPoint,
+  type UsageInsights,
+  type UsageTerminalStatus,
+} from "../lib/api";
 import { microsToUSD } from "../lib/format";
 import { PageHeader } from "../components/Layout";
-import { Card, SectionHeader, StatCard, ErrorCard, Skeleton } from "../components/ui";
+import {
+  Badge,
+  Card,
+  EmptyState,
+  ErrorCard,
+  SegmentedControl,
+  Skeleton,
+  TablePagination,
+  useClientPagination,
+} from "../components/ui";
 
-const periods = [
+const PERIODS = [
   { value: "today", label: "Today" },
-  { value: "week", label: "Last 7 days" },
-  { value: "month", label: "Last 30 days" },
+  { value: "week", label: "7D" },
+  { value: "month", label: "30D" },
 ];
 
 export function OverviewPage() {
@@ -33,7 +59,6 @@ export function OverviewPage() {
     staleTime: 30_000,
     placeholderData: (previous) => previous,
   });
-
   const budgets = useQuery({
     queryKey: ["budget-status"],
     queryFn: () => api.budgetStatus(),
@@ -42,479 +67,603 @@ export function OverviewPage() {
     placeholderData: (previous) => previous,
   });
 
-  const alerts = (budgets.data?.budgets ?? []).filter((b) => b.pct_used >= b.alert_pct);
-  const blocked = alerts.filter((b) => b.pct_used >= 100 && b.hard_cutoff);
-  const warnings = alerts.filter((b) => b.pct_used < 100 || !b.hard_cutoff);
+  const alerts = (budgets.data?.budgets ?? []).filter((budget) => budget.pct_used >= budget.alert_pct);
+  const blocked = alerts.filter((budget) => budget.pct_used >= 100 && budget.hard_cutoff);
+  const warnings = alerts.filter((budget) => budget.pct_used < 100 || !budget.hard_cutoff);
+  const isRefreshing = insights.isFetching && !insights.isLoading;
 
   return (
     <>
-      {/* ── Plan alerts ──────────────────────────────────────────── */}
-      {blocked.length > 0 && (
-        <div className="mb-6 flex items-center gap-3 rounded-xl border border-red-300 bg-red-50 px-4 py-3 dark:border-red-800 dark:bg-red-950/30">
-          <AlertTriangle className="h-5 w-5 shrink-0 text-red-600 dark:text-red-400" />
-          <div className="flex-1">
-            <p className="text-sm font-medium text-red-800 dark:text-red-200">Plan limit reached — requests blocked</p>
-            <p className="text-xs text-red-600 dark:text-red-400">
-              {blocked.map((b) => `${b.scope_name} (${microsToUSD(b.limit_micros)} ${b.period})`).join(", ")}
-            </p>
-          </div>
-          <a
-            href="/plans"
-            className="shrink-0 rounded-lg bg-red-100 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-200 dark:bg-red-900/40 dark:text-red-300 dark:hover:bg-red-900/60"
-          >
-            Manage
-          </a>
-        </div>
-      )}
-      {warnings.length > 0 && blocked.length === 0 && (
-        <div className="mb-6 flex items-center gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-950/30">
-          <Wallet className="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
-          <div className="flex-1">
-            <p className="text-sm font-medium text-amber-800 dark:text-amber-200">Plan alert</p>
-            <p className="text-xs text-amber-600 dark:text-amber-400">
-              {warnings.map((b) => `${b.scope_name}: ${b.pct_used.toFixed(0)}% used`).join(", ")}
-            </p>
-          </div>
-          <a
-            href="/plans"
-            className="shrink-0 rounded-lg bg-amber-100 px-3 py-1.5 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-200 dark:bg-amber-900/40 dark:text-amber-300 dark:hover:bg-amber-900/60"
-          >
-            Manage
-          </a>
-        </div>
-      )}
-
       <PageHeader
         title="Overview"
         icon={Activity}
-        description="Usage and performance across all providers."
+        description="A concise view of traffic, spend, and routing performance."
         action={
-          <div className="flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2">
-            <Calendar className="h-4 w-4 text-[var(--text-muted)]" />
-            <select
-              value={period}
-              onChange={(e) => setPeriod(e.target.value)}
-              className="bg-transparent text-sm font-medium focus:outline-none cursor-pointer"
+          <div className="flex items-center gap-2">
+            <SegmentedControl value={period} onChange={setPeriod} options={PERIODS} />
+            <button
+              type="button"
+              onClick={() => insights.refetch()}
+              disabled={insights.isFetching}
+              aria-label="Refresh overview"
+              title="Refresh overview"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)] shadow-sm transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--bg-subtle)] hover:text-[var(--text)] disabled:opacity-60"
             >
-              {periods.map((p) => (
-                <option key={p.value} value={p.value}>
-                  {p.label}
-                </option>
-              ))}
-            </select>
+              <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
+            </button>
           </div>
         }
       />
 
+      <BudgetNotice blocked={blocked} warnings={warnings} />
+
       {insights.isLoading ? (
         <OverviewSkeleton />
       ) : insights.isError ? (
-        <ErrorCard message="Failed to load usage data. Is the backend running?" />
-      ) : (
-        insights.data ? <InsightsDashboard data={insights.data} /> : null
-      )}
+        <ErrorCard message="Failed to load overview data. Is the backend running?" />
+      ) : insights.data ? (
+        <InsightsDashboard data={insights.data} />
+      ) : null}
     </>
   );
 }
 
-// OverviewSkeleton mirrors the InsightsDashboard layout so the page shows its
-// shape while data loads, avoiding a blank spinner and layout shift on arrival.
+function BudgetNotice({
+  blocked,
+  warnings,
+}: {
+  blocked: Array<{ scope_name: string; limit_micros: number; period: string }>;
+  warnings: Array<{ scope_name: string; pct_used: number }>;
+}) {
+  if (blocked.length === 0 && warnings.length === 0) return null;
+  const isBlocked = blocked.length > 0;
+  const items = isBlocked
+    ? blocked.map((budget) => `${budget.scope_name} · ${microsToUSD(budget.limit_micros)} ${budget.period}`)
+    : warnings.map((budget) => `${budget.scope_name} · ${budget.pct_used.toFixed(0)}% used`);
+
+  return (
+    <div className={`mb-6 flex flex-col gap-3 rounded-xl border px-4 py-3 sm:flex-row sm:items-center ${
+      isBlocked
+        ? "border-red-300/70 bg-red-50/60 dark:border-red-700/50 dark:bg-red-950/20"
+        : "border-amber-300/70 bg-amber-50/60 dark:border-amber-700/50 dark:bg-amber-950/20"
+    }`}>
+      {isBlocked
+        ? <AlertTriangle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+        : <Wallet className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />}
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-[var(--text)]">
+          {isBlocked ? "Plan limit reached" : "Plan threshold reached"}
+        </p>
+        <p className="mt-0.5 truncate text-xs text-[var(--text-muted)]" title={items.join(", ")}>
+          {items.join(" · ")}
+        </p>
+      </div>
+      <Link
+        to="/plans"
+        className="inline-flex shrink-0 items-center gap-1 text-xs font-semibold text-[var(--text)] hover:text-accent-600"
+      >
+        Manage plans <ArrowUpRight className="h-3.5 w-3.5" />
+      </Link>
+    </div>
+  );
+}
+
 function OverviewSkeleton() {
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <Card key={i} className="p-4">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="mt-3 h-8 w-20" />
+    <div className="space-y-6 pb-12">
+      <div className="grid gap-4 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Card key={index} className="p-5">
+            <Skeleton className="h-8 w-28" />
+            <Skeleton className="mt-4 h-9 w-32" />
+            <div className="mt-4 grid grid-cols-3 gap-3 border-t border-[var(--border)] pt-3">
+              {Array.from({ length: 3 }).map((__, item) => <Skeleton key={item} className="h-8 w-full" />)}
+            </div>
           </Card>
         ))}
       </div>
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <Card className="lg:col-span-2 p-6">
-          <Skeleton className="h-4 w-32" />
-          <Skeleton className="mt-4 h-48 w-full" />
-        </Card>
-        <Card className="p-6">
-          <Skeleton className="h-4 w-24" />
-          <div className="mt-4 space-y-3">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="h-8 w-full" />
-            ))}
-          </div>
-        </Card>
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.7fr)_minmax(320px,1fr)]">
+        <Card className="p-6"><Skeleton className="h-72 w-full" /></Card>
+        <Card className="p-6"><Skeleton className="h-72 w-full" /></Card>
       </div>
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <Card className="p-6">
-          <Skeleton className="h-4 w-28" />
-          <Skeleton className="mt-4 h-10 w-32" />
-          <div className="mt-4 space-y-2">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-4 w-full" />
-            ))}
-          </div>
-        </Card>
-        <Card className="lg:col-span-2 p-6">
-          <Skeleton className="h-4 w-32" />
-          <div className="mt-4 space-y-2">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="h-6 w-full" />
-            ))}
-          </div>
-        </Card>
-      </div>
+      <Card className="p-6"><Skeleton className="h-28 w-full" /></Card>
+      <Card className="p-6"><Skeleton className="h-96 w-full" /></Card>
     </div>
   );
 }
 
 function InsightsDashboard({ data }: { data: UsageInsights }) {
-  const { summary, providers, recent, series } = data;
+  const { summary, savings, providers, recent, series } = data;
 
   return (
-    <div className="space-y-6">
-      {/* ── Key metrics ──────────────────────────────────────────── */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <StatCard
+    <div className="space-y-6 pb-12">
+      <div className="grid gap-4 lg:grid-cols-3">
+        <SummaryGroupCard
           icon={Activity}
-          iconTone="accent"
-          label="Requests"
-          value={summary.total_requests.toLocaleString()}
+          title="Traffic"
+          primary={fmtCompact(summary.total_requests)}
+          primaryLabel="requests"
+          items={[
+            { label: "Input", value: fmtCompact(summary.prompt_tokens) },
+            { label: "Output", value: fmtCompact(summary.completion_tokens) },
+            { label: "Cache read", value: fmtCompact(summary.cached_tokens) },
+          ]}
         />
-        <StatCard
+        <SummaryGroupCard
           icon={DollarSign}
-          iconTone="warning"
-          label="Cost"
-          value={`$${summary.cost_usd.toFixed(2)}`}
+          title="Spend & value"
+          primary={fmtUSD(summary.cost_usd)}
+          primaryLabel="tracked cost"
+          tone={summary.unpriced_requests > 0 ? "warning" : "accent"}
+          items={[
+            { label: "Value saved", value: fmtUSD(savings.usd_saved), tone: "good" },
+            { label: "Cost / request", value: fmtUSD(summary.cost_per_request_usd) },
+            { label: "Pricing coverage", value: fmtCoverage(summary.pricing_request_coverage) },
+          ]}
         />
-        <StatCard
-          icon={CheckCircle2}
-          iconTone="accent"
-          label="Success rate"
-          value={`${(summary.success_rate * 100).toFixed(1)}%`}
-        />
-        <StatCard
-          icon={Timer}
-          iconTone="accent"
-          label="Avg TTFT"
-          value={`${Math.round(summary.avg_ttft_ms)}ms`}
+        <SummaryGroupCard
+          icon={ShieldCheck}
+          title="Reliability"
+          primary={fmtPercent(summary.success_rate)}
+          primaryLabel="successful"
+          tone={summary.success_rate < 0.95 && summary.total_requests > 0 ? "warning" : "success"}
+          items={[
+            { label: "Failed", value: fmtCompact(summary.failed_requests), tone: summary.failed_requests > 0 ? "danger" : undefined },
+            { label: "Avg latency", value: fmtMs(summary.avg_latency_ms) },
+            { label: "TTFT", value: fmtMs(summary.avg_ttft_ms) },
+          ]}
         />
       </div>
 
-      {/* ── Activity chart + Provider breakdown ──────────────────── */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <Card className="lg:col-span-2">
-          <SectionHeader
-            title="Request volume"
-            description="Requests over the selected period."
-            icon={TrendingUp}
-          />
-          <div className="px-6 pb-6">
-            <ActivityChart series={series} />
-          </div>
-        </Card>
-
-        <Card>
-          <SectionHeader
-            title="Providers"
-            description="Usage by provider."
-            icon={Database}
-          />
-          <div className="px-6 pb-6">
-            <ProviderBreakdown providers={providers} />
-          </div>
-        </Card>
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.7fr)_minmax(320px,1fr)]">
+        <TrendCard series={series} busiest={data.busiest} />
+        <ProviderPerformance providers={providers} />
       </div>
 
-      {/* ── Token stats + Recent activity ────────────────────────── */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <Card>
-          <SectionHeader
-            title="Token breakdown"
-            description="Input, output, and cached tokens."
-            icon={Zap}
-          />
-          <div className="px-6 pb-6">
-            <TokenStats
-              prompt={summary.prompt_tokens}
-              completion={summary.completion_tokens}
-              cached={summary.cached_tokens}
-              cacheHits={summary.cache_hits}
-            />
-          </div>
-        </Card>
-
-        <Card className="lg:col-span-2">
-          <SectionHeader
-            title="Recent activity"
-            description="Latest requests through the proxy."
-            icon={Clock}
-            action={
-              recent.length > 0 ? (
-                <span className="text-xs text-[var(--text-muted)]">
-                  Last {recent.length} requests
-                </span>
-              ) : undefined
-            }
-          />
-          <RecentActivityTable recent={recent} providers={providers} />
-        </Card>
-      </div>
+      <TokenComposition data={data} />
+      <RecentActivityTable recent={recent} providers={providers} />
     </div>
   );
 }
 
-/* ── Activity sparkline chart ────────────────────────────────────── */
+type SummaryTone = "accent" | "success" | "warning";
 
-function ActivityChart({ series }: { series: UsageInsights["series"] }) {
-  if (series.length === 0) {
-    return (
-      <div className="flex h-48 items-center justify-center text-sm text-[var(--text-muted)]">
-        No activity recorded for this period.
-      </div>
-    );
-  }
-
-  return (
-    <div className="h-48">
-      <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={series} barCategoryGap="20%">
-          <XAxis
-            dataKey="label"
-            axisLine={false}
-            tickLine={false}
-            tick={{ fontSize: 11, fill: "var(--color-ink-400)" }}
-            interval="preserveStartEnd"
-          />
-          <YAxis
-            axisLine={false}
-            tickLine={false}
-            tick={{ fontSize: 11, fill: "var(--color-ink-400)" }}
-            width={36}
-          />
-          <Tooltip
-            cursor={{ fill: "var(--color-ink-100)" }}
-            contentStyle={{
-              background: "var(--bg-elevated)",
-              border: "1px solid var(--border)",
-              borderRadius: "8px",
-              fontSize: "12px",
-              padding: "6px 10px",
-            }}
-          />
-          <Bar
-            dataKey="count"
-            fill="var(--color-accent-500)"
-            radius={[4, 4, 0, 0]}
-          />
-        </BarChart>
-      </ResponsiveContainer>
-    </div>
-  );
-}
-
-/* ── Provider breakdown ──────────────────────────────────────────── */
-
-function ProviderBreakdown({ providers }: { providers: ProviderUsage[] }) {
-  if (providers.length === 0) {
-    return (
-      <div className="py-8 text-center text-sm text-[var(--text-muted)]">
-        No provider usage yet.
-      </div>
-    );
-  }
-
-  const maxRequests = Math.max(...providers.map((p) => p.total_requests));
-
-  return (
-    <div className="divide-y divide-[var(--border)]/50">
-      {providers.map((p) => (
-        <div key={p.provider} className="py-3 first:pt-0 last:pb-0">
-          <div className="flex items-center justify-between text-sm mb-2">
-            <div className="flex items-center gap-2">
-              <SmallProviderIcon p={p} />
-              <span className="font-medium text-[var(--text)]">{p.display_name}</span>
-            </div>
-            <span className="font-mono text-xs tabular-nums text-[var(--text)]">
-              {p.total_requests.toLocaleString()} req
-            </span>
-          </div>
-          <div className="h-1 bg-[var(--bg-subtle)] relative rounded-full overflow-hidden">
-            <div
-              className="absolute inset-y-0 left-0 bg-[var(--color-ink-400)] dark:bg-[var(--color-ink-500)] transition-all duration-500"
-              style={{ width: `${maxRequests > 0 ? (p.total_requests / maxRequests) * 100 : 0}%` }}
-            />
-          </div>
-          <div className="flex items-center justify-between text-xs text-[var(--text-muted)] mt-2 font-mono">
-            <span>{compact(p.prompt_tokens + p.completion_tokens)} tks</span>
-            <span>${p.cost_usd.toFixed(4)}</span>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-/* ── Token stats (no chart, just clean numbers) ──────────────────── */
-
-function TokenStats({
-  prompt,
-  completion,
-  cached,
-  cacheHits,
+function SummaryGroupCard({
+  icon: Icon,
+  title,
+  primary,
+  primaryLabel,
+  items,
+  tone = "accent",
 }: {
-  prompt: number;
-  completion: number;
-  cached: number;
-  cacheHits: number;
+  icon: LucideIcon;
+  title: string;
+  primary: string;
+  primaryLabel: string;
+  items: Array<{ label: string; value: string; tone?: "good" | "danger" }>;
+  tone?: SummaryTone;
 }) {
-  // Cached tokens are a *subset* of prompt tokens (prompt cache hits).
-  // Use prompt + completion as the true total; show non-cached input vs cached
-  // as separate, mutually exclusive breakdown rows.
-  const nonCachedInput = Math.max(prompt - cached, 0);
-  const total = prompt + completion;
-
-  if (total === 0) {
-    return (
-      <div className="py-8 text-center text-sm text-[var(--text-muted)]">
-        No token usage recorded yet.
-      </div>
-    );
-  }
-
-  const rows = [
-    { label: "Input", value: nonCachedInput },
-    { label: "Output", value: completion },
-    { label: "Cached", value: cached },
-  ];
+  const tones: Record<SummaryTone, { icon: string; background: string }> = {
+    accent: {
+      icon: "text-secondary-600 dark:text-secondary-300",
+      background: "bg-secondary-50 ring-secondary-200/70 dark:bg-secondary-950/30 dark:ring-secondary-900/60",
+    },
+    success: {
+      icon: "text-emerald-600 dark:text-emerald-300",
+      background: "bg-emerald-50 ring-emerald-200/70 dark:bg-emerald-950/30 dark:ring-emerald-900/60",
+    },
+    warning: {
+      icon: "text-amber-700 dark:text-amber-300",
+      background: "bg-amber-50 ring-amber-200/70 dark:bg-amber-950/30 dark:ring-amber-900/60",
+    },
+  };
+  const colors = tones[tone];
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="pb-6 mb-6 border-b border-[var(--border)]">
-        <div className="flex items-baseline gap-2">
-          <span className="font-display text-4xl font-semibold tracking-tight">{compact(total)}</span>
-          <span className="text-xs uppercase tracking-wider text-[var(--text-muted)]">tokens</span>
-        </div>
+    <Card className="p-5">
+      <div className="flex items-center gap-2">
+        <span className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ring-1 ${colors.background}`}>
+          <Icon className={`h-4 w-4 ${colors.icon}`} />
+        </span>
+        <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">{title}</span>
       </div>
-
-      <div className="space-y-4 flex-1">
-        {rows.map((row) => (
-          <div key={row.label} className="flex items-center justify-between">
-            <span className="text-sm text-[var(--text-muted)]">{row.label}</span>
-            <div className="flex items-center gap-4">
-              <span className="text-sm font-mono tabular-nums text-[var(--text)]">
-                {row.value.toLocaleString()}
-              </span>
-              <span className="w-10 text-right text-xs font-mono text-[var(--text-muted)]">
-                {total > 0 ? `${((row.value / total) * 100).toFixed(0)}%` : "0%"}
-              </span>
-            </div>
+      <div className="mt-4 flex items-baseline gap-2">
+        <span className="text-3xl font-semibold tracking-tight tabular-nums text-[var(--text)]">{primary}</span>
+        <span className="text-xs text-[var(--text-muted)]">{primaryLabel}</span>
+      </div>
+      <div className="mt-4 grid grid-cols-3 gap-3 border-t border-[var(--border)] pt-3">
+        {items.map((item) => (
+          <div key={item.label} className="min-w-0">
+            <div className={`truncate text-xs font-semibold tabular-nums sm:text-sm ${
+              item.tone === "good"
+                ? "text-emerald-600 dark:text-emerald-300"
+                : item.tone === "danger"
+                  ? "text-red-600 dark:text-red-300"
+                  : "text-[var(--text)]"
+            }`} title={item.value}>{item.value}</div>
+            <div className="mt-0.5 text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">{item.label}</div>
           </div>
         ))}
       </div>
-
-      <div className="pt-4 mt-6 border-t border-[var(--border)]">
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-[var(--text-muted)]">Cache hits</span>
-          <span className="text-sm font-mono tabular-nums text-[var(--text)]">{cacheHits.toLocaleString()}</span>
-        </div>
-      </div>
-    </div>
+    </Card>
   );
 }
 
-/* ── Recent activity table ───────────────────────────────────────── */
+type TrendMetric = "requests" | "tokens" | "cost" | "failures";
+type TrendPoint = SeriesPoint & { total_tokens: number };
 
-function RecentActivityTable({ recent, providers }: { recent: RecentActivity[], providers: ProviderUsage[] }) {
-  if (recent.length === 0) {
-    return (
-      <div className="px-6 py-10 text-center text-sm text-[var(--text-muted)]">
-        No recent activity. Make a request through the proxy to see it here.
-      </div>
-    );
-  }
+const TREND_OPTIONS = [
+  { value: "requests", label: "Requests" },
+  { value: "tokens", label: "Tokens" },
+  { value: "cost", label: "Cost" },
+  { value: "failures", label: "Failures" },
+];
+
+const TREND_CONFIG: Record<TrendMetric, { key: keyof TrendPoint; label: string; color: string }> = {
+  requests: { key: "requests", label: "Requests", color: "var(--color-chart-1)" },
+  tokens: { key: "total_tokens", label: "Tokens", color: "var(--color-chart-2)" },
+  cost: { key: "cost_usd", label: "Cost", color: "var(--color-accent-500)" },
+  failures: { key: "failures", label: "Failures", color: "var(--color-danger)" },
+};
+
+function TrendCard({ series, busiest }: { series: SeriesPoint[]; busiest: string }) {
+  const [metric, setMetric] = useState<TrendMetric>("requests");
+  const points = useMemo<TrendPoint[]>(
+    () => series.map((point) => ({
+      ...point,
+      requests: point.requests || point.count,
+      total_tokens: point.prompt_tokens + point.completion_tokens,
+    })),
+    [series],
+  );
+  const config = TREND_CONFIG[metric];
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-[var(--border)] text-left text-xs uppercase tracking-wider text-[var(--text-muted)]">
-            <th className="px-6 py-3 font-medium">Model</th>
-            <th className="px-4 py-3 font-medium">Provider</th>
-            <th className="px-4 py-3 text-right font-medium">Tokens</th>
-            <th className="px-4 py-3 text-right font-medium">Cost</th>
-            <th className="px-4 py-3 text-right font-medium">Latency</th>
-            <th className="px-6 py-3 text-right font-medium">Cache</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-[var(--border)]/50">
-          {recent.map((row) => (
-            <tr
-              key={row.id}
-              className="group hover:bg-[var(--bg-subtle)]/50 transition-colors"
-            >
-              <td className="px-6 py-3">
-                <span className="font-mono text-xs text-[var(--text)]">{row.model}</span>
-              </td>
-              <td className="px-4 py-3 text-xs text-[var(--text-muted)]">
-                <div className="flex items-center gap-2">
-                  <SmallProviderIcon p={providers.find((p) => p.provider === row.provider)} />
-                  {row.provider}
-                </div>
-              </td>
-              <td className="px-4 py-3 text-right font-mono text-xs text-[var(--text)]">
-                {row.tokens.toLocaleString()}
-              </td>
-              <td className="px-4 py-3 text-right font-mono text-xs text-[var(--text-muted)]">
-                ${row.cost_usd.toFixed(4)}
-              </td>
-              <td className="px-4 py-3 text-right font-mono text-xs text-[var(--text-muted)]">
-                {row.latency_ms}ms
-              </td>
-              <td className="px-6 py-3 text-right">
-                {row.cache_hit ? (
-                  <span className="inline-flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400 font-medium">
-                    <span className="h-1.5 w-1.5 rounded-full bg-current" />
-                    Hit
-                  </span>
-                ) : (
-                  <span className="text-xs text-[var(--text-muted)]">—</span>
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <Card className="flex min-h-[370px] flex-col">
+      <div className="flex flex-col gap-3 border-b border-[var(--border)] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-2.5">
+          <TrendingUp className="mt-0.5 h-4 w-4 text-[var(--text-muted)]" />
+          <div>
+            <h2 className="text-sm font-semibold">Usage trend</h2>
+            <p className="mt-1 text-xs text-[var(--text-muted)]">
+              {busiest ? `Busiest request bucket: ${busiest}` : "Volume across the selected period."}
+            </p>
+          </div>
+        </div>
+        <SegmentedControl value={metric} onChange={(value) => setMetric(value as TrendMetric)} options={TREND_OPTIONS} />
+      </div>
+      {points.length === 0 ? (
+        <EmptyState title="No activity in this period." />
+      ) : (
+        <div className="min-h-0 flex-1 px-3 pb-4 pt-5 sm:px-5">
+          <ResponsiveContainer width="100%" height="100%" minHeight={260}>
+            <AreaChart data={points} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
+              <defs>
+                <linearGradient id={`overview-${metric}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={config.color} stopOpacity={0.22} />
+                  <stop offset="95%" stopColor={config.color} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="label" axisLine={false} tickLine={false} tick={{ fontSize: 10, fill: "var(--text-muted)" }} minTickGap={28} />
+              <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 10, fill: "var(--text-muted)" }} width={46} tickFormatter={(value) => fmtAxis(Number(value), metric)} />
+              <Tooltip
+                cursor={{ stroke: "var(--border-strong)", strokeWidth: 1 }}
+                contentStyle={{
+                  background: "var(--bg-elevated)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "10px",
+                  fontSize: "12px",
+                  boxShadow: "var(--shadow-card)",
+                }}
+                formatter={(value) => [fmtTrendValue(Number(value), metric), config.label]}
+              />
+              <Area
+                type="monotone"
+                dataKey={config.key}
+                name={config.label}
+                stroke={config.color}
+                strokeWidth={2}
+                fill={`url(#overview-${metric})`}
+                animationDuration={350}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </Card>
   );
 }
 
-/* ── Helpers ─────────────────────────────────────────────────────── */
+function ProviderPerformance({ providers }: { providers: ProviderUsage[] }) {
+  const { page, pages, paged, setPage, total } = useClientPagination(providers, 5);
 
-function compact(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
+  return (
+    <Card className="flex min-h-[370px] flex-col">
+      <div className="flex items-start justify-between gap-3 border-b border-[var(--border)] px-5 py-4">
+        <div className="flex items-start gap-2.5">
+          <Database className="mt-0.5 h-4 w-4 text-[var(--text-muted)]" />
+          <div>
+            <h2 className="text-sm font-semibold">Provider mix</h2>
+            <p className="mt-1 text-xs text-[var(--text-muted)]">Traffic share and delivery quality.</p>
+          </div>
+        </div>
+        <span className="text-xs tabular-nums text-[var(--text-muted)]">{providers.length} providers</span>
+      </div>
+      {providers.length === 0 ? (
+        <EmptyState title="No provider usage yet." />
+      ) : (
+        <>
+          <div className="flex-1 divide-y divide-[var(--border)] px-5">
+            {paged.map((provider) => (
+              <div key={provider.provider} className="py-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex min-w-0 items-center gap-2.5">
+                    <SmallProviderIcon provider={provider} className="h-6 w-6" />
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold" title={provider.display_name}>{provider.display_name}</div>
+                      <div className="mt-0.5 text-[10px] text-[var(--text-muted)]">
+                        {fmtPercent(provider.success_rate)} success · {fmtMs(provider.avg_latency_ms)} avg
+                      </div>
+                    </div>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <div className="text-xs font-semibold tabular-nums">{fmtCompact(provider.total_requests)} req</div>
+                    <div className="mt-0.5 text-[10px] tabular-nums text-[var(--text-muted)]">{fmtUSD(provider.cost_usd)}</div>
+                  </div>
+                </div>
+                <div className="mt-2 flex items-center gap-2">
+                  <div className="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-[var(--bg-subtle)]">
+                    <div className="h-full rounded-full bg-secondary-500" style={{ width: `${Math.max(0, Math.min(100, provider.share_pct))}%` }} />
+                  </div>
+                  <span className="w-11 text-right text-[10px] font-medium tabular-nums text-[var(--text-muted)]">{provider.share_pct.toFixed(1)}%</span>
+                </div>
+              </div>
+            ))}
+          </div>
+          <TablePagination page={page} pages={pages} total={total} onPage={setPage} />
+        </>
+      )}
+    </Card>
+  );
 }
 
-function SmallProviderIcon({ p }: { p?: { display_name: string; icon: string; color: string } }) {
+function TokenComposition({ data }: { data: UsageInsights }) {
+  const { summary } = data;
+  const regularInput = Math.max(0, summary.prompt_tokens - summary.cached_tokens - summary.cache_write_tokens);
+  const total = summary.prompt_tokens + summary.completion_tokens;
+  const rows = [
+    { label: "Regular input", value: regularInput, color: "bg-secondary-500" },
+    { label: "Cache read", value: summary.cached_tokens, color: "bg-accent-500" },
+    { label: "Cache write", value: summary.cache_write_tokens, color: "bg-amber-500" },
+    {
+      label: "Output",
+      value: summary.completion_tokens,
+      color: "bg-[var(--color-chart-4)]",
+      note: summary.reasoning_tokens > 0
+        ? `${((summary.completion_tokens / Math.max(1, total)) * 100).toFixed(1)}% · ${fmtCompact(summary.reasoning_tokens)} reasoning`
+        : undefined,
+    },
+  ];
+
+  return (
+    <Card>
+      <div className="grid gap-5 px-5 py-5 lg:grid-cols-[minmax(180px,0.55fr)_minmax(0,1.45fr)] lg:items-center lg:px-6">
+        <div className="flex items-start gap-3">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[var(--bg-subtle)] text-[var(--text-muted)]">
+            <Layers3 className="h-4 w-4" />
+          </span>
+          <div>
+            <h2 className="text-sm font-semibold">Token composition</h2>
+            <div className="mt-2 flex items-baseline gap-2">
+              <span className="text-2xl font-semibold tracking-tight tabular-nums">{fmtCompact(total)}</span>
+              <span className="text-xs text-[var(--text-muted)]">tokens</span>
+            </div>
+            <p className="mt-1 text-[10px] text-[var(--text-muted)]">{fmtCompact(summary.cache_hits)} request cache hits</p>
+          </div>
+        </div>
+        {total === 0 ? (
+          <p className="text-sm text-[var(--text-muted)]">No token usage recorded in this period.</p>
+        ) : (
+          <div className="min-w-0">
+            <div className="flex h-2.5 overflow-hidden rounded-full bg-[var(--bg-subtle)]" aria-label="Token composition">
+              {rows.filter((row) => row.value > 0).map((row) => (
+                <div
+                  key={row.label}
+                  className={row.color}
+                  style={{ width: `${(row.value / total) * 100}%` }}
+                  title={`${row.label}: ${fmtInteger(row.value)}`}
+                />
+              ))}
+            </div>
+            <div className="mt-4 grid grid-cols-2 gap-x-5 gap-y-3 sm:grid-cols-4">
+              {rows.map((row) => (
+                <div key={row.label} className="min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <span className={`h-2 w-2 shrink-0 rounded-full ${row.color}`} />
+                    <span className="truncate text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">{row.label}</span>
+                  </div>
+                  <div className="mt-1 text-sm font-semibold tabular-nums">{fmtCompact(row.value)}</div>
+                  <div className="mt-0.5 truncate text-[10px] text-[var(--text-muted)]">
+                    {row.note || `${((row.value / total) * 100).toFixed(1)}% of total`}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function RecentActivityTable({ recent, providers }: { recent: RecentActivity[]; providers: ProviderUsage[] }) {
+  const { page, pages, paged, setPage, total } = useClientPagination(recent, 10);
+  const providerMap = useMemo(() => new Map(providers.map((provider) => [provider.provider, provider])), [providers]);
+
+  return (
+    <Card>
+      <div className="flex items-start justify-between gap-4 border-b border-[var(--border)] px-5 py-4">
+        <div className="flex items-start gap-2.5">
+          <Timer className="mt-0.5 h-4 w-4 text-[var(--text-muted)]" />
+          <div>
+            <h2 className="text-sm font-semibold">Recent requests</h2>
+            <p className="mt-1 text-xs text-[var(--text-muted)]">Terminal request outcomes from the selected period.</p>
+          </div>
+        </div>
+        <Link to="/usage" className="inline-flex shrink-0 items-center gap-1 text-xs font-semibold text-[var(--text-muted)] hover:text-[var(--text)]">
+          Full accounting <ArrowUpRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+      {recent.length === 0 ? (
+        <EmptyState title="No recent requests." hint="Make a request through the proxy to see it here." />
+      ) : (
+        <>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[900px] text-xs">
+              <thead>
+                <tr className="border-b border-[var(--border)] text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                  <th className="px-5 py-3 text-left">Status</th>
+                  <th className="px-4 py-3 text-left">Provider / model</th>
+                  <th className="px-4 py-3 text-right">Tokens</th>
+                  <th className="px-4 py-3 text-right">Cost</th>
+                  <th className="px-4 py-3 text-right">Latency</th>
+                  <th className="px-5 py-3 text-right">Time</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--border)]">
+                {paged.map((row) => {
+                  const provider = providerMap.get(row.provider);
+                  return (
+                    <tr key={row.id} className="transition-colors hover:bg-[var(--bg-subtle)]/60">
+                      <td className="px-5 py-3"><RequestStatusBadge status={row.status} /></td>
+                      <td className="px-4 py-3">
+                        <div className="flex min-w-0 items-center gap-2.5">
+                          <SmallProviderIcon provider={provider} className="h-7 w-7" />
+                          <div className="min-w-0">
+                            <div className="max-w-md truncate font-mono text-[11px] font-semibold" title={row.model}>{row.model || "Unknown model"}</div>
+                            <div className="mt-0.5 truncate text-[10px] text-[var(--text-muted)]">{provider?.display_name || row.provider}</div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        <div className="font-semibold">{fmtInteger(row.prompt_tokens + row.completion_tokens)}</div>
+                        {(row.cached_tokens > 0 || row.reasoning_tokens > 0) && (
+                          <div className="mt-0.5 text-[10px] text-[var(--text-muted)]">
+                            {row.cached_tokens > 0 ? `${fmtCompact(row.cached_tokens)} cached` : `${fmtCompact(row.reasoning_tokens)} reasoning`}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right font-medium tabular-nums">
+                        {row.pricing_status === "missing" ? "Unpriced" : fmtUSD(row.cost_usd)}
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums text-[var(--text-muted)]">
+                        {fmtMs(row.end_to_end_latency_ms || row.latency_ms)}
+                      </td>
+                      <td className="whitespace-nowrap px-5 py-3 text-right text-[var(--text-muted)]" title={formatDateTime(row.created_at)}>
+                        {relativeTime(row.created_at)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <TablePagination page={page} pages={pages} total={total} onPage={setPage} />
+        </>
+      )}
+    </Card>
+  );
+}
+
+function RequestStatusBadge({ status }: { status: UsageTerminalStatus }) {
+  const config: Record<UsageTerminalStatus, { label: string; tone: "success" | "accent" | "warning" | "danger" | "neutral" }> = {
+    success: { label: "Success", tone: "success" },
+    cache_hit: { label: "Cache hit", tone: "accent" },
+    blocked: { label: "Blocked", tone: "warning" },
+    failed: { label: "Failed", tone: "danger" },
+    cancelled: { label: "Cancelled", tone: "neutral" },
+  };
+  const item = config[status] ?? { label: String(status), tone: "neutral" as const };
+  return <Badge tone={item.tone}>{item.label}</Badge>;
+}
+
+function SmallProviderIcon({ provider, className = "h-5 w-5" }: { provider?: ProviderUsage; className?: string }) {
   const [errored, setErrored] = useState(false);
-  if (!p) return <div className="h-4 w-4 shrink-0 rounded-sm bg-[var(--border)]" />;
-  if (errored || !p.icon) {
+  if (!provider || errored || !provider.icon) {
+    const label = provider?.display_name || "?";
     return (
       <div
-        className="flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-[8px] font-bold text-white"
-        style={{ backgroundColor: p.color || "var(--text-muted)" }}
+        className={`flex shrink-0 items-center justify-center rounded-md text-[9px] font-bold text-white ${className}`}
+        style={{ backgroundColor: provider?.color || "var(--color-ink-400)" }}
+        aria-hidden="true"
       >
-        {p.display_name.slice(0, 1).toUpperCase()}
+        {label.slice(0, 1).toUpperCase()}
       </div>
     );
   }
   return (
     <img
-      src={p.icon}
-      alt={p.display_name}
+      src={provider.icon}
+      alt=""
       onError={() => setErrored(true)}
-      className="h-4 w-4 shrink-0 rounded-sm object-contain"
+      className={`shrink-0 rounded-md object-contain ${className}`}
     />
   );
+}
+
+function fmtCompact(value: number): string {
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return value.toLocaleString();
+}
+
+function fmtInteger(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function fmtUSD(value: number): string {
+  if (value > 0 && value < 0.0001) return "<$0.0001";
+  if (value < 1) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+function fmtMs(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "—";
+  if (value < 1000) return `${Math.round(value)}ms`;
+  return `${(value / 1000).toFixed(2)}s`;
+}
+
+function fmtPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function fmtCoverage(value: number | null): string {
+  return value == null ? "—" : `${(value * 100).toFixed(1)}%`;
+}
+
+function fmtAxis(value: number, metric: TrendMetric): string {
+  if (metric === "cost") return value >= 1 ? `$${value.toFixed(0)}` : `$${value.toFixed(2)}`;
+  return fmtCompact(value);
+}
+
+function fmtTrendValue(value: number, metric: TrendMetric): string {
+  if (metric === "cost") return fmtUSD(value);
+  return fmtInteger(value);
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+}
+
+function relativeTime(value: string): string {
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return "—";
+  const delta = Date.now() - timestamp;
+  if (delta < 60_000) return "just now";
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+  if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+  return `${Math.floor(delta / 86_400_000)}d ago`;
 }

--- a/frontend/src/pages/Quota.tsx
+++ b/frontend/src/pages/Quota.tsx
@@ -1,719 +1,1105 @@
-import { useState, useEffect, useRef } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  Clock, Calendar, RefreshCw, Power, PowerOff,
-  Loader2, Trash2, ToggleLeft, ToggleRight, ChevronDown,
-  Activity, Zap, DollarSign, Server,
+  Activity,
+  AlertTriangle,
+  ChevronDown,
+  Gauge,
+  Loader2,
+  Power,
+  PowerOff,
+  RefreshCw,
+  Search,
+  Server,
+  Trash2,
+  type LucideIcon,
 } from "lucide-react";
 import { api, connectUsageStream, type QuotaAccount, type UpstreamQuota } from "../lib/api";
 import { PageHeader } from "../components/Layout";
-import { Card, Spinner, EmptyState, Badge, StatusDot, StatCard } from "../components/ui";
+import {
+  Badge,
+  Card,
+  EmptyState,
+  ErrorCard,
+  SegmentedControl,
+  Spinner,
+  TablePagination,
+  useClientPagination,
+} from "../components/ui";
 import { useToast } from "../components/Toast";
 
-const periods = [
+const PERIODS = [
   { value: "today", label: "Today" },
-  { value: "week", label: "Last 7 days" },
-  { value: "month", label: "Last 30 days" },
+  { value: "week", label: "7D" },
+  { value: "month", label: "30D" },
 ];
 
+const REFRESH_INTERVAL = 10_000;
 const DEPLETED_THRESHOLD = 5;
-const REFRESH_INTERVAL = 10_000; // 10s near-real-time refresh
+const ACCOUNTS_PER_PAGE = 12;
 
-const statusMeta: Record<string, { label: string; tone: "success" | "warning" | "danger" }> = {
+type QuotaFilter = "all" | "reported" | "capable" | "usage_only";
+type SortMode = "attention" | "reset" | "usage" | "provider";
+type SummaryTone = "accent" | "success" | "warning";
+
+const statusMeta: Record<string, { label: string; tone: "success" | "warning" | "danger" | "neutral" }> = {
   active: { label: "Active", tone: "success" },
-  paused: { label: "Paused", tone: "warning" },
+  paused: { label: "Paused", tone: "neutral" },
   needs_attention: { label: "Needs attention", tone: "danger" },
 };
 
-function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toLocaleString();
-}
-
-function getColor(remainingPct: number) {
-  if (remainingPct > 70) return { bar: "bg-emerald-500", text: "text-emerald-600 dark:text-emerald-400", emoji: "🟢" };
-  if (remainingPct >= 30) return { bar: "bg-amber-500", text: "text-amber-600 dark:text-amber-400", emoji: "🟡" };
-  return { bar: "bg-red-500", text: "text-red-600 dark:text-red-400", emoji: "🔴" };
-}
-
-function formatCountdown(resetAt: string | number | undefined | null): string {
-  if (!resetAt) return "-";
-  try {
-    const resetTime = typeof resetAt === "number" ? resetAt : new Date(resetAt).getTime();
-    const diff = resetTime - Date.now();
-    if (diff <= 0) return "now";
-    const days = Math.floor(diff / 86400000);
-    const hours = Math.floor((diff % 86400000) / 3600000);
-    const mins = Math.floor((diff % 3600000) / 60000);
-    if (days > 0) return `${days}d ${hours}h`;
-    if (hours > 0) return `${hours}h ${mins}m`;
-    return `${mins}m`;
-  } catch { return "-"; }
-}
-
-function isDepleted(account: QuotaAccount): boolean {
-  const quotas = account.upstream_quotas ?? [];
-  if (quotas.length === 0) return false;
-  return quotas.some((q) => {
-    const pct = q.limit > 0 ? Math.round((q.remaining / q.limit) * 100) : 100;
-    return pct < DEPLETED_THRESHOLD;
-  });
-}
-
-function earliestReset(account: QuotaAccount): number | null {
-  let earliest: number | null = null;
-  for (const q of account.upstream_quotas ?? []) {
-    if (q.reset_at) {
-      const t = new Date(q.reset_at).getTime();
-      if (!isNaN(t) && (earliest === null || t < earliest)) earliest = t;
-    }
-  }
-  return earliest;
-}
-
 export function QuotaPage() {
   const [period, setPeriod] = useState("month");
+  const [search, setSearch] = useState("");
   const [providerFilter, setProviderFilter] = useState("all");
   const [statusFilter, setStatusFilter] = useState("all");
-  const [expiringFirst, setExpiringFirst] = useState(false);
+  const [quotaFilter, setQuotaFilter] = useState<QuotaFilter>("all");
+  const [sortMode, setSortMode] = useState<SortMode>("attention");
   const [autoRefresh, setAutoRefresh] = useState(() => localStorage.getItem("quotaAutoRefresh") !== "false");
   const [countdown, setCountdown] = useState(REFRESH_INTERVAL / 1000);
-  const countdownRef = useRef(REFRESH_INTERVAL / 1000);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [activeTab, setActiveTab] = useState<"paid" | "free">("paid");
-  const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
-  const qc = useQueryClient();
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const countdownRef = useRef(REFRESH_INTERVAL / 1000);
+  const queryClient = useQueryClient();
   const toast = useToast();
-
-  const toggleProvider = (provider: string) => {
-    setExpandedProviders(prev => {
-      const next = new Set(prev);
-      if (next.has(provider)) next.delete(provider);
-      else next.add(provider);
-      return next;
-    });
-  };
 
   const quota = useQuery({
     queryKey: ["quota", period],
     queryFn: () => api.quota(period),
     refetchInterval: autoRefresh ? REFRESH_INTERVAL : false,
+    placeholderData: (previous) => previous,
   });
 
-  // Subscribe to SSE usage stream for instant cache invalidation. When a new
-  // usage record is inserted (e.g. a chain-mode request completes), the meter
-  // publishes to the hub, which pushes an SSE event here. We invalidate the
-  // quota query so the next render shows fresh data without waiting for the
-  // polling interval.
+  useEffect(() => connectUsageStream(() => {
+    queryClient.invalidateQueries({ queryKey: ["quota"] });
+  }), [queryClient]);
+
   useEffect(() => {
-    return connectUsageStream(() => {
-      qc.invalidateQueries({ queryKey: ["quota"] });
-    });
-  }, [qc]);
+    if (!autoRefresh) return;
+    countdownRef.current = REFRESH_INTERVAL / 1000;
+    setCountdown(REFRESH_INTERVAL / 1000);
+    const interval = window.setInterval(() => {
+      countdownRef.current = countdownRef.current <= 1
+        ? REFRESH_INTERVAL / 1000
+        : countdownRef.current - 1;
+      setCountdown(countdownRef.current);
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [autoRefresh, quota.dataUpdatedAt]);
+
+  useEffect(() => {
+    localStorage.setItem("quotaAutoRefresh", String(autoRefresh));
+  }, [autoRefresh]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const handleVisibility = () => {
+      if (document.hidden) queryClient.cancelQueries({ queryKey: ["quota"] });
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [autoRefresh, queryClient]);
 
   const accounts = quota.data?.accounts ?? [];
-  const providers = [...new Set(accounts.map((a) => a.provider))].sort();
+  const providers = useMemo(
+    () => [...new Map(accounts.map((account) => [account.provider, account.provider_name || account.provider])).entries()]
+      .sort((left, right) => left[1].localeCompare(right[1])),
+    [accounts],
+  );
 
-  const filtered = accounts.filter((a) => {
-    if (providerFilter !== "all" && a.provider !== providerFilter) return false;
-    if (statusFilter === "active" && a.status !== "active") return false;
-    if (statusFilter === "paused" && a.status === "active") return false;
-    return true;
-  });
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return accounts.filter((account) => {
+      if (providerFilter !== "all" && account.provider !== providerFilter) return false;
+      if (statusFilter !== "all" && account.status !== statusFilter) return false;
+      if (quotaFilter === "reported" && !hasReportedQuota(account)) return false;
+      if (quotaFilter === "capable" && (!supportsQuota(account) || hasReportedQuota(account))) return false;
+      if (quotaFilter === "usage_only" && supportsQuota(account)) return false;
+      if (query) {
+        const haystack = [account.provider, account.provider_name, account.label, account.auth_kind, account.plan_name]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!haystack.includes(query)) return false;
+      }
+      return true;
+    });
+  }, [accounts, providerFilter, quotaFilter, search, statusFilter]);
 
-  const sorted = [...filtered].sort((a, b) => {
-    if (expiringFirst) {
-      const ae = earliestReset(a), be = earliestReset(b);
-      if (ae !== null && be !== null) return ae - be;
-      if (ae !== null) return -1;
-      if (be !== null) return 1;
+  const sorted = useMemo(() => [...filtered].sort((left, right) => {
+    if (sortMode === "provider") {
+      return (left.provider_name || left.provider).localeCompare(right.provider_name || right.provider)
+        || (left.label || left.auth_kind).localeCompare(right.label || right.auth_kind);
     }
-    const ah = (a.upstream_quotas?.length ?? 0) > 0, bh = (b.upstream_quotas?.length ?? 0) > 0;
-    if (ah && !bh) return -1;
-    if (!ah && bh) return 1;
-    const ar = a.upstream_quotas?.[0] ? a.upstream_quotas[0].remaining / Math.max(1, a.upstream_quotas[0].limit) : 1;
-    const br = b.upstream_quotas?.[0] ? b.upstream_quotas[0].remaining / Math.max(1, b.upstream_quotas[0].limit) : 1;
-    return ar - br;
+    if (sortMode === "usage") return right.total_requests - left.total_requests;
+    if (sortMode === "reset") return compareNullableTime(earliestReset(left), earliestReset(right));
+
+    const scoreDelta = accountAttentionScore(left) - accountAttentionScore(right);
+    if (scoreDelta !== 0) return scoreDelta;
+    const resetDelta = compareNullableTime(earliestReset(left), earliestReset(right));
+    if (resetDelta !== 0) return resetDelta;
+    return right.total_requests - left.total_requests;
+  }), [filtered, sortMode]);
+
+  const pagination = useClientPagination(sorted, ACCOUNTS_PER_PAGE);
+
+  useEffect(() => {
+    pagination.setPage(1);
+    setSelected(new Set());
+  }, [providerFilter, quotaFilter, search, sortMode, statusFilter]);
+
+  const toggleAccount = useMutation({
+    mutationFn: ({ id, disabled }: { id: string; disabled: boolean }) => api.updateAccount(id, { disabled }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["quota"] }),
+    onError: (error: Error) => toast.error("Account update failed", error.message),
   });
 
-  // Selection
-  const toggleSelect = (id: string) => {
-    setSelected((prev) => {
-      const next = new Set(prev);
+  const deleteAccount = useMutation({
+    mutationFn: (id: string) => api.deleteAccount(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["quota"] }),
+    onError: (error: Error) => toast.error("Account removal failed", error.message),
+  });
+
+  const toggleSelection = (id: string) => {
+    setSelected((previous) => {
+      const next = new Set(previous);
       if (next.has(id)) next.delete(id);
       else next.add(id);
       return next;
     });
   };
 
-  const selectAll = () => {
-    if (selected.size === sorted.length) setSelected(new Set());
-    else setSelected(new Set(sorted.map((a) => a.id)));
+  const allPageSelected = pagination.paged.length > 0 && pagination.paged.every((account) => selected.has(account.id));
+  const togglePageSelection = () => {
+    setSelected((previous) => {
+      const next = new Set(previous);
+      for (const account of pagination.paged) {
+        if (allPageSelected) next.delete(account.id);
+        else next.add(account.id);
+      }
+      return next;
+    });
   };
 
-  // Countdown timer
-  useEffect(() => {
-    if (!autoRefresh) return;
-    countdownRef.current = REFRESH_INTERVAL / 1000;
-    setCountdown(REFRESH_INTERVAL / 1000);
-    const iv = setInterval(() => {
-      countdownRef.current -= 1;
-      if (countdownRef.current <= 0) countdownRef.current = REFRESH_INTERVAL / 1000;
-      setCountdown(countdownRef.current);
-    }, 1000);
-    return () => clearInterval(iv);
-  }, [autoRefresh, quota.dataUpdatedAt]);
-
-  // Pause when tab hidden
-  useEffect(() => {
-    if (!autoRefresh) return;
-    const h = () => { if (document.hidden) qc.cancelQueries({ queryKey: ["quota"] }); };
-    document.addEventListener("visibilitychange", h);
-    return () => document.removeEventListener("visibilitychange", h);
-  }, [autoRefresh, qc]);
-
-  useEffect(() => { localStorage.setItem("quotaAutoRefresh", String(autoRefresh)); }, [autoRefresh]);
-
-  // Mutations
-  const toggleAccount = useMutation({
-    mutationFn: ({ id, disabled }: { id: string; disabled: boolean }) => api.updateAccount(id, { disabled }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["quota"] }),
-  });
-
-  const deleteAccount = useMutation({
-    mutationFn: (id: string) => api.deleteAccount(id),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["quota"] });
-      toast.success("Account removed", "The upstream provider account has been deleted and its secrets purged.");
-    },
-    onError: (e: Error) => toast.error("Account removal failed", e.message),
-  });
-
-  const handleBulkEnable = () => {
-    const ids = [...selected].filter((id) => sorted.find((a) => a.id === id)?.status === "paused");
-    ids.forEach((id) => toggleAccount.mutate({ id, disabled: false }));
-    toast.success("Accounts enabled", `${ids.length} paused account${ids.length !== 1 ? "s" : ""} reactivated for upstream routing.`);
-    setSelected(new Set());
+  const toggleExpanded = (id: string) => {
+    setExpanded((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   };
 
-  const handleBulkDisable = () => {
-    const ids = [...selected].filter((id) => sorted.find((a) => a.id === id)?.status === "active");
-    ids.forEach((id) => toggleAccount.mutate({ id, disabled: true }));
-    toast.success("Accounts disabled", `${ids.length} active account${ids.length !== 1 ? "s" : ""} paused. Traffic will bypass them.`);
+  const selectedAccounts = accounts.filter((account) => selected.has(account.id));
+  const selectedCanEnable = selectedAccounts.filter((account) => account.status === "paused");
+  const selectedCanPause = selectedAccounts.filter((account) => account.status !== "paused");
+
+  const applyBulkState = (targets: QuotaAccount[], disabled: boolean) => {
+    targets.forEach((account) => toggleAccount.mutate({ id: account.id, disabled }));
+    toast.success(
+      disabled ? "Accounts paused" : "Accounts enabled",
+      `${targets.length} account${targets.length === 1 ? "" : "s"} updated.`,
+    );
     setSelected(new Set());
   };
 
   const handleBulkDelete = () => {
-    const ids = [...selected];
-    ids.forEach((id) => deleteAccount.mutate(id));
-    toast.success("Accounts deleted", `${ids.length} account${ids.length !== 1 ? "s" : ""} permanently removed and secrets purged.`);
+    if (selectedAccounts.length === 0) return;
+    if (!window.confirm(`Delete ${selectedAccounts.length} selected account${selectedAccounts.length === 1 ? "" : "s"}? This cannot be undone.`)) return;
+    selectedAccounts.forEach((account) => deleteAccount.mutate(account.id));
+    toast.success("Accounts removed", `${selectedAccounts.length} account${selectedAccounts.length === 1 ? "" : "s"} deleted.`);
     setSelected(new Set());
   };
 
-  const handleTurnOffEmpty = () => {
-    const depleted = sorted.filter((a) => a.status === "active" && isDepleted(a));
-    depleted.forEach((a) => toggleAccount.mutate({ id: a.id, disabled: true }));
-    toast.success("Depleted accounts paused", `${depleted.length} account${depleted.length !== 1 ? "s" : ""} with exhausted quotas have been disabled to prevent errors.`);
+  const handleDeleteAccount = (account: QuotaAccount) => {
+    if (!window.confirm(`Delete ${account.label || account.provider_name} account? This cannot be undone.`)) return;
+    deleteAccount.mutate(account.id, {
+      onSuccess: () => toast.success("Account removed", "The provider account and its stored secrets were deleted."),
+    });
   };
 
-  const handleTurnOnAvailable = () => {
-    const avail = sorted.filter((a) => a.status === "paused" && !isDepleted(a));
-    avail.forEach((a) => toggleAccount.mutate({ id: a.id, disabled: false }));
-    toast.success("Available accounts reactivated", `${avail.length} paused account${avail.length !== 1 ? "s" : ""} with remaining quota have been re-enabled.`);
-  };
+  const depletedAccounts = accounts.filter((account) => account.status === "active" && isDepleted(account));
+  const resumableAccounts = accounts.filter((account) => account.status === "paused" && hasReportedQuota(account) && !isDepleted(account));
 
-  const handleRefresh = () => {
-    qc.invalidateQueries({ queryKey: ["quota"] });
+  const handlePauseDepleted = () => applyBulkState(depletedAccounts, true);
+  const handleResumeAvailable = () => applyBulkState(resumableAccounts, false);
+
+  const handleRefresh = async () => {
     countdownRef.current = REFRESH_INTERVAL / 1000;
     setCountdown(REFRESH_INTERVAL / 1000);
-    toast.success("Quota data refreshed", "Upstream quota information has been re-fetched from all providers.");
+    const result = await quota.refetch();
+    if (result.isError) toast.error("Quota refresh failed", "The latest account data could not be loaded.");
   };
 
-  const depletedCount = sorted.filter((a) => a.status === "active" && isDepleted(a)).length;
-  const pausedAvailCount = sorted.filter((a) => a.status === "paused" && !isDepleted(a)).length;
-
-  // Aggregate stats across all accounts
-  const totalRequests = accounts.reduce((s, a) => s + a.total_requests, 0);
-  const totalPromptTokens = accounts.reduce((s, a) => s + a.prompt_tokens, 0);
-  const totalCompletionTokens = accounts.reduce((s, a) => s + a.completion_tokens, 0);
-  const totalCost = accounts.reduce((s, a) => s + a.cost_usd, 0);
-  const activeCount = accounts.filter((a) => a.status === "active").length;
+  const totals = useMemo(() => ({
+    requests: accounts.reduce((sum, account) => sum + account.total_requests, 0),
+    input: accounts.reduce((sum, account) => sum + account.prompt_tokens, 0),
+    output: accounts.reduce((sum, account) => sum + account.completion_tokens, 0),
+    cost: accounts.reduce((sum, account) => sum + account.cost_usd, 0),
+    active: accounts.filter((account) => account.status === "active").length,
+    paused: accounts.filter((account) => account.status === "paused").length,
+    attention: accounts.filter((account) => account.status === "needs_attention").length,
+    reported: accounts.filter(hasReportedQuota).length,
+    capable: accounts.filter(supportsQuota).length,
+    usageOnly: accounts.filter((account) => !supportsQuota(account)).length,
+    notReported: accounts.filter((account) => supportsQuota(account) && !hasReportedQuota(account)).length,
+  }), [accounts]);
 
   return (
     <>
       <PageHeader
         title="Quota Tracker"
-        icon={Clock}
-        description="Monitor upstream quota limits and consumption per connected account."
+        icon={Gauge}
+        description="Monitor account capacity, reported upstream limits, and period usage."
         action={
           <div className="flex items-center gap-2">
-            <div className="flex h-8 items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2">
-              <Calendar className="h-3.5 w-3.5 text-[var(--text-muted)]" />
-              <select value={period} onChange={(e) => setPeriod(e.target.value)} className="bg-transparent text-xs font-medium focus:outline-none">
-                {periods.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
-              </select>
-            </div>
+            <SegmentedControl value={period} onChange={setPeriod} options={PERIODS} />
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={quota.isFetching}
+              aria-label="Refresh quota data"
+              title="Refresh quota data"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)] shadow-sm transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--bg-subtle)] hover:text-[var(--text)] disabled:opacity-60"
+            >
+              <RefreshCw className={`h-4 w-4 ${quota.isFetching ? "animate-spin" : ""}`} />
+            </button>
           </div>
         }
       />
 
-      {/* Summary stat cards */}
-      {!quota.isLoading && accounts.length > 0 && (
-        <div className="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
-          <StatCard label="Total Requests" value={totalRequests.toLocaleString()} icon={Activity} iconTone="accent" />
-          <StatCard label="Input Tokens" value={fmtTokens(totalPromptTokens)} icon={Zap} iconTone="accent" />
-          <StatCard label="Output Tokens" value={fmtTokens(totalCompletionTokens)} icon={Zap} iconTone="accent" />
-          <StatCard label="Total Cost" value={`$${totalCost.toFixed(2)}`} icon={DollarSign} iconTone="warning" />
-          <StatCard label="Active Accounts" value={`${activeCount} / ${accounts.length}`} icon={Server} iconTone="accent" />
-        </div>
-      )}
-
-      <Card>
-        {/* ── Toolbar ──────────────────────────────────────────── */}
-        <div className="flex flex-wrap items-center gap-1.5 border-b border-[var(--border)] px-4 py-2.5">
-          {/* Select all */}
-          <button onClick={selectAll} className="flex items-center gap-2 text-xs text-[var(--text-muted)] hover:text-[var(--text)]">
-            <input type="checkbox" checked={selected.size === sorted.length && sorted.length > 0} onChange={selectAll}
-              className="h-3.5 w-3.5 rounded border-[var(--border)] accent-accent-600" />
-            Select all
-          </button>
-
-          <div className="mx-1 h-4 w-px bg-[var(--border)]" />
-
-          {/* Filters */}
-          {providers.length > 1 && (
-            <select value={providerFilter} onChange={(e) => setProviderFilter(e.target.value)}
-              className="h-7 rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2 text-xs">
-              <option value="all">All providers</option>
-              {providers.map((p) => <option key={p} value={p} className="capitalize">{p}</option>)}
-            </select>
-          )}
-          <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)}
-            className="h-7 rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2 text-xs">
-            <option value="all">All accounts</option>
-            <option value="active">Active</option>
-            <option value="paused">Paused</option>
-          </select>
-          <button onClick={() => setExpiringFirst(!expiringFirst)}
-            className={`flex h-7 items-center gap-1 rounded-lg border px-2 text-xs transition-colors ${expiringFirst ? "border-amber-500/40 bg-amber-500/10 text-amber-500" : "border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)] hover:bg-[var(--bg-subtle)]"}`}>
-            <Clock className="h-3 w-3" />
-            <span className="hidden sm:inline">Expiring</span>
-          </button>
-
-          {/* Semantic bulk actions */}
-          {depletedCount > 0 && (
-            <button onClick={handleTurnOffEmpty}
-              className="flex h-7 items-center gap-1 rounded-lg border border-red-500/30 px-2 text-xs text-red-500 hover:bg-red-500/10">
-              <PowerOff className="h-3 w-3" />
-              <span className="hidden sm:inline">Off Empty</span> ({depletedCount})
-            </button>
-          )}
-          {pausedAvailCount > 0 && (
-            <button onClick={handleTurnOnAvailable}
-              className="flex h-7 items-center gap-1 rounded-lg border border-emerald-500/30 px-2 text-xs text-emerald-500 hover:bg-emerald-500/10">
-              <Power className="h-3 w-3" />
-              <span className="hidden sm:inline">On Avail</span> ({pausedAvailCount})
-            </button>
-          )}
-
-          <div className="flex-1" />
-
-          {/* Selection bulk actions */}
-          {selected.size > 0 && (
-            <div className="flex items-center gap-1">
-              <button onClick={handleBulkEnable}
-                className="flex h-7 items-center gap-1 rounded-lg border border-emerald-500/30 px-2 text-xs text-emerald-500 hover:bg-emerald-500/10">
-                <ToggleRight className="h-3 w-3" /> Enable
-              </button>
-              <button onClick={handleBulkDisable}
-                className="flex h-7 items-center gap-1 rounded-lg border border-amber-500/30 px-2 text-xs text-amber-500 hover:bg-amber-500/10">
-                <ToggleLeft className="h-3 w-3" /> Disable
-              </button>
-              <button onClick={handleBulkDelete}
-                className="flex h-7 items-center gap-1 rounded-lg border border-red-500/30 px-2 text-xs text-red-500 hover:bg-red-500/10">
-                <Trash2 className="h-3 w-3" /> Delete
-              </button>
-              <button onClick={() => setSelected(new Set())}
-                className="flex h-7 items-center rounded-lg px-2 text-xs text-[var(--text-muted)] hover:text-[var(--text)]">
-                Clear
-              </button>
+      {quota.isError ? (
+        <ErrorCard message="Failed to load quota and account usage data." />
+      ) : (
+        <div className="space-y-5 pb-12">
+          {!quota.isLoading && accounts.length > 0 && (
+            <div className="grid gap-4 lg:grid-cols-3">
+              <SummaryGroupCard
+                icon={Server}
+                title="Routing accounts"
+                primary={fmtInteger(totals.active)}
+                primaryLabel={`of ${fmtInteger(accounts.length)} active`}
+                tone={totals.attention > 0 || depletedAccounts.length > 0 ? "warning" : "success"}
+                items={[
+                  { label: "Paused", value: fmtInteger(totals.paused) },
+                  { label: "Attention", value: fmtInteger(totals.attention), tone: totals.attention > 0 ? "danger" : undefined },
+                  { label: "Depleted", value: fmtInteger(depletedAccounts.length), tone: depletedAccounts.length > 0 ? "danger" : undefined },
+                ]}
+              />
+              <SummaryGroupCard
+                icon={Activity}
+                title="Period usage"
+                primary={fmtCompact(totals.requests)}
+                primaryLabel="requests"
+                items={[
+                  { label: "Input", value: fmtCompact(totals.input) },
+                  { label: "Output", value: fmtCompact(totals.output) },
+                  { label: "Attributed cost", value: fmtUSD(totals.cost) },
+                ]}
+              />
+              <SummaryGroupCard
+                icon={Gauge}
+                title="Quota visibility"
+                primary={fmtInteger(totals.reported)}
+                primaryLabel="accounts reporting"
+                tone={totals.notReported > 0 ? "warning" : "accent"}
+                items={[
+                  { label: "Quota-capable", value: fmtInteger(totals.capable) },
+                  { label: "Usage only", value: fmtInteger(totals.usageOnly) },
+                  { label: "Not reported", value: fmtInteger(totals.notReported) },
+                ]}
+              />
             </div>
           )}
 
-          {/* Auto-refresh + manual refresh */}
-          <button onClick={() => setAutoRefresh(!autoRefresh)}
-            className={`flex h-7 items-center gap-1 rounded-lg border px-2 text-xs transition-colors ${autoRefresh ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400" : "border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)]"}`}>
-            <RefreshCw className={`h-3 w-3 ${autoRefresh ? "animate-spin" : ""}`} style={{ animationDuration: "3s" }} />
-            {autoRefresh ? `${countdown}s` : "off"}
-          </button>
-          <button onClick={handleRefresh}
-            className="flex h-7 items-center rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-1.5 text-[var(--text-muted)] hover:bg-[var(--bg-subtle)]">
-            <RefreshCw className="h-3 w-3" />
-          </button>
-          <span className="text-xs text-[var(--text-muted)]">{sorted.length}</span>
-        </div>
+          {(depletedAccounts.length > 0 || resumableAccounts.length > 0) && (
+            <CapacityActions
+              depleted={depletedAccounts.length}
+              resumable={resumableAccounts.length}
+              onPauseDepleted={handlePauseDepleted}
+              onResumeAvailable={handleResumeAvailable}
+            />
+          )}
 
-        {/* ── Tabs ─────────────────────────────────────────────── */}
-        <div className="flex gap-4 border-b border-[var(--border)] px-4">
-          <button
-            className={`py-2.5 text-sm font-medium border-b-2 transition-colors ${
-              activeTab === "paid" 
-                ? "border-accent-600 text-[var(--text)]" 
-                : "border-transparent text-[var(--text-muted)] hover:text-[var(--text)]"
-            }`}
-            onClick={() => setActiveTab("paid")}
-          >
-            Paid Providers
-          </button>
-          <button
-            className={`py-2.5 text-sm font-medium border-b-2 transition-colors ${
-              activeTab === "free" 
-                ? "border-accent-600 text-[var(--text)]" 
-                : "border-transparent text-[var(--text-muted)] hover:text-[var(--text)]"
-            }`}
-            onClick={() => setActiveTab("free")}
-          >
-            Free Providers
-          </button>
-        </div>
+          <Card>
+            <div className="flex flex-col gap-3 border-b border-[var(--border)] px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold">Account capacity</h2>
+                <p className="mt-1 text-xs text-[var(--text-muted)]">
+                  Upstream limits are shown only when the provider reports them; every account still shows local period usage.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setAutoRefresh((current) => !current)}
+                aria-pressed={autoRefresh}
+                className={`inline-flex h-8 shrink-0 items-center gap-2 self-start rounded-lg border px-3 text-xs font-medium transition-colors lg:self-auto ${
+                  autoRefresh
+                    ? "border-emerald-300/70 bg-emerald-50 text-emerald-700 dark:border-emerald-700/50 dark:bg-emerald-950/20 dark:text-emerald-300"
+                    : "border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)]"
+                }`}
+              >
+                <span className={`h-1.5 w-1.5 rounded-full ${autoRefresh ? "bg-emerald-500" : "bg-[var(--text-muted)]"}`} />
+                {autoRefresh ? `Auto refresh · ${countdown}s` : "Auto refresh off"}
+              </button>
+            </div>
 
-        {/* ── Account list ─────────────────────────────────────── */}
-        {quota.isLoading ? (
-          <div className="flex items-center justify-center py-12"><Spinner /></div>
-        ) : sorted.length === 0 ? (
-          <EmptyState title="No connected accounts" hint="Add a provider account to start tracking quota usage." />
-        ) : (
-          <div className="flex flex-col">
-            {(() => {
-              // Filter by tab
-              const tabAccounts = sorted.filter(a => activeTab === "paid" ? a.usage_type === "credit" : a.usage_type === "token");
-              
-              if (tabAccounts.length === 0) {
-                return (
-                  <div className="py-12 text-center text-sm text-[var(--text-muted)]">
-                    No {activeTab} provider accounts found.
-                  </div>
-                );
-              }
+            <div className="flex flex-col gap-3 border-b border-[var(--border)] bg-[var(--bg-subtle)]/30 px-4 py-3 xl:flex-row xl:items-center">
+              <label className="relative min-w-0 flex-1 xl:max-w-xs">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
+                <span className="sr-only">Search accounts</span>
+                <input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search provider or account…"
+                  className="h-9 w-full rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] pl-9 pr-3 text-xs outline-none transition-colors placeholder:text-[var(--text-muted)] focus:border-[var(--border-strong)] focus:ring-2 focus:ring-accent-400/20"
+                />
+              </label>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:flex xl:items-center">
+                <FilterSelect value={providerFilter} onChange={setProviderFilter} label="Provider">
+                  <option value="all">All providers</option>
+                  {providers.map(([id, name]) => <option key={id} value={id}>{name}</option>)}
+                </FilterSelect>
+                <FilterSelect value={statusFilter} onChange={setStatusFilter} label="Status">
+                  <option value="all">All statuses</option>
+                  <option value="active">Active</option>
+                  <option value="paused">Paused</option>
+                  <option value="needs_attention">Needs attention</option>
+                </FilterSelect>
+                <FilterSelect value={quotaFilter} onChange={(value) => setQuotaFilter(value as QuotaFilter)} label="Quota visibility">
+                  <option value="all">All quota states</option>
+                  <option value="reported">Limits reported</option>
+                  <option value="capable">No current report</option>
+                  <option value="usage_only">Usage only</option>
+                </FilterSelect>
+                <FilterSelect value={sortMode} onChange={(value) => setSortMode(value as SortMode)} label="Sort accounts">
+                  <option value="attention">Attention first</option>
+                  <option value="reset">Reset soon</option>
+                  <option value="usage">Highest usage</option>
+                  <option value="provider">Provider name</option>
+                </FilterSelect>
+              </div>
+              <span className="shrink-0 text-xs tabular-nums text-[var(--text-muted)]">{fmtInteger(sorted.length)} accounts</span>
+            </div>
 
-              // Group accounts by provider
-              const tabProviders = [...new Set(tabAccounts.map(a => a.provider))].sort();
-              const groupedAccounts = tabProviders.map(p => {
-                const pAccounts = tabAccounts.filter(a => a.provider === p);
-                return {
-                  provider: p,
-                  provider_name: pAccounts[0]?.provider_name || p,
-                  accounts: pAccounts
-                };
-              });
+            {selected.size > 0 && (
+              <div className="flex flex-wrap items-center gap-2 border-b border-[var(--border)] bg-accent-50/50 px-4 py-2.5 text-xs dark:bg-accent-950/20">
+                <span className="mr-1 font-semibold">{selected.size} selected</span>
+                {selectedCanEnable.length > 0 && (
+                  <button type="button" onClick={() => applyBulkState(selectedCanEnable, false)} className="rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2.5 py-1.5 font-medium hover:bg-[var(--bg-subtle)]">Enable</button>
+                )}
+                {selectedCanPause.length > 0 && (
+                  <button type="button" onClick={() => applyBulkState(selectedCanPause, true)} className="rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2.5 py-1.5 font-medium hover:bg-[var(--bg-subtle)]">Pause</button>
+                )}
+                <button type="button" onClick={handleBulkDelete} className="rounded-lg border border-red-300/60 bg-[var(--bg-elevated)] px-2.5 py-1.5 font-medium text-red-600 hover:bg-red-50 dark:border-red-700/50 dark:text-red-300 dark:hover:bg-red-950/20">Delete</button>
+                <button type="button" onClick={() => setSelected(new Set())} className="px-2 py-1.5 text-[var(--text-muted)] hover:text-[var(--text)]">Clear</button>
+              </div>
+            )}
 
-              return groupedAccounts.map((group, i) => (
-                <div key={group.provider} className={i > 0 ? "border-t border-[var(--border)]" : ""}>
-                  <div 
-                    className="flex cursor-pointer select-none items-center gap-2 border-b border-[var(--border)] bg-[var(--bg-subtle)]/30 px-4 py-2 hover:bg-[var(--bg-subtle)] transition-colors"
-                    onClick={() => toggleProvider(group.provider)}
-                  >
-                    <ChevronDown className={`h-4 w-4 text-[var(--text-muted)] transition-transform ${expandedProviders.has(group.provider) ? "rotate-180" : ""}`} />
-                    <ProviderIcon provider={group.provider} className="h-5 w-5" />
-                    <span className="text-sm font-semibold capitalize text-[var(--text)]">{group.provider_name}</span>
-                    <span className="text-xs text-[var(--text-muted)] bg-[var(--bg-elevated)] px-1.5 py-0.5 rounded-full border border-[var(--border)]">
-                      {group.accounts.length}
-                    </span>
-                  </div>
-                  {expandedProviders.has(group.provider) && (
-                    <div className="divide-y divide-[var(--border)]">
-                      {group.accounts.map((account) => (
-                        <QuotaRow
+            {quota.isLoading ? (
+              <div className="flex min-h-64 items-center justify-center"><Spinner /></div>
+            ) : accounts.length === 0 ? (
+              <EmptyState title="No connected accounts" hint="Add a provider account to begin tracking usage and quota visibility." />
+            ) : sorted.length === 0 ? (
+              <EmptyState title="No accounts match these filters." hint="Clear a filter or search for another account." />
+            ) : (
+              <>
+                <div className="divide-y divide-[var(--border)] md:hidden">
+                  {pagination.paged.map((account) => (
+                    <QuotaAccountMobile
+                      key={account.id}
+                      account={account}
+                      selected={selected.has(account.id)}
+                      expanded={expanded.has(account.id)}
+                      onSelect={() => toggleSelection(account.id)}
+                      onExpand={() => toggleExpanded(account.id)}
+                      onToggle={() => toggleAccount.mutate({ id: account.id, disabled: account.status !== "paused" })}
+                      onDelete={() => handleDeleteAccount(account)}
+                    />
+                  ))}
+                </div>
+                <div className="hidden overflow-x-auto md:block">
+                  <table className="w-full min-w-[1120px] text-xs">
+                    <thead>
+                      <tr className="border-b border-[var(--border)] text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                        <th className="w-12 px-4 py-3 text-left">
+                          <input
+                            type="checkbox"
+                            checked={allPageSelected}
+                            onChange={togglePageSelection}
+                            aria-label="Select accounts on this page"
+                            className="h-3.5 w-3.5 rounded border-[var(--border)] accent-accent-600"
+                          />
+                        </th>
+                        <th className="px-3 py-3 text-left">Provider / account</th>
+                        <th className="px-3 py-3 text-left">Routing</th>
+                        <th className="w-[290px] px-3 py-3 text-left">Quota visibility</th>
+                        <th className="px-3 py-3 text-right">Period usage</th>
+                        <th className="px-3 py-3 text-right">Attributed cost</th>
+                        <th className="px-4 py-3 text-right">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-[var(--border)]">
+                      {pagination.paged.map((account) => (
+                        <QuotaAccountRow
                           key={account.id}
                           account={account}
                           selected={selected.has(account.id)}
-                          onSelect={() => toggleSelect(account.id)}
+                          expanded={expanded.has(account.id)}
+                          onSelect={() => toggleSelection(account.id)}
+                          onExpand={() => toggleExpanded(account.id)}
                           onToggle={() => toggleAccount.mutate({ id: account.id, disabled: account.status !== "paused" })}
-                          onDelete={() => deleteAccount.mutate(account.id)}
-                          hideProviderIcon
+                          onDelete={() => handleDeleteAccount(account)}
                         />
                       ))}
-                    </div>
-                  )}
+                    </tbody>
+                  </table>
                 </div>
-              ));
-            })()}
-          </div>
-        )}
-      </Card>
+                <TablePagination
+                  page={pagination.page}
+                  pages={pagination.pages}
+                  total={pagination.total}
+                  onPage={pagination.setPage}
+                />
+              </>
+            )}
+          </Card>
+        </div>
+      )}
     </>
   );
 }
 
-// ─── Quota Row (compact single-line layout) ──────────────────────────────────
-
-function QuotaRow({
-  account,
-  selected,
-  onSelect,
-  onToggle,
-  onDelete,
-  hideProviderIcon,
+function CapacityActions({
+  depleted,
+  resumable,
+  onPauseDepleted,
+  onResumeAvailable,
 }: {
-  account: QuotaAccount;
-  selected: boolean;
-  onSelect: () => void;
-  onToggle: () => void;
-  onDelete: () => void;
-  hideProviderIcon?: boolean;
+  depleted: number;
+  resumable: number;
+  onPauseDepleted: () => void;
+  onResumeAvailable: () => void;
 }) {
-  const qc = useQueryClient();
-  const toast = useToast();
-  const meta = statusMeta[account.status] ?? statusMeta.active;
-  const quotas = account.upstream_quotas ?? [];
-  const hasQuota = quotas.length > 0;
-  const depleted = isDepleted(account);
-  const [expanded, setExpanded] = useState(false);
-
-  const refreshMut = useMutation({
-    mutationFn: () => api.accountQuota(account.id),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ["quota"] }); toast.success("Quota refreshed", "Upstream quota data re-fetched for this account."); },
-    onError: (e: Error) => toast.error("Quota refresh failed", e.message),
-  });
-
-  // Compute summary stats from quotas
-  const avgRemaining = quotas.length > 0
-    ? Math.round(quotas.reduce((s, q) => s + (q.limit > 0 ? (q.remaining / q.limit) * 100 : 100), 0) / quotas.length)
-    : 100;
-  const color = getColor(avgRemaining);
-  const reset = formatCountdown(earliestReset(account));
-
   return (
-    <div className={`transition-colors hover:bg-[var(--bg-subtle)]/50 ${account.status === "paused" ? "opacity-60" : ""}`}>
-      {/* Main row */}
-      <div className="flex items-center gap-3 px-4 py-2.5">
-        {/* Checkbox */}
-        <input
-          type="checkbox"
-          checked={selected}
-          onChange={onSelect}
-          className="h-3.5 w-3.5 shrink-0 rounded border-[var(--border)] accent-accent-600"
-        />
-
-        {/* Provider icon */}
-        {!hideProviderIcon && <ProviderIcon provider={account.provider} />}
-
-        {/* Info */}
-        <div className="min-w-0 flex-1 pl-1">
-          <div className="flex items-center gap-1.5">
-            {!hideProviderIcon && <span className="text-sm font-semibold capitalize truncate">{account.provider_name}</span>}
-            <span className={`text-sm ${hideProviderIcon ? "font-medium" : "text-[var(--text-muted)]"} truncate`}>
-              {account.label || account.auth_kind}
-            </span>
-            {account.plan_name && <Badge tone="accent">{account.plan_name}</Badge>}
-            {depleted && account.status === "active" && <Badge tone="danger">depleted</Badge>}
-            {account.status !== "active" && (
-              <span className="inline-flex items-center gap-1">
-                <StatusDot tone={meta.tone} />
-                <span className="text-[11px] font-medium">{meta.label}</span>
-              </span>
-            )}
-          </div>
-          <p className="truncate text-xs text-[var(--text-muted)]">
-            {!hideProviderIcon && `${account.label || account.auth_kind} `}
-            {hasQuota ? `${!hideProviderIcon ? "· " : ""}${quotas.length} quota${quotas.length !== 1 ? "s" : ""}` : (!hideProviderIcon ? "" : "No quota configured")}
-          </p>
-        </div>
-
-        {/* Inline quota summary (if has quotas) */}
-        {hasQuota && (
-          <div className="hidden items-center gap-3 sm:flex">
-            <div className="w-24">
-              <div className="h-1 w-full overflow-hidden rounded-full bg-[var(--bg-subtle)]">
-                <div className={`h-full rounded-full ${color.bar}`} style={{ width: `${Math.max(2, 100 - avgRemaining)}%` }} />
-              </div>
-              <p className="mt-0.5 text-[10px] text-[var(--text-muted)]">{avgRemaining}% left</p>
-            </div>
-            {reset !== "-" && (
-              <span className={`text-[11px] ${avgRemaining < 30 ? "font-medium text-red-500" : "text-[var(--text-muted)]"}`}>
-                resets {reset}
-              </span>
-            )}
-          </div>
-        )}
-
-        {/* Stats — always show request/token/cost; credit accounts also show quota inline */}
-        <div className="hidden items-center gap-3 text-[11px] text-[var(--text-muted)] md:flex">
-          <span className="flex items-center gap-1">
-            <Activity className="h-3 w-3" />
-            <span className="font-medium text-[var(--text)]">{account.total_requests.toLocaleString()}</span> req
-          </span>
-          <span className="flex items-center gap-1">
-            <Zap className="h-3 w-3" />
-            {fmtTokens(account.prompt_tokens + account.completion_tokens)} tok
-          </span>
-          <span className="flex items-center gap-1">
-            <DollarSign className="h-3 w-3" />
-            <span className="font-medium tabular-nums text-[var(--text)]">${account.cost_usd.toFixed(4)}</span>
-          </span>
-          {account.usage_type === "credit" && (() => {
-            const q = account.upstream_quotas?.[0];
-            if (!q) return null;
-            const remainingPct = q.limit > 0 ? Math.round((q.remaining / q.limit) * 100) : null;
-            return (
-              <>
-                <div className="mx-0.5 h-3 w-px bg-[var(--border)]" />
-                <span>
-                  <span className="font-medium text-[var(--text)]">{q.used.toLocaleString()}</span>
-                  <span className="mx-0.5">/</span>
-                  <span>{q.limit > 0 ? q.limit.toLocaleString() : "∞"}</span>
-                  <span className="ml-0.5">used</span>
-                </span>
-                <span>
-                  <span className={`font-medium ${remainingPct !== null && remainingPct < 30 ? "text-red-500" : remainingPct !== null && remainingPct < 70 ? "text-amber-500" : "text-emerald-500"}`}>
-                    {q.remaining.toLocaleString()}
-                  </span>
-                  <span className="ml-0.5">left</span>
-                </span>
-              </>
-            );
-          })()}
-        </div>
-
-        {/* Actions */}
-        <div className="flex shrink-0 items-center gap-0.5">
-          <button onClick={() => refreshMut.mutate()} disabled={refreshMut.isPending}
-            className="rounded-lg p-1 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]" title="Refresh">
-            {refreshMut.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
-          </button>
-          <button onClick={onToggle}
-            className="rounded-lg p-1 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
-            title={account.status === "paused" ? "Enable" : "Disable"}>
-            {account.status === "paused" ? <ToggleLeft className="h-3.5 w-3.5" /> : <ToggleRight className="h-3.5 w-3.5 text-emerald-500" />}
-          </button>
-          <button onClick={onDelete}
-            className="rounded-lg p-1 text-[var(--text-muted)] hover:bg-red-500/10 hover:text-red-500" title="Delete">
-            <Trash2 className="h-3.5 w-3.5" />
-          </button>
-          {hasQuota && (
-            <button onClick={() => setExpanded(!expanded)}
-              className="rounded-lg p-1 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
-              title={expanded ? "Collapse" : "Expand"}>
-              <ChevronDown className={`h-3.5 w-3.5 transition-transform ${expanded ? "rotate-180" : ""}`} />
-            </button>
-          )}
-        </div>
+    <div className="flex flex-col gap-3 rounded-xl border border-amber-300/60 bg-amber-50/40 px-4 py-3 dark:border-amber-700/40 dark:bg-amber-950/10 lg:flex-row lg:items-center">
+      <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold">Capacity actions available</p>
+        <p className="mt-0.5 text-xs text-[var(--text-muted)]">
+          Recommendations use only the upstream limits currently reported by providers.
+        </p>
       </div>
-
-      {/* Expanded quota details */}
-      {expanded && hasQuota && (
-        <div className="border-t border-[var(--border)] bg-[var(--bg-subtle)]/30 px-4 py-2">
-          <QuotaTable quotas={quotas} />
-          {/* Mobile stats (hidden on md+) — always show req/tokens/cost */}
-          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-[var(--text-muted)] md:hidden">
-            <span>{account.total_requests.toLocaleString()} requests</span>
-            <span>{fmtTokens(account.prompt_tokens + account.completion_tokens)} tokens</span>
-            <span className="font-medium tabular-nums">${account.cost_usd.toFixed(4)}</span>
-            {account.usage_type === "credit" && (() => {
-              const q = account.upstream_quotas?.[0];
-              if (!q) return null;
-              const remainingPct = q.limit > 0 ? Math.round((q.remaining / q.limit) * 100) : null;
-              return (
-                <span>
-                  {q.used.toLocaleString()} / {q.limit > 0 ? q.limit.toLocaleString() : "∞"} used
-                  {" · "}
-                  <span className={remainingPct !== null && remainingPct < 30 ? "text-red-500" : remainingPct !== null && remainingPct < 70 ? "text-amber-500" : "text-emerald-500"}>
-                    {q.remaining.toLocaleString()} left
-                  </span>
-                </span>
-              );
-            })()}
-          </div>
-        </div>
-      )}
+      <div className="flex flex-wrap gap-2">
+        {depleted > 0 && (
+          <button type="button" onClick={onPauseDepleted} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-red-300/70 bg-[var(--bg-elevated)] px-3 text-xs font-medium text-red-600 hover:bg-red-50 dark:border-red-700/50 dark:text-red-300 dark:hover:bg-red-950/20">
+            <PowerOff className="h-3.5 w-3.5" /> Pause depleted ({depleted})
+          </button>
+        )}
+        {resumable > 0 && (
+          <button type="button" onClick={onResumeAvailable} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-emerald-300/70 bg-[var(--bg-elevated)] px-3 text-xs font-medium text-emerald-700 hover:bg-emerald-50 dark:border-emerald-700/50 dark:text-emerald-300 dark:hover:bg-emerald-950/20">
+            <Power className="h-3.5 w-3.5" /> Resume available ({resumable})
+          </button>
+        )}
+      </div>
     </div>
   );
 }
 
-// ─── Quota Table (compact inline detail) ─────────────────────────────────────
-
-function QuotaTable({ quotas }: { quotas: UpstreamQuota[] }) {
-  const [page, setPage] = useState(0);
-  const PAGE_SIZE = 8;
-  const totalPages = Math.ceil(quotas.length / PAGE_SIZE);
-  const pageQuotas = quotas.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+function SummaryGroupCard({
+  icon: Icon,
+  title,
+  primary,
+  primaryLabel,
+  items,
+  tone = "accent",
+}: {
+  icon: LucideIcon;
+  title: string;
+  primary: string;
+  primaryLabel: string;
+  items: Array<{ label: string; value: string; tone?: "good" | "danger" }>;
+  tone?: SummaryTone;
+}) {
+  const tones: Record<SummaryTone, { icon: string; background: string }> = {
+    accent: {
+      icon: "text-secondary-600 dark:text-secondary-300",
+      background: "bg-secondary-50 ring-secondary-200/70 dark:bg-secondary-950/30 dark:ring-secondary-900/60",
+    },
+    success: {
+      icon: "text-emerald-600 dark:text-emerald-300",
+      background: "bg-emerald-50 ring-emerald-200/70 dark:bg-emerald-950/30 dark:ring-emerald-900/60",
+    },
+    warning: {
+      icon: "text-amber-700 dark:text-amber-300",
+      background: "bg-amber-50 ring-amber-200/70 dark:bg-amber-950/30 dark:ring-amber-900/60",
+    },
+  };
+  const colors = tones[tone];
 
   return (
-    <div>
-      <table className="w-full table-fixed">
-        <tbody>
-          {pageQuotas.map((q) => (
-            <QuotaDetailRow key={q.resource_type} quota={q} />
-          ))}
-        </tbody>
-      </table>
-      {quotas.length > PAGE_SIZE && (
-        <div className="mt-1 flex items-center justify-between rounded-md border border-[var(--border)] bg-[var(--bg-subtle)] px-2 py-1">
-          <span className="text-[10px] text-[var(--text-muted)]">
-            {quotas.length} quotas · Page {page + 1}/{totalPages}
-          </span>
-          <div className="flex items-center gap-1">
-            <button onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0}
-              className="rounded border border-[var(--border)] px-1.5 py-0.5 text-[10px] disabled:opacity-30">Prev</button>
-            <button onClick={() => setPage(Math.min(totalPages - 1, page + 1))} disabled={page >= totalPages - 1}
-              className="rounded border border-[var(--border)] px-1.5 py-0.5 text-[10px] disabled:opacity-30">Next</button>
+    <Card className="p-5">
+      <div className="flex items-center gap-2">
+        <span className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ring-1 ${colors.background}`}>
+          <Icon className={`h-4 w-4 ${colors.icon}`} />
+        </span>
+        <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">{title}</span>
+      </div>
+      <div className="mt-4 flex items-baseline gap-2">
+        <span className="text-3xl font-semibold tracking-tight tabular-nums">{primary}</span>
+        <span className="text-xs text-[var(--text-muted)]">{primaryLabel}</span>
+      </div>
+      <div className="mt-4 grid grid-cols-3 gap-3 border-t border-[var(--border)] pt-3">
+        {items.map((item) => (
+          <div key={item.label} className="min-w-0">
+            <div className={`truncate text-xs font-semibold tabular-nums sm:text-sm ${
+              item.tone === "good"
+                ? "text-emerald-600 dark:text-emerald-300"
+                : item.tone === "danger"
+                  ? "text-red-600 dark:text-red-300"
+                  : "text-[var(--text)]"
+            }`} title={item.value}>{item.value}</div>
+            <div className="mt-0.5 text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">{item.label}</div>
           </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function FilterSelect({
+  value,
+  onChange,
+  label,
+  children,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="min-w-0">
+      <span className="sr-only">{label}</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-9 w-full rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2.5 text-xs outline-none focus:border-[var(--border-strong)] focus:ring-2 focus:ring-accent-400/20 xl:w-auto"
+      >
+        {children}
+      </select>
+    </label>
+  );
+}
+
+function QuotaAccountRow({
+  account,
+  selected,
+  expanded,
+  onSelect,
+  onExpand,
+  onToggle,
+  onDelete,
+}: {
+  account: QuotaAccount;
+  selected: boolean;
+  expanded: boolean;
+  onSelect: () => void;
+  onExpand: () => void;
+  onToggle: () => void;
+  onDelete: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const quotas = account.upstream_quotas ?? [];
+  const canReportQuota = supportsQuota(account);
+  const state = effectiveQuotaState(account);
+  const status = statusMeta[account.status] ?? { label: account.status, tone: "neutral" as const };
+  const refreshQuota = useMutation({
+    mutationFn: () => api.accountQuota(account.id),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["quota"] });
+      if (result.supported) toast.success("Quota refreshed", "The latest upstream limits are now available.");
+      else toast.success("Usage-only account", "This provider does not expose upstream quota through KeiRouter.");
+    },
+    onError: (error: Error) => toast.error("Quota refresh failed", error.message),
+  });
+
+  return (
+    <>
+      <tr className={`transition-colors hover:bg-[var(--bg-subtle)]/60 ${account.status === "paused" ? "opacity-65" : ""}`}>
+        <td className="px-4 py-3 align-middle">
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={onSelect}
+            aria-label={`Select ${account.label || account.provider_name}`}
+            className="h-3.5 w-3.5 rounded border-[var(--border)] accent-accent-600"
+          />
+        </td>
+        <td className="px-3 py-3 align-middle">
+          <div className="flex min-w-0 items-center gap-3">
+            <ProviderIcon provider={account.provider} label={account.provider_name} />
+            <div className="min-w-0">
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="max-w-48 truncate text-sm font-semibold" title={account.provider_name}>{account.provider_name || account.provider}</span>
+                {account.plan_name && <Badge tone="accent">{account.plan_name}</Badge>}
+              </div>
+              <div className="mt-0.5 max-w-64 truncate text-[10px] text-[var(--text-muted)]" title={account.label || account.auth_kind}>
+                {account.label || account.auth_kind} · {formatAuthKind(account.auth_kind)}
+              </div>
+            </div>
+          </div>
+        </td>
+        <td className="px-3 py-3 align-middle">
+          <span className="whitespace-nowrap"><Badge tone={status.tone}>{status.label}</Badge></span>
+          <div className="mt-1 text-[10px] text-[var(--text-muted)]">Priority {account.priority}</div>
+        </td>
+        <td className="px-3 py-3 align-middle">
+          <QuotaVisibilityCell account={account} expanded={expanded} onExpand={onExpand} />
+        </td>
+        <td className="px-3 py-3 text-right align-middle tabular-nums">
+          <div className="font-semibold">{fmtInteger(account.total_requests)} req</div>
+          <div className="mt-1 text-[10px] text-[var(--text-muted)]">{fmtCompact(account.prompt_tokens + account.completion_tokens)} tokens</div>
+        </td>
+        <td className="px-3 py-3 text-right align-middle font-semibold tabular-nums">{fmtUSD(account.cost_usd)}</td>
+        <td className="px-4 py-3 text-right align-middle">
+          <div className="inline-flex items-center gap-1">
+            {canReportQuota && (
+              <button
+                type="button"
+                onClick={() => refreshQuota.mutate()}
+                disabled={refreshQuota.isPending || account.status === "paused"}
+                aria-label={`Refresh quota for ${account.label || account.provider_name}`}
+                title={account.status === "paused" ? "Enable the account before refreshing quota" : "Refresh upstream quota"}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--bg-subtle)] hover:text-[var(--text)] disabled:cursor-not-allowed disabled:opacity-35"
+              >
+                {refreshQuota.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onToggle}
+              aria-label={account.status === "paused" ? `Enable ${account.label || account.provider_name}` : `Pause ${account.label || account.provider_name}`}
+              title={account.status === "paused" ? "Enable account" : "Pause account"}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[var(--bg-subtle)] hover:text-[var(--text)]"
+            >
+              {account.status === "paused" ? <Power className="h-3.5 w-3.5" /> : <PowerOff className="h-3.5 w-3.5" />}
+            </button>
+            <button
+              type="button"
+              onClick={onDelete}
+              aria-label={`Delete ${account.label || account.provider_name}`}
+              title="Delete account"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/20 dark:hover:text-red-300"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          {state === "error" && <span className="sr-only">Quota refresh error</span>}
+        </td>
+      </tr>
+      {expanded && quotas.length > 0 && (
+        <tr>
+          <td colSpan={7} className="border-t border-[var(--border)] bg-[var(--bg-subtle)]/35 px-5 py-4">
+            <QuotaDetails account={account} />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function QuotaAccountMobile({
+  account,
+  selected,
+  expanded,
+  onSelect,
+  onExpand,
+  onToggle,
+  onDelete,
+}: {
+  account: QuotaAccount;
+  selected: boolean;
+  expanded: boolean;
+  onSelect: () => void;
+  onExpand: () => void;
+  onToggle: () => void;
+  onDelete: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const status = statusMeta[account.status] ?? { label: account.status, tone: "neutral" as const };
+  const canReportQuota = supportsQuota(account);
+  const refreshQuota = useMutation({
+    mutationFn: () => api.accountQuota(account.id),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["quota"] });
+      if (result.supported) toast.success("Quota refreshed", "The latest upstream limits are now available.");
+      else toast.success("Usage-only account", "This provider does not expose upstream quota through KeiRouter.");
+    },
+    onError: (error: Error) => toast.error("Quota refresh failed", error.message),
+  });
+
+  return (
+    <article className={`px-4 py-4 ${account.status === "paused" ? "opacity-65" : ""}`}>
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={onSelect}
+          aria-label={`Select ${account.label || account.provider_name}`}
+          className="mt-2 h-3.5 w-3.5 shrink-0 rounded border-[var(--border)] accent-accent-600"
+        />
+        <ProviderIcon provider={account.provider} label={account.provider_name} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <h3 className="truncate text-sm font-semibold">{account.provider_name || account.provider}</h3>
+            {account.plan_name && <Badge tone="accent">{account.plan_name}</Badge>}
+          </div>
+          <p className="mt-0.5 truncate text-[10px] text-[var(--text-muted)]">
+            {account.label || account.auth_kind} · {formatAuthKind(account.auth_kind)}
+          </p>
+        </div>
+        <span className="shrink-0 whitespace-nowrap"><Badge tone={status.tone}>{status.label}</Badge></span>
+      </div>
+
+      <div className="mt-4 rounded-lg border border-[var(--border)] bg-[var(--bg-subtle)]/35 px-3 py-2.5">
+        <QuotaVisibilityCell account={account} expanded={expanded} onExpand={onExpand} />
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-3 border-t border-[var(--border)] pt-3">
+        <div>
+          <div className="text-[9px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Period usage</div>
+          <div className="mt-1 text-xs font-semibold tabular-nums">{fmtInteger(account.total_requests)} requests</div>
+          <div className="mt-0.5 text-[10px] text-[var(--text-muted)]">{fmtCompact(account.prompt_tokens + account.completion_tokens)} tokens</div>
+        </div>
+        <div className="text-right">
+          <div className="text-[9px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Attributed cost</div>
+          <div className="mt-1 text-xs font-semibold tabular-nums">{fmtUSD(account.cost_usd)}</div>
+          <div className="mt-0.5 text-[10px] text-[var(--text-muted)]">Priority {account.priority}</div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {canReportQuota && (
+          <button
+            type="button"
+            onClick={() => refreshQuota.mutate()}
+            disabled={refreshQuota.isPending || account.status === "paused"}
+            className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-[var(--border)] px-2.5 text-[10px] font-medium text-[var(--text-muted)] hover:bg-[var(--bg-subtle)] hover:text-[var(--text)] disabled:opacity-35"
+          >
+            {refreshQuota.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+            Refresh quota
+          </button>
+        )}
+        <button type="button" onClick={onToggle} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-[var(--border)] px-2.5 text-[10px] font-medium text-[var(--text-muted)] hover:bg-[var(--bg-subtle)] hover:text-[var(--text)]">
+          {account.status === "paused" ? <Power className="h-3.5 w-3.5" /> : <PowerOff className="h-3.5 w-3.5" />}
+          {account.status === "paused" ? "Enable" : "Pause"}
+        </button>
+        <button type="button" onClick={onDelete} className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-red-300/50 px-2.5 text-[10px] font-medium text-red-600 hover:bg-red-50 dark:border-red-700/40 dark:text-red-300 dark:hover:bg-red-950/20">
+          <Trash2 className="h-3.5 w-3.5" /> Delete
+        </button>
+      </div>
+
+      {expanded && hasReportedQuota(account) && (
+        <div className="mt-4">
+          <QuotaDetails account={account} />
         </div>
       )}
+    </article>
+  );
+}
+
+function QuotaVisibilityCell({ account, expanded, onExpand }: { account: QuotaAccount; expanded: boolean; onExpand: () => void }) {
+  const quotas = account.upstream_quotas ?? [];
+  const state = effectiveQuotaState(account);
+
+  if (quotas.length === 0) {
+    const content: Record<string, { label: string; detail: string; tone: string }> = {
+      usage_only: {
+        label: "Usage only",
+        detail: "Provider does not expose upstream limits.",
+        tone: "bg-[var(--text-muted)]",
+      },
+      paused: {
+        label: "Quota refresh paused",
+        detail: "Enable the account to fetch limits.",
+        tone: "bg-[var(--text-muted)]",
+      },
+      error: {
+        label: "Refresh failed",
+        detail: account.message || "Retry the upstream quota request.",
+        tone: "bg-red-500",
+      },
+      pending: {
+        label: "Not yet reported",
+        detail: "The provider supports upstream limits.",
+        tone: "bg-amber-500",
+      },
+      unavailable: {
+        label: "Not reported",
+        detail: account.message || "The provider returned no limit buckets.",
+        tone: "bg-amber-500",
+      },
+    };
+    const item = content[state] ?? content.unavailable;
+    return (
+      <div className="flex min-w-0 items-start gap-2">
+        <span className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${item.tone}`} />
+        <div className="min-w-0">
+          <div className="text-xs font-semibold">{item.label}</div>
+          <div className="mt-0.5 max-w-64 truncate text-[10px] text-[var(--text-muted)]" title={item.detail}>{item.detail}</div>
+        </div>
+      </div>
+    );
+  }
+
+  const remaining = worstRemainingPercent(account);
+  const resetAt = earliestReset(account);
+  const color = quotaColor(remaining);
+  return (
+    <div className="min-w-0">
+      <div className="flex items-center justify-between gap-3">
+        <span className={`text-xs font-semibold tabular-nums ${color.text}`}>{remaining}% remaining</span>
+        <button
+          type="button"
+          onClick={onExpand}
+          aria-expanded={expanded}
+          className="inline-flex items-center gap-1 text-[10px] font-medium text-[var(--text-muted)] hover:text-[var(--text)]"
+        >
+          {quotas.length} limit{quotas.length === 1 ? "" : "s"}
+          <ChevronDown className={`h-3 w-3 transition-transform ${expanded ? "rotate-180" : ""}`} />
+        </button>
+      </div>
+      <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-[var(--bg-subtle)]">
+        <div className={`h-full rounded-full ${color.bar}`} style={{ width: `${Math.max(2, 100 - remaining)}%` }} />
+      </div>
+      <div className="mt-1 text-[10px] text-[var(--text-muted)]">
+        {resetAt ? `Next reset ${formatCountdown(resetAt)}` : "No reset time reported"}
+      </div>
+    </div>
+  );
+}
+
+function QuotaDetails({ account }: { account: QuotaAccount }) {
+  const quotas = account.upstream_quotas ?? [];
+  const { page, pages, paged, setPage, total } = useClientPagination(quotas, 6);
+
+  return (
+    <div className="mx-auto max-w-5xl overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)]">
+      <div className="flex flex-col gap-2 border-b border-[var(--border)] px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-xs font-semibold">Reported upstream limits</h3>
+          <p className="mt-0.5 text-[10px] text-[var(--text-muted)]">
+            {account.message || "Values are fetched directly from the provider and may use provider-specific units."}
+          </p>
+        </div>
+        <span className="text-[10px] text-[var(--text-muted)]">Account updated {relativeTime(account.updated_at)}</span>
+      </div>
+      <div className="divide-y divide-[var(--border)] sm:hidden">
+        {paged.map((quota, index) => <QuotaDetailMobile key={`${quota.resource_type}-${index}`} quota={quota} />)}
+      </div>
+      <div className="hidden overflow-x-auto sm:block">
+        <table className="w-full min-w-[680px] text-xs">
+          <thead>
+            <tr className="border-b border-[var(--border)] text-[9px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+              <th className="px-4 py-2.5 text-left">Resource</th>
+              <th className="px-3 py-2.5 text-left">Consumption</th>
+              <th className="px-3 py-2.5 text-right">Used</th>
+              <th className="px-3 py-2.5 text-right">Remaining</th>
+              <th className="px-4 py-2.5 text-right">Reset</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[var(--border)]">
+            {paged.map((quota, index) => <QuotaDetailRow key={`${quota.resource_type}-${index}`} quota={quota} />)}
+          </tbody>
+        </table>
+      </div>
+      <TablePagination page={page} pages={pages} total={total} onPage={setPage} />
+    </div>
+  );
+}
+
+function QuotaDetailMobile({ quota }: { quota: UpstreamQuota }) {
+  const remaining = quota.limit > 0 ? Math.max(0, Math.min(100, Math.round((quota.remaining / quota.limit) * 100))) : 100;
+  const used = quota.limit > 0 ? 100 - remaining : 0;
+  const color = quotaColor(remaining);
+  return (
+    <div className="px-3 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xs font-semibold">{humanize(quota.resource_type)}</div>
+          <div className="mt-0.5 text-[10px] text-[var(--text-muted)]">
+            {fmtInteger(quota.used)} used of {quota.limit > 0 ? fmtInteger(quota.limit) : "unlimited"}
+          </div>
+        </div>
+        <div className={`shrink-0 text-right text-xs font-semibold tabular-nums ${color.text}`}>
+          {quota.limit > 0 ? `${remaining}% left` : "Unlimited"}
+        </div>
+      </div>
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--bg-subtle)]">
+        <div className={`h-full rounded-full ${color.bar}`} style={{ width: `${Math.max(quota.used > 0 ? 2 : 0, used)}%` }} />
+      </div>
+      <div className="mt-1.5 text-[10px] text-[var(--text-muted)]">
+        {quota.reset_at ? `Resets ${formatCountdown(quota.reset_at)}` : "No reset time reported"}
+      </div>
     </div>
   );
 }
 
 function QuotaDetailRow({ quota }: { quota: UpstreamQuota }) {
-  const usedPct = quota.limit > 0 ? Math.min(100, Math.round((quota.used / quota.limit) * 100)) : 0;
-  const remainingPct = quota.limit > 0 ? Math.round((quota.remaining / quota.limit) * 100) : 0;
-  const color = getColor(remainingPct);
-  const countdown = formatCountdown(quota.reset_at);
-  const name = quota.resource_type.toLowerCase().replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-
+  const remaining = quota.limit > 0 ? Math.max(0, Math.min(100, Math.round((quota.remaining / quota.limit) * 100))) : 100;
+  const used = quota.limit > 0 ? 100 - remaining : 0;
+  const color = quotaColor(remaining);
   return (
-    <tr className="border-b border-black/5 dark:border-white/5 hover:bg-black/[0.02] dark:hover:bg-white/[0.02]">
-      <td className="w-[30%] truncate py-1 px-1.5">
-        <div className="flex items-center gap-1.5">
-          <span className="text-[10px]">{color.emoji}</span>
-          <span className="truncate text-[11px] font-medium">{name}</span>
+    <tr>
+      <td className="px-4 py-3 font-medium">{humanize(quota.resource_type)}</td>
+      <td className="px-3 py-3">
+        <div className="h-1.5 overflow-hidden rounded-full bg-[var(--bg-subtle)]">
+          <div className={`h-full rounded-full ${color.bar}`} style={{ width: `${Math.max(quota.used > 0 ? 2 : 0, used)}%` }} />
         </div>
       </td>
-      <td className="w-[45%] py-1 px-1.5">
-        <div className="space-y-0.5">
-          <div className="h-1 w-full overflow-hidden rounded-full bg-[var(--bg-subtle)]">
-            <div className={`h-full rounded-full ${color.bar}`} style={{ width: `${Math.max(2, usedPct)}%` }} />
-          </div>
-          <div className="flex items-center justify-between text-[10px] text-[var(--text-muted)]">
-            <span>{quota.used.toLocaleString()} / {quota.limit > 0 ? quota.limit.toLocaleString() : "∞"}</span>
-            <span className={`font-semibold ${color.text}`}>{remainingPct}%</span>
-          </div>
-        </div>
-      </td>
-      <td className="w-[25%] py-1 px-1.5 text-right">
-        <span className={`text-[11px] ${remainingPct < 30 ? "font-medium text-red-500" : "text-[var(--text-muted)]"}`}>
-          {countdown !== "-" ? `resets ${countdown}` : "-"}
-        </span>
+      <td className="px-3 py-3 text-right tabular-nums">{fmtInteger(quota.used)} / {quota.limit > 0 ? fmtInteger(quota.limit) : "Unlimited"}</td>
+      <td className={`px-3 py-3 text-right font-semibold tabular-nums ${color.text}`}>{quota.limit > 0 ? `${remaining}%` : "Unlimited"}</td>
+      <td className="whitespace-nowrap px-4 py-3 text-right text-[var(--text-muted)]" title={quota.reset_at ? formatDateTime(quota.reset_at) : undefined}>
+        {quota.reset_at ? formatCountdown(quota.reset_at) : "—"}
       </td>
     </tr>
   );
 }
 
-// ─── Provider Icon ───────────────────────────────────────────────────────────
-
-function ProviderIcon({ provider, className }: { provider: string, className?: string }) {
+function ProviderIcon({ provider, label }: { provider: string; label: string }) {
   const [errored, setErrored] = useState(false);
-  const sizeClass = className || "h-7 w-7";
   if (errored) {
     return (
-      <div className={`flex shrink-0 items-center justify-center rounded-md bg-[var(--bg-subtle)] text-[10px] font-bold text-[var(--text-muted)] ${sizeClass}`}>
-        {provider.slice(0, 2).toUpperCase()}
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-subtle)] text-[10px] font-bold text-[var(--text-muted)]">
+        {(label || provider).slice(0, 2).toUpperCase()}
       </div>
     );
   }
   return (
-    <img src={`/providers/${provider}.png`} alt={provider} onError={() => setErrored(true)}
-      className="h-7 w-7 shrink-0 rounded-md object-contain" />
+    <img
+      src={`/providers/${provider}.png`}
+      alt=""
+      onError={() => setErrored(true)}
+      className="h-8 w-8 shrink-0 rounded-lg object-contain"
+    />
   );
+}
+
+function supportsQuota(account: QuotaAccount): boolean {
+  return account.quota_supported ?? account.usage_type === "credit";
+}
+
+function hasReportedQuota(account: QuotaAccount): boolean {
+  return (account.upstream_quotas?.length ?? 0) > 0;
+}
+
+function effectiveQuotaState(account: QuotaAccount): string {
+  if (hasReportedQuota(account)) return "reported";
+  if (account.quota_state) return account.quota_state;
+  if (!supportsQuota(account)) return "usage_only";
+  if (account.status === "paused") return "paused";
+  return "unavailable";
+}
+
+function isDepleted(account: QuotaAccount): boolean {
+  return (account.upstream_quotas ?? []).some((quota) => quota.limit > 0 && (quota.remaining / quota.limit) * 100 < DEPLETED_THRESHOLD);
+}
+
+function worstRemainingPercent(account: QuotaAccount): number {
+  const percentages = (account.upstream_quotas ?? [])
+    .filter((quota) => quota.limit > 0)
+    .map((quota) => Math.max(0, Math.min(100, Math.round((quota.remaining / quota.limit) * 100))));
+  return percentages.length > 0 ? Math.min(...percentages) : 100;
+}
+
+function earliestReset(account: QuotaAccount): number | null {
+  let earliest: number | null = null;
+  for (const quota of account.upstream_quotas ?? []) {
+    if (!quota.reset_at) continue;
+    const timestamp = new Date(quota.reset_at).getTime();
+    if (Number.isFinite(timestamp) && (earliest == null || timestamp < earliest)) earliest = timestamp;
+  }
+  return earliest;
+}
+
+function compareNullableTime(left: number | null, right: number | null): number {
+  if (left == null && right == null) return 0;
+  if (left == null) return 1;
+  if (right == null) return -1;
+  return left - right;
+}
+
+function accountAttentionScore(account: QuotaAccount): number {
+  if (account.status === "active" && isDepleted(account)) return 0;
+  if (account.status === "needs_attention") return 1;
+  if (effectiveQuotaState(account) === "error") return 2;
+  if (account.status === "active") return 3;
+  return 4;
+}
+
+function quotaColor(remaining: number): { bar: string; text: string } {
+  if (remaining > 70) return { bar: "bg-emerald-500", text: "text-emerald-600 dark:text-emerald-300" };
+  if (remaining >= 30) return { bar: "bg-amber-500", text: "text-amber-600 dark:text-amber-300" };
+  return { bar: "bg-red-500", text: "text-red-600 dark:text-red-300" };
+}
+
+function formatCountdown(value: string | number): string {
+  const timestamp = typeof value === "number" ? value : new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return "—";
+  const difference = timestamp - Date.now();
+  if (difference <= 0) return "now";
+  const days = Math.floor(difference / 86_400_000);
+  const hours = Math.floor((difference % 86_400_000) / 3_600_000);
+  const minutes = Math.floor((difference % 3_600_000) / 60_000);
+  if (days > 0) return `in ${days}d ${hours}h`;
+  if (hours > 0) return `in ${hours}h ${minutes}m`;
+  return `in ${Math.max(1, minutes)}m`;
+}
+
+function relativeTime(value: string): string {
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return "unknown";
+  const difference = Date.now() - timestamp;
+  if (difference < 60_000) return "just now";
+  if (difference < 3_600_000) return `${Math.floor(difference / 60_000)}m ago`;
+  if (difference < 86_400_000) return `${Math.floor(difference / 3_600_000)}h ago`;
+  return `${Math.floor(difference / 86_400_000)}d ago`;
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+}
+
+function humanize(value: string): string {
+  return value.replace(/[_-]+/g, " ").replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function formatAuthKind(value: string): string {
+  const known: Record<string, string> = {
+    oauth: "OAuth",
+    api_key: "API key",
+    bearer: "Bearer token",
+  };
+  return known[value.toLowerCase()] || humanize(value);
+}
+
+function fmtInteger(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function fmtCompact(value: number): string {
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return value.toLocaleString();
+}
+
+function fmtUSD(value: number): string {
+  if (value > 0 && value < 0.0001) return "<$0.0001";
+  if (value < 1) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
 }

--- a/frontend/src/pages/Usage.tsx
+++ b/frontend/src/pages/Usage.tsx
@@ -1,32 +1,89 @@
-import { useState, useMemo, useEffect, useRef, useLayoutEffect } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
 import {
-  Activity, DollarSign, Zap, RefreshCw, TrendingUp, Clock, Box, TerminalSquare, ArrowUpDown, ArrowUp, ArrowDown, Search,
-  Layers, ChevronRight, Shield, ArrowRight
+  Activity,
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+	ArrowUpDown,
+	ChevronDown,
+	Database,
+	DollarSign,
+	Info,
+  Layers3,
+  RefreshCw,
+  Search,
+	Server,
+	ShieldCheck,
+	Timer,
+  TrendingUp,
+  Zap,
+  type LucideIcon,
 } from "lucide-react";
 import {
-  AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
 } from "recharts";
-import { api, connectUsageStream, type ProviderUsage, type RecentActivity, type ModelUsage, type SeriesPoint, type Chain, type Provider } from "../lib/api";
+import {
+  api,
+  connectUsageStream,
+  type HealthOverview,
+  type HealthProviderRow,
+  type ModelUsage,
+  type PricingStatus,
+  type ProviderUsage,
+  type RecentActivity,
+  type SeriesPoint,
+  type UsageInsights,
+  type UsageSource,
+  type UsageTerminalStatus,
+} from "../lib/api";
 import { PageHeader } from "../components/Layout";
-import { Spinner, ErrorCard, StatCard } from "../components/ui";
+import {
+  Badge,
+  Card,
+  EmptyState,
+  ErrorBanner,
+  ErrorCard,
+  Modal,
+  SegmentedControl,
+  Spinner,
+  TabBar,
+  TablePagination,
+  useClientPagination,
+} from "../components/ui";
+import { HealthStatusBadge } from "../components/HealthBadge";
 import { useToast } from "../components/Toast";
 import { TokenSavingsBreakdown } from "../components/SavingsBreakdown";
 
-const periods = [
+const PERIODS = [
   { value: "today", label: "Today" },
   { value: "24h", label: "24h" },
   { value: "week", label: "7D" },
   { value: "month", label: "30D" },
 ];
 
-const USAGE_REFRESH_DEBOUNCE_MS = 8000;
+const HEALTH_RANGE: Record<string, string> = {
+  today: "24h",
+  "24h": "24h",
+  week: "7d",
+  month: "30d",
+};
+
+const USAGE_REFRESH_DEBOUNCE_MS = 8_000;
 
 export function UsagePage() {
   const [period, setPeriod] = useState("today");
-  const qc = useQueryClient();
+  const queryClient = useQueryClient();
   const toast = useToast();
   const refreshTimer = useRef<number | null>(null);
+  const healthRange = HEALTH_RANGE[period] ?? "24h";
 
   const insights = useQuery({
     queryKey: ["usage-insights", period],
@@ -44,16 +101,12 @@ export function UsagePage() {
     placeholderData: (previous) => previous,
   });
 
-  const chains = useQuery({
-    queryKey: ["chains"],
-    queryFn: () => api.listChains(),
-    staleTime: 30_000,
-  });
-
-  const providerCatalog = useQuery({
-    queryKey: ["providers"],
-    queryFn: () => api.providers(),
-    staleTime: 60_000,
+  const health = useQuery({
+    queryKey: ["health-overview", healthRange],
+    queryFn: () => api.healthOverview(healthRange),
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+    retry: 1,
   });
 
   useEffect(() => {
@@ -61,829 +114,1645 @@ export function UsagePage() {
       if (refreshTimer.current != null) return;
       refreshTimer.current = window.setTimeout(() => {
         refreshTimer.current = null;
-        qc.invalidateQueries({ queryKey: ["usage-insights", period] });
-        qc.invalidateQueries({ queryKey: ["usage-models", period] });
+        queryClient.invalidateQueries({ queryKey: ["usage-insights", period] });
+        queryClient.invalidateQueries({ queryKey: ["usage-models", period] });
       }, USAGE_REFRESH_DEBOUNCE_MS);
     };
-    return connectUsageStream(() => {
-      scheduleRefresh();
-    });
-  }, [qc, period]);
+    return connectUsageStream(scheduleRefresh);
+  }, [period, queryClient]);
 
-  useEffect(() => {
-    return () => {
-      if (refreshTimer.current != null) {
-        window.clearTimeout(refreshTimer.current);
-      }
-    };
+  useEffect(() => () => {
+    if (refreshTimer.current != null) window.clearTimeout(refreshTimer.current);
   }, []);
 
   const handleRefresh = () => {
-    qc.invalidateQueries({ queryKey: ["usage-insights", period] });
-    qc.invalidateQueries({ queryKey: ["usage-models", period] });
-    toast.success("Usage data refreshed", "All usage metrics and breakdowns have been re-fetched from the server.");
+    queryClient.invalidateQueries({ queryKey: ["usage-insights", period] });
+    queryClient.invalidateQueries({ queryKey: ["usage-models", period] });
+    queryClient.invalidateQueries({ queryKey: ["health-overview", healthRange] });
+    toast.success("Usage data refreshed", "Accounting, pricing, and health metrics are being re-fetched.");
   };
+
+  const isRefreshing = insights.isFetching || modelUsage.isFetching || health.isFetching;
 
   return (
     <>
-      <PageHeader
-        title="Usage"
-        icon={Activity}
-        description="Monitor request flow and provider distribution."
+		<PageHeader
+			title="Usage"
+			icon={Activity}
+			description="Requests, spend, optimization, and provider performance."
         action={
-          <div className="flex items-center gap-2">
-            <div className="flex items-center gap-1 rounded-lg border border-[var(--border)] bg-[var(--bg-subtle)] p-1">
-              {periods.map((p) => (
-                <button key={p.value} onClick={() => setPeriod(p.value)}
-                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${period === p.value ? "bg-accent-600 text-white shadow-sm" : "text-[var(--text-muted)] hover:text-[var(--text)]"}`}>
-                  {p.label}
-                </button>
-              ))}
-            </div>
-            <button onClick={handleRefresh}
-              className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--bg-subtle)] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]">
-              <RefreshCw className="h-4 w-4" />
+          <div className="flex flex-wrap items-center gap-2">
+            <SegmentedControl value={period} onChange={setPeriod} options={PERIODS} />
+            <button
+              type="button"
+              onClick={handleRefresh}
+              aria-label="Refresh usage analytics"
+              title="Refresh usage analytics"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)] shadow-sm transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--bg-subtle)] hover:text-[var(--text)]"
+            >
+              <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
             </button>
           </div>
         }
       />
 
-      {insights.isLoading ? <Spinner />
-        : insights.isError ? <ErrorCard message="Failed to load usage. Is the backend running?" />
-        : insights.data ? <UsageContent data={insights.data} models={modelUsage.data?.models ?? []} chains={chains.data?.chains ?? []} providerCatalog={providerCatalog.data?.providers ?? []} period={period} /> : null}
+      {insights.isLoading ? (
+        <Spinner />
+      ) : insights.isError ? (
+        <ErrorCard message="Failed to load usage analytics. Is the backend running?" />
+      ) : insights.data ? (
+        <UsageContent
+          data={insights.data}
+          models={modelUsage.data?.models ?? []}
+          modelsLoading={modelUsage.isLoading}
+          modelsError={modelUsage.isError}
+          health={health.data}
+          healthLoading={health.isLoading}
+          healthError={health.isError}
+          period={period}
+        />
+      ) : null}
     </>
   );
 }
 
-function UsageContent({ data, models, chains, providerCatalog, period }: { data: any; models: ModelUsage[]; chains: Chain[]; providerCatalog: Provider[]; period: string }) {
+function UsageContent({
+  data,
+  models,
+  modelsLoading,
+  modelsError,
+  health,
+  healthLoading,
+  healthError,
+  period,
+}: {
+  data: UsageInsights;
+  models: ModelUsage[];
+  modelsLoading: boolean;
+  modelsError: boolean;
+  health?: HealthOverview;
+  healthLoading: boolean;
+  healthError: boolean;
+  period: string;
+}) {
   const { summary, savings, providers, recent, series } = data;
 
-  return (
-    <div className="space-y-8 pb-12">
-      {/* Precision Minimalist Stat Grid */}
-      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
-        <StatCard label="REQUESTS" value={fmtNum(summary.total_requests)} icon={Activity} />
-        <StatCard label="INPUT TOKENS" value={fmtNum(summary.prompt_tokens)} icon={Zap} />
-        <StatCard label="OUTPUT TOKENS" value={fmtNum(summary.completion_tokens)} icon={TrendingUp} />
-        <StatCard label="EST. COST" value={`$${summary.cost_usd.toFixed(2)}`} icon={DollarSign} />
-        
-        <div className="flex flex-col justify-between p-5 rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm transition-colors hover:bg-[var(--bg-subtle)] relative overflow-hidden group col-span-2 lg:col-span-1">
-          <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/5 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100 dark:from-emerald-500/10" />
-          <div className="relative flex items-center justify-between mb-4">
-            <div className="flex items-center gap-2">
-              <Clock className="h-4 w-4 text-[var(--text-muted)]" />
-              <span className="text-xs font-medium tracking-wide uppercase text-[var(--text-muted)]">EFFICIENCY</span>
-            </div>
-          </div>
-          <div className="relative space-y-2">
-            <div className="flex items-baseline justify-between">
-              <div className="text-lg font-light tracking-tight tabular-nums text-[var(--text)]">
-                {summary.avg_latency_ms > 0 ? `${summary.avg_latency_ms}ms` : summary.total_requests > 0 ? "<1ms" : "—"}
-              </div>
-              <div className="text-[11px] text-[var(--text-muted)]">latency</div>
-            </div>
-            <div className="flex items-baseline justify-between">
-              <div className="text-lg font-light tracking-tight tabular-nums text-[var(--text)]">
-                {summary.success_rate != null ? (summary.success_rate * 100).toFixed(1) : summary.total_requests > 0 ? "—" : "100"}%
-              </div>
-              <div className="text-[11px] text-[var(--text-muted)]">success</div>
-            </div>
-          </div>
-        </div>
+	return (
+		<div className="space-y-6 pb-12">
+			<div className="grid gap-4 lg:grid-cols-3">
+				<SummaryCard
+					icon={Activity}
+					title="Traffic"
+					primary={fmtCompact(summary.total_requests)}
+					primaryLabel="requests"
+					items={[
+						{ label: "Tokens", value: fmtCompact(summary.total_tokens) },
+						{ label: "Success / failed", value: `${fmtCompact(summary.successful_requests)} / ${fmtCompact(summary.failed_requests)}` },
+						{ label: "Input / output", value: `${fmtCompact(summary.prompt_tokens)} / ${fmtCompact(summary.completion_tokens)}` },
+					]}
+				/>
+				<SummaryCard
+					icon={DollarSign}
+					title="Spend & savings"
+					primary={fmtUSD(summary.cost_usd)}
+					primaryLabel="tracked cost"
+					items={[
+						{ label: "Value saved", value: fmtUSD(savings.usd_saved), tone: "good" },
+						{ label: "Cost / request", value: fmtUSD(summary.cost_per_request_usd) },
+						{ label: "Tokens saved", value: fmtCompact(savings.total_tokens_saved) },
+					]}
+					tone={summary.unpriced_requests > 0 ? "warning" : "accent"}
+				/>
+				<SummaryCard
+					icon={ShieldCheck}
+					title="Performance"
+					primary={fmtRatio(summary.success_rate)}
+					primaryLabel="successful"
+					items={[
+						{ label: "Avg latency", value: fmtMs(summary.avg_latency_ms) },
+						{ label: "TTFT", value: fmtMs(summary.avg_ttft_ms) },
+						{ label: "Tokens / request", value: fmtCompact(summary.tokens_per_request) },
+					]}
+					tone={summary.success_rate < 0.95 && summary.total_requests > 0 ? "warning" : "success"}
+				/>
+			</div>
+
+			<PricingCoverageNotice summary={summary} />
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.7fr)_minmax(320px,1fr)]">
+        <UsageTrendCard series={series} busiest={data.busiest} />
+        <ProviderDistribution providers={providers} totalRequests={summary.total_requests} />
       </div>
 
-      {/* Main Layout Grid */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] items-stretch">
-        {/* Custom SVG Topology */}
-        <div className="flex flex-col rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm overflow-hidden h-full">
-          <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
-            <div className="flex items-center gap-2">
-              <Box className="h-4 w-4 text-[var(--text-muted)]" />
-              <h3 className="text-sm font-semibold tracking-tight">Routing Topology</h3>
-            </div>
-            <span className="text-[11px] font-medium text-[var(--text-muted)] uppercase tracking-wider">
-              {providers.filter((p: ProviderUsage) => p.share_pct > 0).length} providers · {chains.length} chains
-            </span>
+      <TokenSavingsBreakdown
+        savings={savings}
+        totalRequests={summary.total_requests}
+        insights={data}
+        period={period}
+      />
+
+      <ProviderHealthOverview
+        data={health}
+        loading={healthLoading}
+        error={healthError}
+      />
+
+      <ProviderBreakdown providers={providers} />
+      <ModelUsageTable models={models} loading={modelsLoading} error={modelsError} />
+      <RecentRequests records={recent} />
+    </div>
+  );
+}
+
+function PricingCoverageNotice({ summary }: { summary: UsageInsights["summary"] }) {
+  const notices = [
+    summary.unpriced_requests > 0 && {
+      label: "Missing pricing",
+      detail: `${fmtInteger(summary.unpriced_requests)} pricing-eligible requests and ${fmtInteger(summary.unpriced_tokens)} tokens have no deterministic rate. Tracked cost excludes them rather than treating them as free.`,
+    },
+    summary.estimated_requests > 0 && {
+      label: "Pricing estimate",
+      detail: `${fmtInteger(summary.estimated_requests)} requests use an alias, catalog fallback, or retail-equivalent rate. This estimates price, independently of whether usage was measured.`,
+    },
+    summary.estimated_usage_requests > 0 && {
+      label: "Usage estimate",
+      detail: `${fmtInteger(summary.estimated_usage_requests)} requests and ${fmtInteger(summary.estimated_usage_tokens)} tokens use estimated usage counters. Their cost can still use an exact or estimated rate.`,
+    },
+    summary.legacy_usage_requests > 0 && {
+      label: "Legacy usage",
+      detail: `${fmtInteger(summary.legacy_usage_requests)} requests and ${fmtInteger(summary.legacy_usage_tokens)} tokens predate complete provenance. Available totals are retained without inventing component breakdowns.`,
+    },
+    summary.backfilled_requests > 0 && {
+      label: "Historical backfill",
+      detail: `${fmtInteger(summary.backfilled_requests)} requests use current rates applied later as historical estimates, not original request-time pricing snapshots.`,
+    },
+  ].filter((notice): notice is { label: string; detail: string } => Boolean(notice));
+
+  if (notices.length === 0) return null;
+
+  const hasCaution = summary.unpriced_requests > 0 || summary.legacy_usage_requests > 0 || summary.backfilled_requests > 0;
+	return (
+		<details
+			className={`group overflow-hidden rounded-xl border ${
+				hasCaution
+					? "border-amber-300/60 bg-amber-50/40 dark:border-amber-500/30 dark:bg-amber-950/10"
+					: "border-[var(--border)] bg-[var(--bg-elevated)]"
+			}`}
+		>
+			<summary className="flex cursor-pointer list-none flex-wrap items-center gap-3 px-4 py-3 [&::-webkit-details-marker]:hidden">
+				{hasCaution ? (
+					<AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+				) : (
+					<Info className="h-4 w-4 shrink-0 text-[var(--text-muted)]" />
+				)}
+				<div className="min-w-[180px] flex-1">
+					<p className="text-sm font-semibold text-[var(--text)]">Accounting quality</p>
+					<p className="text-xs text-[var(--text-muted)]">
+						{notices.length} audit note{notices.length === 1 ? "" : "s"} · expand for provenance
+					</p>
+				</div>
+				<div className="ml-auto flex shrink-0 items-center gap-2">
+				<CoveragePill label="Requests" ratio={summary.pricing_request_coverage} />
+				<CoveragePill label="Tokens" ratio={summary.pricing_token_coverage} />
+					<ChevronDown className="ml-1 h-4 w-4 text-[var(--text-muted)] transition-transform group-open:rotate-180" />
+				</div>
+			</summary>
+			<div className="border-t border-[var(--border)] px-4 py-3">
+				<ul className="grid gap-3 text-xs leading-5 text-[var(--text-muted)] lg:grid-cols-2">
+					{notices.map((notice) => (
+						<li key={notice.label}>
+							<span className="font-semibold text-[var(--text)]">{notice.label}</span>
+							<p>{notice.detail}</p>
+						</li>
+					))}
+				</ul>
+				<p className="mt-3 border-t border-[var(--border)] pt-2 text-[10px] text-[var(--text-muted)]">
+					Coverage denominator: {fmtInteger(summary.pricing_eligible_requests)} token-bearing, pricing-eligible request{summary.pricing_eligible_requests === 1 ? "" : "s"}.
+				</p>
+			</div>
+		</details>
+	);
+}
+
+function CoveragePill({ label, ratio }: { label: string; ratio: number | null }) {
+	return (
+		<div className="min-w-16 rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2.5 py-1 text-right">
+			<div className="text-[9px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">{label}</div>
+			<div className="text-xs font-semibold tabular-nums">{fmtRatio(ratio)}</div>
+		</div>
+	);
+}
+
+type MetricTone = "accent" | "success" | "warning";
+
+function SummaryCard({
+	icon: Icon,
+	title,
+	primary,
+	primaryLabel,
+	items,
+	tone = "accent",
+}: {
+	icon: LucideIcon;
+	title: string;
+	primary: string;
+	primaryLabel: string;
+	items: Array<{ label: string; value: string; tone?: "good" }>;
+	tone?: MetricTone;
+}) {
+	const tones: Record<MetricTone, { icon: string; background: string }> = {
+		accent: {
+			icon: "text-secondary-600 dark:text-secondary-300",
+			background: "bg-secondary-50 ring-secondary-200/70 dark:bg-secondary-950/30 dark:ring-secondary-900/60",
+		},
+		success: {
+			icon: "text-emerald-600 dark:text-emerald-300",
+			background: "bg-emerald-50 ring-emerald-200/70 dark:bg-emerald-950/30 dark:ring-emerald-900/60",
+		},
+		warning: {
+			icon: "text-amber-700 dark:text-amber-300",
+			background: "bg-amber-50 ring-amber-200/70 dark:bg-amber-950/30 dark:ring-amber-900/60",
+		},
+	};
+	const colors = tones[tone];
+
+	return (
+		<Card className="p-5">
+			<div className="flex items-center gap-2">
+				<span className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ring-1 ${colors.background}`}>
+					<Icon className={`h-4 w-4 ${colors.icon}`} />
+				</span>
+				<span className="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">{title}</span>
+			</div>
+			<div className="mt-4 flex items-baseline gap-2">
+				<span className="text-3xl font-semibold tracking-tight tabular-nums text-[var(--text)]">{primary}</span>
+				<span className="text-xs text-[var(--text-muted)]">{primaryLabel}</span>
+			</div>
+			<div className="mt-4 grid grid-cols-3 gap-3 border-t border-[var(--border)] pt-3">
+				{items.map((item) => (
+					<div key={item.label} className="min-w-0">
+						<div className={`truncate text-xs font-semibold tabular-nums sm:text-sm ${item.tone === "good" ? "text-emerald-600 dark:text-emerald-300" : "text-[var(--text)]"}`}>{item.value}</div>
+						<div className="mt-0.5 text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">{item.label}</div>
+					</div>
+				))}
+			</div>
+		</Card>
+	);
+}
+
+type TrendMetric = "requests" | "tokens" | "cost" | "failures";
+
+type ChartPoint = SeriesPoint & { total_tokens: number };
+
+const TREND_OPTIONS: { value: TrendMetric; label: string }[] = [
+  { value: "requests", label: "Requests" },
+  { value: "tokens", label: "Tokens" },
+  { value: "cost", label: "Cost" },
+  { value: "failures", label: "Failures" },
+];
+
+const TREND_CONFIG: Record<TrendMetric, { key: keyof ChartPoint; label: string; color: string }> = {
+  requests: { key: "requests", label: "Requests", color: "var(--color-chart-1)" },
+  tokens: { key: "total_tokens", label: "Tokens", color: "var(--color-chart-2)" },
+  cost: { key: "cost_usd", label: "Cost", color: "var(--color-accent-500)" },
+  failures: { key: "failures", label: "Failures", color: "var(--color-danger)" },
+};
+
+function UsageTrendCard({ series, busiest }: { series: SeriesPoint[]; busiest: string }) {
+  const [metric, setMetric] = useState<TrendMetric>("requests");
+  const points = useMemo<ChartPoint[]>(
+    () => series.map((point) => ({ ...point, total_tokens: point.prompt_tokens + point.completion_tokens })),
+    [series],
+  );
+  const config = TREND_CONFIG[metric];
+
+  return (
+    <Card className="flex min-h-[390px] flex-col">
+      <div className="flex flex-col gap-3 border-b border-[var(--border)] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-[var(--text-muted)]" />
+            <h2 className="text-sm font-semibold">Usage trend</h2>
           </div>
-          <div className="flex-1 flex flex-col justify-center relative">
-            <RoutingTopology providers={providers} chains={chains} providerCatalog={providerCatalog} />
+          <p className="mt-1 text-xs text-[var(--text-muted)]">
+            {busiest ? `Busiest request bucket: ${busiest}` : "No active request bucket in this period"}
+          </p>
+        </div>
+        <SegmentedControl value={metric} onChange={setMetric} options={TREND_OPTIONS} />
+      </div>
+      <div className="min-h-0 flex-1 px-2 pb-4 pt-5">
+        {points.length === 0 ? (
+          <EmptyState title="No trend data for this period." />
+        ) : (
+          <ResponsiveContainer width="100%" height="100%" minHeight={280}>
+            <AreaChart data={points} margin={{ top: 8, right: 18, left: 2, bottom: 2 }}>
+              <defs>
+                <linearGradient id="usageTrendFill" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={config.color} stopOpacity={0.22} />
+                  <stop offset="95%" stopColor={config.color} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid vertical={false} stroke="var(--border)" opacity={0.45} />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 10, fill: "var(--text-muted)", fontWeight: 500 }}
+                tickLine={false}
+                axisLine={false}
+                dy={10}
+              />
+              <YAxis
+                tick={{ fontSize: 10, fill: "var(--text-muted)", fontWeight: 500 }}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(value: number) => formatTrendValue(metric, value, true)}
+                width={66}
+              />
+              <Tooltip
+                contentStyle={{
+                  fontSize: 12,
+                  background: "var(--bg-elevated)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 10,
+                  boxShadow: "var(--shadow-card)",
+                }}
+                formatter={(value: number) => [formatTrendValue(metric, Number(value)), config.label]}
+                labelStyle={{ color: "var(--text-muted)", marginBottom: 4 }}
+              />
+              <Area
+                type="monotone"
+                dataKey={config.key}
+                stroke={config.color}
+                strokeWidth={2}
+                fill="url(#usageTrendFill)"
+                activeDot={{ r: 4, strokeWidth: 0, fill: config.color }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function formatTrendValue(metric: TrendMetric, value: number, compact = false) {
+  if (metric === "cost") return compact ? fmtUSDCompact(value) : fmtUSD(value);
+  return compact ? fmtCompact(value) : fmtInteger(value);
+}
+
+function ProviderDistribution({ providers, totalRequests }: { providers: ProviderUsage[]; totalRequests: number }) {
+  const active = providers
+    .filter((provider) => provider.total_requests > 0)
+    .slice()
+    .sort((a, b) => b.total_requests - a.total_requests);
+
+  return (
+    <Card className="flex min-h-[390px] flex-col">
+      <div className="border-b border-[var(--border)] px-5 py-4">
+        <div className="flex items-center gap-2">
+          <Server className="h-4 w-4 text-[var(--text-muted)]" />
+          <h2 className="text-sm font-semibold">Provider distribution</h2>
+        </div>
+        <p className="mt-1 text-xs text-[var(--text-muted)]">Request and token shares from recorded terminal requests.</p>
+      </div>
+      {active.length === 0 ? (
+        <EmptyState title="No provider activity." hint="Provider shares appear after requests are recorded." />
+      ) : (
+        <div className="flex flex-1 flex-col p-5">
+          <div className="flex h-3 w-full overflow-hidden rounded-full bg-[var(--bg-subtle)]">
+            {active.map((provider) => (
+              <div
+                key={provider.provider}
+                style={{ width: `${provider.share_pct}%`, backgroundColor: provider.color || "var(--color-chart-1)" }}
+                title={`${provider.display_name}: ${provider.share_pct.toFixed(1)}% of requests`}
+              />
+            ))}
+          </div>
+          <div className="mt-5 space-y-3">
+            {active.slice(0, 6).map((provider) => (
+              <div key={provider.provider} className="flex items-center gap-3">
+                <ProviderIcon provider={provider.provider} src={provider.icon} color={provider.color} className="h-8 w-8" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="truncate text-xs font-semibold">{provider.display_name || provider.provider}</span>
+                    <span className="text-xs font-semibold tabular-nums">{provider.share_pct.toFixed(1)}%</span>
+                  </div>
+                  <div className="mt-0.5 flex items-center justify-between gap-3 text-[10px] text-[var(--text-muted)]">
+                    <span>{fmtInteger(provider.total_requests)} requests</span>
+                    <span>{provider.token_share_pct.toFixed(1)}% tokens</span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-auto border-t border-[var(--border)] pt-3 text-[11px] text-[var(--text-muted)]">
+            {fmtInteger(totalRequests)} terminal requests across {active.length} active provider{active.length === 1 ? "" : "s"}.
           </div>
         </div>
+      )}
+    </Card>
+  );
+}
 
-        {/* Insights */}
-        <UsageInsightsCard data={data} />
-        
-        {/* Activity chart */}
-        <div className="flex flex-col rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm overflow-hidden h-[380px]">
-          <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
-            <h3 className="text-sm font-semibold tracking-tight">Usage Trends</h3>
-            <span className="text-[11px] font-medium text-[var(--text-muted)] uppercase tracking-wider">Requests over time</span>
+function ProviderHealthOverview({
+  data,
+  loading,
+  error,
+}: {
+  data?: HealthOverview;
+  loading: boolean;
+  error: boolean;
+}) {
+  const rows = useMemo(
+    () => (data?.providers ?? []).slice().sort((a, b) => healthSeverity(a) - healthSeverity(b) || a.provider.localeCompare(b.provider)),
+    [data?.providers],
+  );
+  const collectorWindow = formatDurationSeconds(data?.window.duration_seconds);
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 border-b border-[var(--border)] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-[var(--text-muted)]" />
+            <h2 className="text-sm font-semibold">Provider health</h2>
           </div>
-          <div className="flex-1 px-2 pb-3 pt-4 min-h-0">
-            <ActivityChart series={series} />
-          </div>
+			<p className="mt-1 text-xs text-[var(--text-muted)]">
+				{collectorWindow
+					? `Rolling ${collectorWindow} attempt telemetry.`
+					: "Current rolling attempt telemetry."}
+          </p>
         </div>
-
-        {/* Recent Requests */}
-        <div className="flex flex-col rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm overflow-hidden h-[380px]">
-          <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3 bg-[var(--bg-subtle)] shrink-0">
-            <div className="flex items-center gap-2">
-              <TerminalSquare className="h-4 w-4 text-[var(--text-muted)]" />
-              <h3 className="text-sm font-semibold tracking-tight">Recent Requests</h3>
-            </div>
+        <Link to="/provider-health" className="text-xs font-semibold text-accent-600 hover:text-accent-700 dark:text-accent-300">
+          Open full health dashboard →
+        </Link>
+      </div>
+      {loading ? (
+        <Spinner />
+      ) : error ? (
+        <div className="p-4"><ErrorBanner message="Usage loaded, but provider-health telemetry is currently unavailable." /></div>
+      ) : !data ? null : (
+        <>
+			{(data.summary.telemetry_dropped ?? 0) > 0 && (
+				<div className="border-b border-amber-300/40 bg-amber-50/60 px-5 py-2.5 text-xs text-amber-800 dark:border-amber-500/20 dark:bg-amber-950/20 dark:text-amber-300">
+					<strong>{fmtInteger(data.summary.telemetry_dropped ?? 0)} health events dropped.</strong> Provider rates may be incomplete; usage accounting is unaffected.
+				</div>
+			)}
+			<div className="flex flex-wrap items-center divide-x divide-[var(--border)] border-b border-[var(--border)] px-2 py-3">
+            <HealthSummaryItem label="Healthy" value={data.summary.healthy} tone="good" />
+            <HealthSummaryItem label="Degraded" value={data.summary.degraded} tone="warn" />
+            <HealthSummaryItem label="Unhealthy" value={data.summary.unhealthy} tone="bad" />
+            <HealthSummaryItem label="Unknown" value={data.summary.unknown} />
+            <HealthSummaryItem label="Fallbacks" value={data.summary.fallbacks} tone={data.summary.fallbacks > 0 ? "warn" : "muted"} />
+            <HealthSummaryItem label="Avg p95" value={fmtMs(data.summary.avg_p95_latency_ms)} />
           </div>
-          {!recent.length ? (
-            <div className="flex flex-1 flex-col items-center justify-center gap-3 bg-[var(--bg)]">
-              <Activity className="h-6 w-6 text-[var(--text-muted)] opacity-30" />
-              <p className="text-xs font-medium text-[var(--text-muted)]">No active requests</p>
-            </div>
+          {rows.length === 0 ? (
+            <EmptyState title="No provider health data yet." hint="Send traffic or run a provider probe to populate telemetry." />
           ) : (
-            <div className="flex-1 overflow-y-auto">
-              <table className="w-full border-collapse text-xs">
-                <thead className="sticky top-0 z-10 bg-[var(--bg-elevated)] backdrop-blur-sm bg-opacity-90">
-                  <tr className="border-b border-[var(--border)]">
-                    <th className="w-6 px-3 py-2.5" />
-                    <th className="px-3 py-2.5 text-left font-medium text-[var(--text-muted)] uppercase tracking-wider text-[10px]">Model</th>
-                    <th className="px-3 py-2.5 text-right font-medium text-[var(--text-muted)] uppercase tracking-wider text-[10px]">Tokens</th>
-                    <th className="px-3 py-2.5 text-right font-medium text-[var(--text-muted)] uppercase tracking-wider text-[10px]">Time</th>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[860px] text-xs">
+                <thead>
+                  <tr className="border-b border-[var(--border)] text-left text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                    <th className="px-4 py-2.5">Provider</th>
+                    <th className="px-4 py-2.5">Status</th>
+                    <th className="px-4 py-2.5 text-right">Success</th>
+                    <th className="px-4 py-2.5 text-right">Errors</th>
+                    <th className="px-4 py-2.5 text-right">p95 / TTFT</th>
+                    <th className="px-4 py-2.5 text-right">Fallbacks</th>
+                    <th className="px-4 py-2.5">Main issue</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-[var(--border)]">
-                  {recent.map((r: RecentActivity) => <RecentRow key={r.id} row={r} />)}
+                  {rows.map((row) => (
+                    <tr key={row.provider} className="hover:bg-[var(--bg-subtle)]">
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2.5">
+                          <ProviderIcon provider={row.provider} className="h-7 w-7" />
+                          <span className="font-semibold">{row.provider}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3"><HealthStatusBadge status={row.status} issue={row.main_issue} /></td>
+                      <td className="px-4 py-3 text-right font-medium tabular-nums">{fmtHealthPercent(row.success_rate)}</td>
+                      <td className="px-4 py-3 text-right tabular-nums text-[var(--text-muted)]">{fmtHealthPercent(row.error_rate)}</td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        <div>{fmtMs(row.latency_p95_ms)}</div>
+                        <div className="text-[10px] text-[var(--text-muted)]">TTFT {fmtMs(row.ttft_p95_ms)}</div>
+                      </td>
+                      <td className="px-4 py-3 text-right font-medium tabular-nums">{fmtInteger(row.fallback_count)}</td>
+                      <td className="max-w-xs px-4 py-3 text-[var(--text-muted)]">{humanize(row.main_issue) || "—"}</td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             </div>
           )}
-        </div>
-      </div>
-
-      {/* Token Savings breakdown */}
-      {savings && (
-        <TokenSavingsBreakdown savings={savings} totalRequests={summary.total_requests} insights={data} period={period} />
-      )}
-
-      {/* Breakdowns container to keep grid alignment */}
-      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
-        <ModelUsageTable models={models} />
-        <ProviderBreakdown providers={providers} />
-      </div>
-    </div>
-  );
-}
-
-// ─── Routing Topology ────────────────────────────────────────────────────────
-// Radial hub-and-spoke topology: the Router sits at the center with live
-// providers and configured chains orbiting around it. Active sources (real
-// provider+model traffic) get animated flow links; dormant chains get a faint
-// static hint. Chains expand to reveal their steps in a detail strip below.
-
-interface TopoSource {
-  key: string;
-  kind: "provider" | "chain";
-  label: string;
-  sublabel: string;
-  color: string;
-  icon?: string;
-  share: number;
-  active: boolean;
-  chain?: Chain;
-}
-
-function RoutingTopology({ providers, chains, providerCatalog }: { providers: ProviderUsage[]; chains: Chain[]; providerCatalog: Provider[] }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [width, setWidth] = useState(0);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-
-  const providerColors = useMemo(() => {
-    const m = new Map<string, string>();
-    providerCatalog.forEach((p) => m.set(p.id, p.color));
-    return m;
-  }, [providerCatalog]);
-
-  // Set of provider ids that carried real traffic this period — used to mark a
-  // chain as "active" when one of its steps routed live requests.
-  const activeProviderIds = useMemo(() => {
-    const s = new Set<string>();
-    providers.forEach((p) => { if (p.share_pct > 0) s.add(p.provider); });
-    return s;
-  }, [providers]);
-
-  const sources = useMemo<TopoSource[]>(() => {
-    const provs = providers
-      .filter((p) => p.share_pct > 0)
-      .sort((a, b) => b.share_pct - a.share_pct)
-      .map<TopoSource>((p) => ({
-        key: `provider:${p.provider}`,
-        kind: "provider",
-        label: p.display_name || p.provider,
-        sublabel: `${p.share_pct.toFixed(1)}% traffic`,
-        color: p.color || "var(--color-ink-400)",
-        icon: `/providers/${p.provider}.png`,
-        share: p.share_pct,
-        active: true,
-      }));
-    const chs = chains.map<TopoSource>((c) => ({
-      key: `chain:${c.id}`,
-      kind: "chain",
-      label: c.name,
-      sublabel: `${c.steps.length} step${c.steps.length !== 1 ? "s" : ""} · ${displayStrategy(c.strategy)}`,
-      color: "var(--color-accent-500)",
-      share: 0,
-      // A chain only "connects" when one of its steps used a provider with live
-      // traffic, matching the rule that links appear for real provider+model use.
-      active: c.steps.some((s) => activeProviderIds.has(s.provider)),
-      chain: c,
-    }));
-    return [...provs, ...chs];
-  }, [providers, chains, activeProviderIds]);
-
-  useLayoutEffect(() => {
-    const c = containerRef.current;
-    if (c) setWidth(c.clientWidth);
-  }, []);
-
-  useEffect(() => {
-    const c = containerRef.current;
-    if (!c) return;
-    const ro = new ResizeObserver(() => setWidth(c.clientWidth));
-    ro.observe(c);
-    return () => ro.disconnect();
-  }, []);
-
-  const toggle = (key: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key); else next.add(key);
-      return next;
-    });
-  };
-
-  const n = sources.length;
-  // Height scales gently with node count so orbiting nodes have room to breathe.
-  const height = Math.max(280, Math.min(480, 200 + Math.max(0, n - 2) * 46));
-
-  // Radial hub-and-spoke placement: the Router sits dead center and sources
-  // orbit it on an ellipse. Starting the sweep at 180° puts the first node on
-  // the left, so 1–2 nodes read as a clean left/right split while larger counts
-  // wrap fully around the hub.
-  const placed = useMemo(() => {
-    const w = width || 600;
-    const cx = w / 2;
-    const cy = height / 2;
-    const rx = Math.max(130, Math.min(w * 0.34, cx - 108));
-    const ry = Math.max(84, cy - 62);
-    return sources.map((s, i) => {
-      const theta = Math.PI + (i * 2 * Math.PI) / Math.max(1, n);
-      return { ...s, x: cx + rx * Math.cos(theta), y: cy + ry * Math.sin(theta) };
-    });
-  }, [sources, width, height, n]);
-
-  const cx = (width || 600) / 2;
-  const cy = height / 2;
-
-  if (sources.length === 0) {
-    return (
-      <div className="m-4 flex h-[200px] flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-[var(--border)] bg-[var(--bg-subtle)]">
-        <TrendingUp className="h-6 w-6 text-[var(--text-muted)] opacity-30" />
-        <p className="text-xs font-medium uppercase tracking-wider text-[var(--text-muted)]">No routing activity</p>
-      </div>
-    );
-  }
-
-  const expandedChains = placed.filter((s) => s.kind === "chain" && expanded.has(s.key) && s.chain);
-
-  return (
-    <div className="relative p-4">
-      <style>{`
-        @keyframes topoFlow { to { stroke-dashoffset: -24; } }
-        .topo-flow { animation: topoFlow 1s linear infinite; }
-      `}</style>
-
-      <div ref={containerRef} className="relative w-full" style={{ height }}>
-        {/* Connector layer */}
-        {width > 0 && (
-          <svg className="pointer-events-none absolute inset-0" width={width} height={height} viewBox={`0 0 ${width} ${height}`} fill="none">
-            {/* Hub rings for a subtle radial anchor */}
-            <circle cx={cx} cy={cy} r={44} stroke="var(--border)" strokeWidth={1} strokeOpacity={0.5} />
-            <circle cx={cx} cy={cy} r={70} stroke="var(--border)" strokeWidth={1} strokeDasharray="2 6" strokeOpacity={0.35} />
-            {placed.map((s) => {
-              const d = `M ${s.x} ${s.y} L ${cx} ${cy}`;
-              const high = s.active && (s.kind === "chain" || s.share > 20);
-              return s.active ? (
-                <g key={s.key}>
-                  <path d={d} stroke={s.color} strokeWidth={high ? 2.5 : 1.5} strokeOpacity={high ? 0.25 : 0.15} strokeLinecap="round" />
-                  <path d={d} stroke={s.color} strokeWidth={high ? 2.5 : 1.5} strokeDasharray="4 8" strokeLinecap="round" strokeOpacity={high ? 0.9 : 0.55} className="topo-flow" />
-                </g>
-              ) : (
-                // Dormant chain / no live traffic — subtle static hint, no flow.
-                <path key={s.key} d={d} stroke="var(--text-muted)" strokeWidth={1} strokeDasharray="1 6" strokeLinecap="round" strokeOpacity={0.25} />
-              );
-            })}
-          </svg>
-        )}
-
-        {/* Router hub (center) */}
-        <div
-          className="absolute z-20 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1 rounded-2xl border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-3 shadow-lg"
-          style={{ left: cx, top: cy }}
-        >
-          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[var(--bg-subtle)] ring-1 ring-[var(--border)]">
-            <img src="/keirouter-favicon.png" alt="Router" className="h-5 w-5" />
-          </div>
-          <div className="text-center">
-            <div className="text-[13px] font-bold leading-tight tracking-tight text-[var(--text)]">Router</div>
-            <div className="text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">{n} route{n !== 1 ? "s" : ""}</div>
-          </div>
-        </div>
-
-        {/* Source nodes (orbit) */}
-        {width > 0 && placed.map((s) => (
-          <div key={s.key} className="absolute z-10 -translate-x-1/2 -translate-y-1/2" style={{ left: s.x, top: s.y }}>
-            <RadialNode source={s} expanded={expanded.has(s.key)} onToggle={() => toggle(s.key)} />
-          </div>
-        ))}
-      </div>
-
-      {/* Expanded chain details (below the orbit so the layout stays stable) */}
-      {expandedChains.length > 0 && (
-        <div className="mt-3 space-y-2 border-t border-[var(--border)] pt-3">
-          {expandedChains.map((s) => (
-            <ChainDetail key={s.key} chain={s.chain!} providerColors={providerColors} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function RadialNode({ source, expanded, onToggle }: { source: TopoSource; expanded: boolean; onToggle: () => void }) {
-  const isChain = source.kind === "chain";
-  const hasFallback = !!(source.chain?.fallback_provider && source.chain?.fallback_model);
-  return (
-    <div
-      role={isChain ? "button" : undefined}
-      onClick={isChain ? onToggle : undefined}
-      className={`flex w-[190px] items-center gap-2 rounded-xl border bg-[var(--bg-elevated)] px-2.5 py-2 shadow-sm transition-all hover:border-[var(--text-muted)] hover:shadow-md ${
-        source.active ? "border-[var(--border)]" : "border-dashed border-[var(--border)] opacity-80"
-      } ${isChain ? "cursor-pointer select-none" : ""} ${expanded ? "ring-2 ring-accent-500/40" : ""}`}
-    >
-      {isChain ? (
-        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-accent-500/15 text-accent-600 dark:text-accent-400">
-          <Layers className="h-3 w-3" />
-        </span>
-      ) : (
-        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[var(--bg-subtle)] ring-1 ring-[var(--border)]" style={{ boxShadow: `inset 3px 0 0 ${source.color}` }}>
-          {source.icon && <img src={source.icon} alt="" className="h-3.5 w-3.5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }} />}
-        </span>
-      )}
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1">
-          {isChain && <span className="font-mono text-[9px] text-[var(--text-muted)]">chain:</span>}
-          <span className="truncate text-xs font-semibold text-[var(--text)]">{source.label}</span>
-        </div>
-        <span className="block truncate text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">{source.sublabel}</span>
-      </div>
-      {isChain ? (
-        <>
-          {hasFallback && (
-            <span className="flex h-4 items-center rounded bg-amber-500/10 px-1 text-amber-600 dark:text-amber-400">
-              <Shield className="h-2.5 w-2.5" />
-            </span>
-          )}
-          <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-[var(--text-muted)] transition-transform ${expanded ? "rotate-90" : ""}`} />
         </>
+      )}
+    </Card>
+  );
+}
+
+function healthSeverity(row: HealthProviderRow) {
+  const rank = { unhealthy: 0, degraded: 1, unknown: 2, disabled: 3, healthy: 4 };
+  return rank[row.status] ?? 5;
+}
+
+function HealthSummaryItem({
+  label,
+  value,
+  tone = "muted",
+}: {
+  label: string;
+  value: string | number;
+  tone?: "muted" | "good" | "warn" | "bad";
+}) {
+  const color = tone === "good"
+    ? "text-emerald-600 dark:text-emerald-300"
+    : tone === "warn"
+      ? "text-amber-600 dark:text-amber-300"
+      : tone === "bad"
+        ? "text-red-600 dark:text-red-300"
+        : "text-[var(--text)]";
+	return (
+		<div className="min-w-24 px-3 py-1">
+			<div className="text-[9px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">{label}</div>
+			<div className={`mt-0.5 text-base font-semibold tabular-nums ${color}`}>{typeof value === "number" ? fmtInteger(value) : value}</div>
+    </div>
+  );
+}
+
+function ProviderBreakdown({ providers }: { providers: ProviderUsage[] }) {
+  const rows = providers.filter((provider) => provider.total_requests > 0).slice().sort((a, b) => b.total_requests - a.total_requests);
+
+  return (
+    <Card>
+      <div className="border-b border-[var(--border)] px-5 py-4">
+        <div className="flex items-center gap-2">
+          <Server className="h-4 w-4 text-[var(--text-muted)]" />
+          <h2 className="text-sm font-semibold">Provider accounting</h2>
+        </div>
+		<p className="mt-1 text-xs text-[var(--text-muted)]">Requests, tokens, cost, latency, and pricing by provider.</p>
+      </div>
+      {rows.length === 0 ? (
+        <EmptyState title="No provider usage for this period." />
       ) : (
-        <div className="h-1.5 w-10 shrink-0 overflow-hidden rounded-full bg-[var(--bg-subtle)]">
-          <div className="h-full rounded-full" style={{ width: `${Math.max(4, source.share)}%`, backgroundColor: source.color }} />
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[1080px] text-xs">
+            <thead>
+              <tr className="border-b border-[var(--border)] text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                <th className="px-4 py-3 text-left">Provider</th>
+                <th className="px-4 py-3 text-right">Requests</th>
+                <th className="px-4 py-3 text-right">Input classes</th>
+                <th className="px-4 py-3 text-right">Output classes</th>
+                <th className="px-4 py-3 text-right">Cost / savings</th>
+                <th className="px-4 py-3 text-right">Latency</th>
+                <th className="px-4 py-3 text-right">Pricing</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--border)]">
+              {rows.map((provider) => (
+                <tr key={provider.provider} className="hover:bg-[var(--bg-subtle)]">
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <ProviderIcon provider={provider.provider} src={provider.icon} color={provider.color} className="h-8 w-8" />
+                      <div className="min-w-0">
+                        <div className="truncate font-semibold">{provider.display_name || provider.provider}</div>
+                        <div className="truncate font-mono text-[9px] text-[var(--text-muted)]">{provider.provider}</div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    <div className="font-semibold">{fmtInteger(provider.total_requests)}</div>
+                    <div className="text-[10px] text-[var(--text-muted)]">{fmtInteger(provider.failed_requests)} failed · {fmtRatio(provider.success_rate)}</div>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    <div>{fmtCompact(provider.prompt_tokens)} input</div>
+                    <div className="text-[10px] text-[var(--text-muted)]">{fmtCompact(provider.cached_tokens)} cache read · {fmtCompact(provider.cache_write_tokens)} write</div>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    <div>{fmtCompact(provider.completion_tokens)} output</div>
+                    <div className="text-[10px] text-[var(--text-muted)]">{fmtCompact(provider.reasoning_tokens)} reasoning subset</div>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    <div className="font-semibold">{fmtUSD(provider.cost_usd)}</div>
+                    <div className="text-[10px] text-emerald-600 dark:text-emerald-300">{fmtUSD(provider.saved_cost_usd + provider.avoided_cost_usd)} saved</div>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    <div>{fmtMs(provider.avg_latency_ms)}</div>
+                    <div className="text-[10px] text-[var(--text-muted)]">TTFT {fmtMs(provider.avg_ttft_ms)}</div>
+                  </td>
+					<td className="px-4 py-3 text-right">
+						<div className="font-semibold tabular-nums">{fmtRatio(provider.pricing_request_coverage)}</div>
+						<div className="text-[10px] tabular-nums text-[var(--text-muted)]">
+							{provider.pricing_eligible_requests > 0
+								? `${fmtInteger(Math.max(0, provider.pricing_eligible_requests - provider.unpriced_requests))} / ${fmtInteger(provider.pricing_eligible_requests)} eligible covered`
+								: "No pricing-eligible usage"}
+                    </div>
+                    <div className="mt-0.5 text-[9px] tabular-nums text-[var(--text-muted)]">
+                      {fmtInteger(provider.estimated_requests)} pricing est. · {fmtInteger(provider.estimated_usage_requests)} usage est.
+                    </div>
+                    <div className="text-[9px] tabular-nums text-[var(--text-muted)]">
+                      {fmtInteger(provider.legacy_usage_requests)} legacy · {fmtInteger(provider.backfilled_requests)} backfilled
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
-    </div>
+    </Card>
   );
 }
 
-function ChainDetail({ chain, providerColors }: { chain: Chain; providerColors: Map<string, string> }) {
-  const hasFallback = !!(chain.fallback_provider && chain.fallback_model);
-  return (
-    <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-subtle)]/50 px-3 py-2.5">
-      <div className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-        <Layers className="h-3 w-3 text-accent-500" />
-        <span className="font-mono normal-case text-[var(--text)]">chain:{chain.name}</span>
-      </div>
-      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-2">
-        {chain.steps.map((step, i) => {
-          const color = providerColors.get(step.provider) || "var(--border)";
-          return (
-            <div key={i} className="flex items-center gap-1.5">
-              {i > 0 && <ArrowRight className="h-3 w-3 text-[var(--text-muted)] opacity-50" strokeWidth={2} />}
-              <div className="flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--bg)] py-1 pl-1 pr-2 shadow-sm">
-                <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded" style={{ backgroundColor: `${color}22` }}>
-                  <img src={`/providers/${step.provider}.png`} alt="" className="h-3 w-3 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }} />
-                </span>
-                <div className="flex min-w-0 flex-col">
-                  <span className="truncate font-mono text-[10px] font-medium leading-tight text-[var(--text)]">{step.model}</span>
-                  <span className="truncate text-[8px] uppercase tracking-wider text-[var(--text-muted)]">{step.provider}</span>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-        {hasFallback && (
-          <div className="flex items-center gap-1.5">
-            <ArrowRight className="h-3 w-3 text-amber-500/60" strokeWidth={2} />
-            <div className="flex items-center gap-1.5 rounded-md border border-amber-300/40 bg-amber-500/5 py-1 pl-1 pr-2 shadow-sm dark:border-amber-500/20 dark:bg-amber-500/10">
-              <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded bg-amber-500/10 text-amber-500">
-                <Shield className="h-2.5 w-2.5" />
-              </span>
-              <div className="flex min-w-0 flex-col">
-                <span className="truncate font-mono text-[10px] font-medium leading-tight text-amber-700 dark:text-amber-400">{chain.fallback_model}</span>
-                <span className="truncate text-[8px] uppercase tracking-wider text-amber-600/70 dark:text-amber-400/70">fallback</span>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
+type ModelSortKey = "model" | "requests" | "tokens" | "cost" | "latency" | "coverage";
 
-const isRoundRobinStrategy = (strategy: string) =>
-  strategy === "round_robin" || strategy === "round-robin";
-
-const displayStrategy = (strategy: string) =>
-  isRoundRobinStrategy(strategy) ? "round-robin" : strategy;
-
-// ─── Insights Component ───────────────────────────────────────────────────────
-
-function UsageInsightsCard({ data }: { data: any }) {
-  const { providers, summary } = data;
-  const activeProviders = providers.filter((p: any) => p.share_pct > 0);
-  
-  const tokenRatio = summary.prompt_tokens > 0 
-    ? summary.completion_tokens / summary.prompt_tokens
-    : 0;
-
-  return (
-    <div className="flex flex-col rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm overflow-hidden">
-      <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3 bg-[var(--bg-subtle)]">
-        <h3 className="text-sm font-semibold tracking-tight">Insights</h3>
-      </div>
-      <div className="p-5 flex flex-col gap-6">
-        
-        {/* Token Efficiency - Elevated design */}
-        <div className="flex flex-col">
-          <h4 className="text-[10px] font-semibold tracking-widest text-[var(--text-muted)] uppercase mb-3">Efficiency Multiplier</h4>
-          <div className="flex items-end gap-3">
-            <span className="text-4xl font-light tabular-nums leading-none text-[var(--text)] tracking-tighter">
-              {tokenRatio.toFixed(2)}<span className="text-2xl text-[var(--text-muted)]">x</span>
-            </span>
-            <div className="pb-1">
-              {summary.prompt_tokens > 0 && (
-                <p className="text-[11px] text-[var(--text-muted)] font-medium">
-                  {fmtNum(summary.completion_tokens)} out / {fmtNum(summary.prompt_tokens)} in
-                </p>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className="h-px w-full bg-[var(--border)]" />
-
-        {/* Provider Distribution - Sleek Stacked Bar */}
-        <div>
-          <h4 className="text-[10px] font-semibold tracking-widest text-[var(--text-muted)] uppercase mb-4">Traffic Distribution</h4>
-          
-          <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-[var(--bg-subtle)] mb-4">
-            {activeProviders.map((p: any) => (
-              <div 
-                key={p.provider} 
-                className="h-full transition-all"
-                style={{ width: `${p.share_pct}%`, backgroundColor: p.color || "var(--color-chart-1)" }} 
-                title={`${p.provider_name}: ${p.share_pct.toFixed(1)}%`}
-              />
-            ))}
-          </div>
-
-          <div className="grid grid-cols-2 gap-y-3 gap-x-2">
-            {activeProviders.slice(0, 4).map((p: any) => (
-              <div key={p.provider} className="flex items-center justify-between text-xs pr-2 border-r border-[var(--border)] last:border-r-0 even:border-r-0">
-                <div className="flex items-center gap-2 truncate">
-                  <span className="h-1.5 w-1.5 rounded-full shrink-0" style={{ backgroundColor: p.color || "var(--color-chart-1)" }} />
-                  <span className="text-[var(--text-muted)] truncate font-medium">{p.provider_name || p.provider}</span>
-                </div>
-                <span className="font-semibold tabular-nums ml-2">{p.share_pct.toFixed(0)}%</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Activity Chart ──────────────────────────────────────────────────────────
-
-function ActivityChart({ series }: { series: SeriesPoint[] }) {
-  if (!series.length) {
-    return <div className="flex h-full items-center justify-center text-xs font-medium uppercase tracking-wider text-[var(--text-muted)]">No data</div>;
-  }
-
-  return (
-    <ResponsiveContainer width="100%" height="100%">
-      <AreaChart data={series} margin={{ top: 10, right: 0, left: -20, bottom: 0 }}>
-        <defs>
-          <linearGradient id="usageFill" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor="var(--color-chart-1)" stopOpacity={0.15} />
-            <stop offset="95%" stopColor="var(--color-chart-1)" stopOpacity={0} />
-          </linearGradient>
-        </defs>
-        {/* Removed harsh grid, kept only subtle horizontal lines */}
-        <CartesianGrid vertical={false} stroke="var(--border)" opacity={0.3} />
-        <XAxis 
-          dataKey="label" 
-          tick={{ fontSize: 10, fill: "var(--text-muted)", fontWeight: 500 }} 
-          tickLine={false} 
-          axisLine={false} 
-          dy={10}
-        />
-        <YAxis 
-          tick={{ fontSize: 10, fill: "var(--text-muted)", fontWeight: 500 }} 
-          tickLine={false} 
-          axisLine={false} 
-          tickFormatter={(v: number) => fmtNum(v)} 
-          width={60} 
-        />
-        <Tooltip
-          contentStyle={{ fontSize: 12, background: "var(--bg-elevated)", border: "1px solid var(--border)", borderRadius: 6, boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1)" }}
-          itemStyle={{ color: "var(--text)", fontWeight: 600 }}
-          formatter={(value: number) => [fmtNum(value), "Requests"]}
-          labelStyle={{ color: "var(--text-muted)", marginBottom: 4 }}
-        />
-        <Area 
-          type="monotone" 
-          dataKey="count" 
-          stroke="var(--color-chart-1)" 
-          strokeWidth={2} 
-          fill="url(#usageFill)" 
-          activeDot={{ r: 4, strokeWidth: 0, fill: "var(--color-chart-1)" }}
-        />
-      </AreaChart>
-    </ResponsiveContainer>
-  );
-}
-
-// ─── Recent Row ──────────────────────────────────────────────────────────────
-
-function RecentRow({ row }: { row: RecentActivity }) {
-  const success = row.latency_ms > 0;
-  const hasSavings = (row.slim_bytes_saved ?? 0) > 0 || row.caveman_active || row.terse_active;
-  return (
-    <tr className="transition-colors hover:bg-[var(--bg-subtle)] group">
-      <td className="w-6 px-3 py-2.5">
-        <span className={`block h-1.5 w-1.5 rounded-full ${success ? "bg-emerald-500" : "bg-red-500"}`} />
-      </td>
-      <td className="px-3 py-2.5">
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-1.5">
-            <span className="font-mono text-[11px] font-semibold text-[var(--text)]">{row.model || "—"}</span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            {row.provider && (
-              <>
-                <ProviderIcon provider={row.provider} className="h-3 w-3" />
-                <span className="text-[9px] uppercase tracking-wider font-medium text-[var(--text-muted)]">{row.provider}</span>
-              </>
-            )}
-            {hasSavings && (
-              <span className="flex items-center gap-1">
-                {(row.slim_bytes_saved ?? 0) > 0 && (
-                  <span className="text-[9px] font-bold text-teal-600 dark:text-teal-400 uppercase tracking-widest" title={`RTK saved ${fmtBytes(row.slim_bytes_saved ?? 0)}`}>
-                    [RTK]
-                  </span>
-                )}
-                {row.caveman_active && (
-                  <span className="text-[9px] font-bold text-purple-600 dark:text-purple-400 uppercase tracking-widest" title="Caveman compression">
-                    [CVMN]
-                  </span>
-                )}
-                {row.terse_active && (
-                  <span className="text-[9px] font-bold text-indigo-600 dark:text-indigo-400 uppercase tracking-widest" title="Terse compression">
-                    [TRSE]
-                  </span>
-                )}
-              </span>
-            )}
-          </div>
-        </div>
-      </td>
-      <td className="px-3 py-2.5 text-right tabular-nums text-[11px] font-medium text-[var(--text-muted)]">
-        <span className="text-[var(--text)]">{fmtNum(Math.round(row.tokens * 0.6))}</span> <span className="opacity-40">in</span><br/>
-        <span className="text-[var(--text)]">{fmtNum(Math.round(row.tokens * 0.4))}</span> <span className="opacity-40">out</span>
-      </td>
-      <td className="px-3 py-2.5 text-right text-[10px] font-medium text-[var(--text-muted)] whitespace-nowrap">
-        {relTime(row.created_at)}
-      </td>
-    </tr>
-  );
-}
-
-function ProviderIcon({ provider, className = "h-5 w-5" }: { provider: string, className?: string }) {
-  const [errored, setErrored] = useState(false);
-  if (errored) {
-    return (
-      <div className={`flex shrink-0 items-center justify-center rounded bg-[var(--bg-subtle)] border border-[var(--border)] text-[8px] font-bold text-[var(--text-muted)] uppercase ${className}`}>
-        {provider.slice(0, 2)}
-      </div>
-    );
-  }
-  return <img src={`/providers/${provider}.png`} alt={provider} onError={() => setErrored(true)} className={`shrink-0 rounded object-contain grayscale opacity-80 mix-blend-multiply dark:mix-blend-screen ${className}`} />;
-}
-
-// ─── Token Savings Breakdown moved to ../components/SavingsBreakdown.tsx ──
-
-// ─── Model Usage Table ──────────────────────────────────────────────────────
-
-type SortKey = "provider" | "model" | "requests" | "prompt" | "completion" | "cost";
-
-function ModelUsageTable({ models }: { models: ModelUsage[] }) {
+function ModelUsageTable({ models, loading, error }: { models: ModelUsage[]; loading: boolean; error: boolean }) {
   const [search, setSearch] = useState("");
-  const [sortKey, setSortKey] = useState<SortKey>("requests");
-  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
-
-  const toggleSort = (key: SortKey) => {
-    if (sortKey === key) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-    } else {
-      setSortKey(key);
-      setSortDir("desc");
-    }
-  };
+  const [sortKey, setSortKey] = useState<ModelSortKey>("cost");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
 
   const filtered = useMemo(() => {
-    const q = search.toLowerCase();
-    let rows = models;
-    if (q) {
-      rows = rows.filter(
-        (m) => m.model.toLowerCase().includes(q) || m.provider_name.toLowerCase().includes(q) || m.provider.toLowerCase().includes(q),
-      );
-    }
-    return [...rows].sort((a, b) => {
-      const dir = sortDir === "asc" ? 1 : -1;
+    const query = search.trim().toLowerCase();
+    const rows = query
+      ? models.filter((model) => `${model.provider} ${model.provider_name} ${model.model}`.toLowerCase().includes(query))
+      : models;
+    return rows.slice().sort((a, b) => {
+      const direction = sortDirection === "asc" ? 1 : -1;
       switch (sortKey) {
-        case "provider": return dir * a.provider_name.localeCompare(b.provider_name);
-        case "model": return dir * a.model.localeCompare(b.model);
-        case "requests": return dir * (a.total_requests - b.total_requests);
-        case "prompt": return dir * (a.prompt_tokens - b.prompt_tokens);
-        case "completion": return dir * (a.completion_tokens - b.completion_tokens);
-        case "cost": return dir * (a.cost_usd - b.cost_usd);
-        default: return 0;
+        case "model": return direction * `${a.provider}/${a.model}`.localeCompare(`${b.provider}/${b.model}`);
+        case "requests": return direction * (a.total_requests - b.total_requests);
+        case "tokens": return direction * (a.total_tokens - b.total_tokens);
+        case "cost": return direction * (a.cost_usd - b.cost_usd);
+        case "latency": return direction * (a.avg_latency_ms - b.avg_latency_ms);
+			case "coverage":
+				if (a.pricing_request_coverage == null && b.pricing_request_coverage == null) return 0;
+				if (a.pricing_request_coverage == null) return 1;
+				if (b.pricing_request_coverage == null) return -1;
+				return direction * (a.pricing_request_coverage - b.pricing_request_coverage);
       }
     });
-  }, [models, search, sortKey, sortDir]);
+  }, [models, search, sortDirection, sortKey]);
 
-  const SortIcon = ({ col }: { col: SortKey }) => {
-    if (sortKey !== col) return <ArrowUpDown className="ml-1 inline h-3 w-3 opacity-30" />;
-    return sortDir === "asc" ? <ArrowUp className="ml-1 inline h-3 w-3" /> : <ArrowDown className="ml-1 inline h-3 w-3" />;
+  const { page, pages, paged, setPage, total } = useClientPagination(filtered, 10);
+
+  const toggleSort = (key: ModelSortKey) => {
+    if (sortKey === key) setSortDirection((current) => current === "asc" ? "desc" : "asc");
+    else {
+      setSortKey(key);
+      setSortDirection(key === "model" ? "asc" : "desc");
+    }
   };
 
-  const th = (col: SortKey, label: string, align: "left" | "right" = "left") => (
-    <th
-      className={`cursor-pointer select-none px-4 py-3 font-semibold uppercase tracking-wider text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--text)] ${align === "right" ? "text-right" : "text-left"}`}
-      onClick={() => toggleSort(col)}
-    >
-      {label}
-      <SortIcon col={col} />
-    </th>
-  );
-
   return (
-    <div className="flex flex-col rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm overflow-hidden">
-      <div className="flex flex-col gap-3 border-b border-[var(--border)] px-5 py-3 bg-[var(--bg-subtle)] sm:flex-row sm:items-center sm:justify-between">
-        <h3 className="text-sm font-semibold tracking-tight">Model Usage</h3>
-        <div className="relative">
-          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
+    <Card>
+      <div className="flex flex-col gap-3 border-b border-[var(--border)] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <Layers3 className="h-4 w-4 text-[var(--text-muted)]" />
+            <h2 className="text-sm font-semibold">Model accounting</h2>
+          </div>
+			<p className="mt-1 text-xs text-[var(--text-muted)]">Usage, cost, and immutable pricing snapshots by model.</p>
+        </div>
+        <div className="relative w-full sm:w-64">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
           <input
+            aria-label="Search model accounting by provider or model"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search models…"
-            className="rounded-lg border border-[var(--border)] bg-[var(--bg)] py-1.5 pl-8 pr-3 text-xs placeholder:text-[var(--text-muted)] focus:border-[var(--text)] focus:outline-none transition-colors w-48"
+            onChange={(event) => { setSearch(event.target.value); setPage(1); }}
+            placeholder="Search provider or model…"
+            className="h-9 w-full rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] pl-9 pr-3 text-xs outline-none transition-colors placeholder:text-[var(--text-muted)] hover:border-[var(--border-strong)] focus:border-accent-400"
           />
         </div>
       </div>
-      {filtered.length === 0 ? (
-        <div className="py-12 text-center text-xs font-medium text-[var(--text-muted)]">
-          {models.length === 0 ? "No model data for this period" : "No models match your search"}
-        </div>
+      {loading ? (
+        <Spinner />
+      ) : error ? (
+        <div className="p-4"><ErrorBanner message="Failed to load model-level usage." /></div>
+      ) : filtered.length === 0 ? (
+        <EmptyState title={models.length === 0 ? "No model usage for this period." : "No models match your search."} />
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs">
-            <thead className="bg-[var(--bg)]">
-              <tr className="border-b border-[var(--border)]">
-                {th("model", "Model")}
-                {th("requests", "Req", "right")}
-                {th("prompt", "In", "right")}
-                {th("completion", "Out", "right")}
-                {th("cost", "Cost", "right")}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-[var(--border)]">
-              {filtered.map((m) => (
-                <tr key={`${m.provider}/${m.model}`} className="transition-colors hover:bg-[var(--bg-subtle)]">
-                  <td className="px-4 py-3">
-                    <div className="flex flex-col gap-1">
-                      <span className="font-mono text-[11px] font-semibold">{m.model}</span>
-                      <div className="flex items-center gap-1.5">
-                        <ProviderIcon provider={m.provider} className="h-3 w-3" />
-                        <span className="text-[9px] uppercase tracking-wider text-[var(--text-muted)]">{m.provider_name}</span>
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-right tabular-nums font-medium">{m.total_requests.toLocaleString()}</td>
-                  <td className="px-4 py-3 text-right tabular-nums text-[var(--text-muted)]">{fmtNum(m.prompt_tokens)}</td>
-                  <td className="px-4 py-3 text-right tabular-nums text-[var(--text-muted)]">{fmtNum(m.completion_tokens)}</td>
-                  <td className="px-4 py-3 text-right tabular-nums font-medium text-[var(--text)]">${m.cost_usd.toFixed(4)}</td>
+        <>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[1120px] text-xs">
+              <thead>
+                <tr className="border-b border-[var(--border)] text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                  <SortableHeader label="Provider / model" sortKey="model" active={sortKey} direction={sortDirection} onSort={toggleSort} />
+                  <SortableHeader label="Requests" sortKey="requests" active={sortKey} direction={sortDirection} onSort={toggleSort} align="right" />
+                  <SortableHeader label="Tokens" sortKey="tokens" active={sortKey} direction={sortDirection} onSort={toggleSort} align="right" />
+                  <SortableHeader label="Cost" sortKey="cost" active={sortKey} direction={sortDirection} onSort={toggleSort} align="right" />
+                  <SortableHeader label="Latency" sortKey="latency" active={sortKey} direction={sortDirection} onSort={toggleSort} align="right" />
+                  <SortableHeader label="Pricing" sortKey="coverage" active={sortKey} direction={sortDirection} onSort={toggleSort} align="right" />
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className="divide-y divide-[var(--border)]">
+                {paged.map((model) => (
+                  <tr key={`${model.provider}/${model.model}`} className="hover:bg-[var(--bg-subtle)]">
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <ProviderIcon provider={model.provider} src={model.provider_icon} color={model.provider_color} className="h-8 w-8" />
+                        <div className="min-w-0">
+                          <div className="max-w-sm truncate font-mono text-[11px] font-semibold" title={model.model}>{model.model}</div>
+                          <div className="truncate text-[9px] uppercase tracking-wider text-[var(--text-muted)]">{model.provider_name || model.provider}</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums">
+                      <div className="font-semibold">{fmtInteger(model.total_requests)}</div>
+                      <div className="text-[10px] text-[var(--text-muted)]">{fmtRatio(model.success_rate)} success</div>
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums">
+                      <div className="font-semibold">{fmtCompact(model.total_tokens)}</div>
+                      <div className="text-[10px] text-[var(--text-muted)]">{fmtCompact(model.prompt_tokens)} in · {fmtCompact(model.completion_tokens)} out</div>
+                      <div className="text-[9px] text-[var(--text-muted)]">{fmtCompact(model.cached_tokens)} cached · {fmtCompact(model.reasoning_tokens)} reasoning</div>
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums">
+                      <div className="font-semibold">{model.pricing_status === "missing" ? "Unpriced" : fmtUSD(model.cost_usd)}</div>
+                      <div className="text-[10px] text-emerald-600 dark:text-emerald-300">{fmtUSD(model.saved_cost_usd + model.avoided_cost_usd)} saved</div>
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums">
+                      <div>{fmtMs(model.avg_latency_ms)}</div>
+                      <div className="text-[10px] text-[var(--text-muted)]">TTFT {fmtMs(model.avg_ttft_ms)}</div>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex justify-end"><PricingBadge status={model.pricing_status} /></div>
+						<div className="mt-1 text-[10px] font-medium tabular-nums text-[var(--text-muted)]">{fmtRatio(model.pricing_request_coverage)} covered</div>
+						<div className="text-[9px] tabular-nums text-[var(--text-muted)]">
+							{model.pricing_eligible_requests > 0
+								? `${fmtInteger(Math.max(0, model.pricing_eligible_requests - model.unpriced_requests))} / ${fmtInteger(model.pricing_eligible_requests)} pricing-eligible`
+								: "No pricing-eligible usage"}
+                      </div>
+                      <div className="mt-0.5 text-[9px] tabular-nums text-[var(--text-muted)]">
+                        {fmtInteger(model.estimated_requests)} pricing est. · {fmtInteger(model.estimated_usage_requests)} usage est.
+                      </div>
+                      <div className="text-[9px] tabular-nums text-[var(--text-muted)]">
+                        {fmtInteger(model.legacy_usage_requests)} legacy · {fmtInteger(model.backfilled_requests)} backfilled
+                      </div>
+                      {model.pricing_mixed ? (
+                        <div className="mt-1 text-[9px] font-semibold text-amber-700 dark:text-amber-300">Multiple immutable snapshots</div>
+                      ) : (
+                        <>
+                          <div className="mt-1 max-w-xs truncate font-mono text-[9px] text-[var(--text-muted)]" title={model.pricing_key || undefined}>{model.pricing_key || "No pricing key"}</div>
+                          <div className="mt-0.5 text-[9px] text-[var(--text-muted)]">{formatRates(model)}</div>
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <TablePagination page={page} pages={pages} total={total} onPage={setPage} />
+        </>
       )}
-    </div>
+    </Card>
   );
 }
 
-// ─── Provider Breakdown ─────────────────────────────────────────────────────
-
-function ProviderBreakdown({ providers }: { providers: ProviderUsage[] }) {
-  const active = providers.filter((p) => p.total_requests > 0).sort((a,b) => b.total_requests - a.total_requests);
-  
+function SortableHeader({
+  label,
+  sortKey,
+  active,
+  direction,
+  onSort,
+  align = "left",
+}: {
+  label: string;
+  sortKey: ModelSortKey;
+  active: ModelSortKey;
+  direction: "asc" | "desc";
+  onSort: (key: ModelSortKey) => void;
+  align?: "left" | "right";
+}) {
+  const Icon = active !== sortKey ? ArrowUpDown : direction === "asc" ? ArrowUp : ArrowDown;
+  const ariaSort = active === sortKey ? (direction === "asc" ? "ascending" : "descending") : "none";
   return (
-    <div className="flex flex-col rounded-xl border border-[var(--border)] bg-[var(--bg)] shadow-sm overflow-hidden">
-      <div className="border-b border-[var(--border)] px-5 py-4 bg-[var(--bg-subtle)]">
-        <h3 className="text-sm font-semibold tracking-tight">Provider Breakdown</h3>
+    <th
+      aria-sort={ariaSort}
+      className={`px-4 py-3 ${align === "right" ? "text-right" : "text-left"}`}
+    >
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className={`inline-flex items-center gap-1 transition-colors hover:text-[var(--text)] ${align === "right" ? "flex-row-reverse" : ""}`}
+      >
+        {label}<Icon className={`h-3 w-3 ${active === sortKey ? "opacity-100" : "opacity-30"}`} />
+      </button>
+    </th>
+  );
+}
+
+function formatRates(model: ModelUsage) {
+  if (model.pricing_mixed) return "Multiple immutable snapshots";
+  if (model.pricing_status === "legacy") return "Legacy rate breakdown unavailable";
+  if (model.pricing_status === "missing" || model.pricing_status === "none") return "Rates unavailable";
+  return `${fmtRate(model.input_per_m)} in · ${fmtRate(model.cached_input_per_m)} cache · ${fmtRate(model.output_per_m)} out`;
+}
+
+function RecentRequests({ records }: { records: RecentActivity[] }) {
+  const [selected, setSelected] = useState<RecentActivity | null>(null);
+  const { page, pages, paged, setPage, total } = useClientPagination(records, 12);
+
+  return (
+    <>
+      <Card>
+        <div className="border-b border-[var(--border)] px-5 py-4">
+          <div className="flex items-center gap-2">
+            <Activity className="h-4 w-4 text-[var(--text-muted)]" />
+            <h2 className="text-sm font-semibold">Recent terminal requests</h2>
+          </div>
+		<p className="mt-1 text-xs text-[var(--text-muted)]">Open a request to audit tokens, cost, pricing, and latency.</p>
+        </div>
+        {records.length === 0 ? (
+          <EmptyState title="No requests in this period." />
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[1060px] text-xs">
+                <thead>
+                  <tr className="border-b border-[var(--border)] text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                    <th className="px-4 py-3 text-left">Status</th>
+                    <th className="px-4 py-3 text-left">Provider / model</th>
+                    <th className="px-4 py-3 text-right">Input</th>
+                    <th className="px-4 py-3 text-right">Output</th>
+                    <th className="px-4 py-3 text-right">Cost</th>
+                    <th className="px-4 py-3 text-right">Latency</th>
+                    <th className="px-4 py-3 text-right">Time</th>
+                    <th className="px-4 py-3 text-right">Detail</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[var(--border)]">
+                  {paged.map((record) => (
+                    <tr
+                      key={record.id}
+                      className="transition-colors hover:bg-[var(--bg-subtle)]"
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex flex-col items-start gap-1.5">
+                          <StatusBadge status={record.status} />
+                          <UsageSourceBadge source={record.usage_source} />
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-3">
+                          <ProviderIcon provider={record.provider} src={record.provider_icon} color={record.provider_color} className="h-8 w-8" />
+                          <div className="min-w-0">
+                            <div className="max-w-sm truncate font-mono text-[11px] font-semibold" title={record.model}>{record.model || "—"}</div>
+                            <div className="truncate text-[9px] uppercase tracking-wider text-[var(--text-muted)]">{record.provider_name || record.provider}</div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        <div className="font-semibold">{fmtInteger(record.prompt_tokens)}</div>
+                        <div className="text-[10px] text-[var(--text-muted)]">{fmtInteger(record.cached_tokens)} read · {fmtInteger(record.cache_write_tokens)} write</div>
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        <div className="font-semibold">{fmtInteger(record.completion_tokens)}</div>
+                        <div className="text-[10px] text-[var(--text-muted)]">{fmtInteger(record.reasoning_tokens)} reasoning</div>
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        <div className="font-semibold">{record.pricing_status === "missing" ? "Unpriced" : fmtUSD(record.cost_usd)}</div>
+                        <div className="mt-1 flex justify-end"><PricingBadge status={record.pricing_status} /></div>
+                      </td>
+                      <td className="px-4 py-3 text-right tabular-nums">
+                        <div>{fmtMs(record.end_to_end_latency_ms)}</div>
+                        <div className="text-[10px] text-[var(--text-muted)]">upstream {fmtMs(record.upstream_latency_ms)}</div>
+                      </td>
+                      <td className="px-4 py-3 text-right whitespace-nowrap text-[var(--text-muted)]" title={formatDateTime(record.created_at)}>{relativeTime(record.created_at)}</td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          type="button"
+                          onClick={() => setSelected(record)}
+                          aria-label={`View accounting detail for request ${record.request_id || record.id}`}
+                          className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-2.5 py-1.5 text-[10px] font-semibold text-[var(--text-muted)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+                        >
+                          <Info className="h-3 w-3" aria-hidden="true" /> Details
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <TablePagination page={page} pages={pages} total={total} onPage={setPage} />
+          </>
+        )}
+      </Card>
+
+      <Modal
+        open={selected != null}
+        onClose={() => setSelected(null)}
+        title="Request details"
+        subtitle="Accounting, performance, and pricing audit"
+        maxWidth="max-w-4xl"
+      >
+        {selected && <RequestDetail record={selected} />}
+      </Modal>
+    </>
+  );
+}
+
+type RequestDetailTab = "overview" | "pricing";
+
+type RequestNotice = {
+  title: string;
+  message: string;
+  tone: "info" | "warning" | "danger";
+  pricing?: boolean;
+};
+
+const REQUEST_DETAIL_TABS: { value: RequestDetailTab; label: string; icon: LucideIcon }[] = [
+  { value: "overview", label: "Overview", icon: Activity },
+  { value: "pricing", label: "Pricing & audit", icon: Database },
+];
+
+function RequestDetail({ record }: { record: RecentActivity }) {
+  const [tab, setTab] = useState<RequestDetailTab>("overview");
+  const optimizationFlags = [
+    record.slim_active && "RTK",
+    record.caveman_active && "Caveman",
+    record.terse_active && "Terse",
+    record.headroom_active && "Headroom",
+    record.ponytail_active && "Ponytail",
+  ].filter((value): value is string => Boolean(value));
+  const legacyBreakdownUnavailable = record.pricing_status === "legacy" && !record.pricing_backfilled;
+  const cacheHit = record.cache_hit || record.status === "cache_hit" || record.usage_source === "cache";
+  const sourceURL = safeExternalURL(record.pricing_source_url);
+  const totalTokens = record.prompt_tokens + record.completion_tokens;
+  const regularInputTokens = Math.max(0, record.prompt_tokens - record.cached_tokens - record.cache_write_tokens);
+  const regularOutputTokens = Math.max(0, record.completion_tokens - record.reasoning_tokens);
+  const pricingUnavailable = record.pricing_status === "missing";
+  const hasOptimizationDetail = optimizationFlags.length > 0
+    || record.slim_tokens_saved > 0
+    || record.slim_bytes_saved > 0
+    || record.headroom_tokens_saved > 0
+    || record.headroom_bytes_saved > 0
+    || Boolean(record.slim_rules);
+  const chargedTotal = pricingUnavailable
+    ? "Unpriced"
+    : cacheHit
+      ? "$0.00"
+      : fmtUSD(record.cost_usd);
+  const notices: RequestNotice[] = [];
+
+  if (record.error_kind) {
+    notices.push({
+      title: "Terminal error",
+      message: humanize(record.error_kind),
+      tone: "danger",
+    });
+  }
+  if (pricingUnavailable) {
+    notices.push({
+      title: "Pricing unavailable",
+      message: "No catalog or custom rate matched. Tokens are retained and cost remains unpriced.",
+      tone: "warning",
+      pricing: true,
+    });
+  }
+  if (record.usage_source === "estimated") {
+    notices.push({
+      title: "Estimated usage",
+      message: "Token counts were estimated because authoritative provider usage was unavailable.",
+      tone: "info",
+    });
+  }
+  if (legacyBreakdownUnavailable) {
+    notices.push({
+      title: "Legacy accounting",
+      message: `The historical total ${fmtUSD(record.cost_usd)} was retained, but its component and rate split was not stored.`,
+      tone: "warning",
+      pricing: true,
+    });
+  }
+  if (record.pricing_backfilled) {
+    notices.push({
+      title: "Historical estimate",
+      message: "Current rates were applied later during backfill; this is not the original request-time snapshot.",
+      tone: "warning",
+      pricing: true,
+    });
+  }
+  if (record.pricing_status === "partial") {
+    notices.push({
+      title: "Partial pricing",
+      message: "Only matched components are included in the charged total.",
+      tone: "warning",
+      pricing: true,
+    });
+  }
+  if (cacheHit) {
+    notices.push({
+      title: "Served from cache",
+      message: "Component costs show avoided provider spend; the charged total is zero.",
+      tone: "info",
+      pricing: true,
+    });
+  }
+
+  const pricingNotices = notices.filter((notice) => notice.pricing);
+
+  return (
+    <div className="flex h-[76vh] max-h-[720px] min-h-0 flex-col overflow-hidden">
+      <div className="shrink-0 px-5 pt-4 sm:px-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
+            <ProviderIcon provider={record.provider} src={record.provider_icon} color={record.provider_color} className="h-10 w-10" />
+            <div className="min-w-0">
+              <div className="truncate font-mono text-sm font-semibold" title={record.model}>{record.model || "Unknown model"}</div>
+              <div className="mt-0.5 truncate text-xs text-[var(--text-muted)]">
+                {record.provider_name || record.provider} · {formatDateTime(record.created_at)}
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={record.status} />
+            <UsageSourceBadge source={record.usage_source} />
+            <PricingBadge status={record.pricing_status} />
+          </div>
+        </div>
+        <div className="mt-4">
+          <TabBar tabs={REQUEST_DETAIL_TABS} active={tab} onChange={setTab} />
+        </div>
       </div>
-      {active.length === 0 ? (
-        <div className="py-12 text-center text-xs font-medium text-[var(--text-muted)]">No provider data</div>
-      ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs">
-            <thead className="bg-[var(--bg)]">
-              <tr className="border-b border-[var(--border)]">
-                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wider text-[10px] text-[var(--text-muted)]">Provider</th>
-                <th className="px-4 py-3 text-right font-semibold uppercase tracking-wider text-[10px] text-[var(--text-muted)]">Req</th>
-                <th className="px-4 py-3 text-right font-semibold uppercase tracking-wider text-[10px] text-[var(--text-muted)]">Share</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-[var(--border)]">
-              {active.map((p) => (
-                <tr key={p.provider} className="transition-colors hover:bg-[var(--bg-subtle)]">
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-3">
-                      <ProviderIcon provider={p.provider} />
-                      <span className="font-medium text-[var(--text)]">{p.display_name}</span>
+
+      {tab === "overview" ? (
+        <div
+          role="tabpanel"
+          aria-label="Request overview"
+          className="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6"
+        >
+          <div className="space-y-4">
+            <DetailSummaryStrip
+              items={[
+                {
+                  label: "Total tokens",
+                  value: fmtInteger(totalTokens),
+                  hint: `${fmtInteger(record.prompt_tokens)} input · ${fmtInteger(record.completion_tokens)} output`,
+                },
+                {
+                  label: "Charged cost",
+                  value: chargedTotal,
+                  hint: cacheHit ? "Cache served" : humanize(record.pricing_status),
+                },
+                {
+                  label: "End-to-end latency",
+                  value: fmtMs(record.end_to_end_latency_ms),
+                  hint: `TTFT ${fmtMs(record.ttft_ms)}`,
+                },
+              ]}
+            />
+
+            <RequestNoticeList notices={notices} />
+
+            <div className="grid gap-4 lg:grid-cols-2">
+              <DetailPanel
+                icon={Layers3}
+                title="Token usage"
+                description="Cache and reasoning are included in their respective totals."
+              >
+                <div className="grid gap-5 sm:grid-cols-2 sm:gap-0 sm:divide-x sm:divide-[var(--border)]">
+                  <TokenBreakdown
+                    className="sm:pr-4"
+                    label="Input total"
+                    value={fmtInteger(record.prompt_tokens)}
+                    rows={[
+                      { label: "Regular", value: fmtInteger(regularInputTokens) },
+                      { label: "Cache read", value: fmtInteger(record.cached_tokens) },
+                      { label: "Cache write", value: fmtInteger(record.cache_write_tokens) },
+                    ]}
+                  />
+                  <TokenBreakdown
+                    className="sm:pl-4"
+                    label="Output total"
+                    value={fmtInteger(record.completion_tokens)}
+                    rows={[
+                      { label: "Regular", value: fmtInteger(regularOutputTokens) },
+                      { label: "Reasoning", value: fmtInteger(record.reasoning_tokens) },
+                    ]}
+                  />
+                </div>
+              </DetailPanel>
+
+              <DetailPanel
+                icon={DollarSign}
+                title={cacheHit ? "Avoided provider cost" : "Cost breakdown"}
+                description={
+                  legacyBreakdownUnavailable
+                    ? "Only the retained aggregate total is available."
+                    : pricingUnavailable
+                      ? "A rate is required before component cost can be calculated."
+                      : cacheHit
+                        ? "Counterfactual components, not customer charges."
+                        : record.pricing_backfilled
+                          ? "Calculated with the later backfill rate."
+                          : "Per-request USD snapshot."
+                }
+              >
+                {legacyBreakdownUnavailable ? (
+                  <BreakdownUnavailable
+                    label="Legacy total"
+                    value={fmtUSD(record.cost_usd)}
+                    message="A reconcilable component split was not retained for this row."
+                  />
+                ) : pricingUnavailable ? (
+                  <BreakdownUnavailable
+                    label="Charged total"
+                    value="Unpriced"
+                    message="Zero-valued components are hidden so missing pricing is not mistaken for free usage."
+                  />
+                ) : (
+                  <>
+                    <div className="divide-y divide-[var(--border)]">
+                      <DetailValueRow label="Regular input" value={fmtUSD(record.input_cost_usd)} />
+                      <DetailValueRow label="Cached input" value={fmtUSD(record.cached_cost_usd)} />
+                      <DetailValueRow label="Cache write" value={fmtUSD(record.cache_write_cost_usd)} />
+                      <DetailValueRow label="Regular output" value={fmtUSD(record.output_cost_usd)} />
+                      <DetailValueRow label="Reasoning" value={fmtUSD(record.reasoning_cost_usd)} />
                     </div>
-                  </td>
-                  <td className="px-4 py-3 text-right tabular-nums font-medium">{p.total_requests.toLocaleString()}</td>
-                  <td className="px-4 py-3 text-right">
-                    <div className="flex items-center justify-end gap-3">
-                      <span className="w-8 text-right tabular-nums font-medium text-[var(--text)]">{p.share_pct.toFixed(0)}%</span>
-                      <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--bg-subtle)]">
-                        <div className="h-full rounded-full transition-all" style={{ width: `${Math.max(2, p.share_pct)}%`, backgroundColor: p.color || "var(--text)" }} />
+                    {(record.saved_cost_usd > 0 || record.avoided_cost_usd > 0) && (
+                      <div className="mt-3 grid grid-cols-2 gap-px overflow-hidden rounded-lg bg-[var(--border)]">
+                        <DetailMiniMetric label="Saved" value={fmtUSD(record.saved_cost_usd)} tone="good" />
+                        <DetailMiniMetric label="Avoided" value={fmtUSD(record.avoided_cost_usd)} tone="good" />
                       </div>
+                    )}
+                  </>
+                )}
+              </DetailPanel>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
+              <DetailPanel
+                icon={Timer}
+                title="Latency"
+                description="Router completion includes upstream time."
+              >
+                <div className="grid grid-cols-3 gap-px overflow-hidden rounded-lg bg-[var(--border)]">
+                  <DetailMiniMetric label="Upstream" value={fmtMs(record.upstream_latency_ms)} />
+                  <DetailMiniMetric label="End to end" value={fmtMs(record.end_to_end_latency_ms)} />
+                  <DetailMiniMetric label="TTFT" value={fmtMs(record.ttft_ms)} />
+                </div>
+              </DetailPanel>
+
+              <DetailPanel icon={Zap} title="Optimizations">
+                {!hasOptimizationDetail ? (
+                  <p className="text-xs text-[var(--text-muted)]">No optimization was recorded for this request.</p>
+                ) : (
+                  <div className="space-y-3">
+                    {optimizationFlags.length > 0 && (
+                      <div className="flex flex-wrap gap-2">
+                        {optimizationFlags.map((flag) => <Badge key={flag} tone="accent">{flag}</Badge>)}
+                      </div>
+                    )}
+                    <div className="divide-y divide-[var(--border)]">
+                      {(record.slim_active || record.slim_tokens_saved > 0 || record.slim_bytes_saved > 0) && (
+                        <DetailValueRow
+                          label="Slim saved"
+                          value={`${fmtInteger(record.slim_tokens_saved)} tokens · ${fmtBytes(record.slim_bytes_saved)}`}
+                        />
+                      )}
+                      {(record.headroom_active || record.headroom_tokens_saved > 0 || record.headroom_bytes_saved > 0) && (
+                        <DetailValueRow
+                          label="Headroom saved"
+                          value={`${fmtInteger(record.headroom_tokens_saved)} tokens · ${fmtBytes(record.headroom_bytes_saved)}`}
+                        />
+                      )}
                     </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                    {record.slim_rules && (
+                      <div className="rounded-lg bg-[var(--bg-subtle)] px-3 py-2 text-[11px] leading-4">
+                        <span className="font-semibold text-[var(--text)]">Applied rules:</span>{" "}
+                        <span className="break-words font-mono text-[var(--text-muted)]">{record.slim_rules}</span>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </DetailPanel>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div
+          role="tabpanel"
+          aria-label="Pricing and audit details"
+          className="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6"
+        >
+          <div className="space-y-4">
+            <RequestNoticeList notices={pricingNotices} />
+
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+              <DetailPanel
+                icon={Database}
+                title="Pricing provenance"
+                description="The source and match retained with this request."
+              >
+                <div className="divide-y divide-[var(--border)]">
+                  <KeyValue label="Status" value={<PricingBadge status={record.pricing_status} />} />
+                  <KeyValue label="Source" value={record.pricing_source || "—"} />
+                  <KeyValue label="Match" value={humanize(record.pricing_match_kind) || "—"} />
+                  <KeyValue label="Resolved key" value={<span className="break-all font-mono text-[11px]">{record.pricing_key || "—"}</span>} />
+                  <KeyValue
+                    label="Source URL"
+                    value={record.pricing_source_url ? (
+                      sourceURL ? (
+                        <a
+                          href={sourceURL}
+                          target="_blank"
+                          rel="noreferrer"
+                          title={record.pricing_source_url}
+                          className="text-accent-600 underline decoration-accent-400/50 underline-offset-2 hover:text-accent-700 dark:text-accent-300"
+                        >
+                          Open pricing source
+                        </a>
+                      ) : (
+                        <span className="break-all">{record.pricing_source_url}</span>
+                      )
+                    ) : "—"}
+                  />
+                  <KeyValue label="Pricing as of" value={record.pricing_as_of ? formatDateTime(record.pricing_as_of) : "—"} />
+                  <KeyValue
+                    label="Backfilled"
+                    value={record.pricing_backfilled ? <Badge tone="warning">Historical estimate</Badge> : <Badge tone="neutral">No</Badge>}
+                  />
+                </div>
+              </DetailPanel>
+
+              <DetailPanel
+                icon={DollarSign}
+                title="Rates per 1M tokens"
+                description="USD rates used for each component."
+              >
+                {legacyBreakdownUnavailable || pricingUnavailable ? (
+                  <BreakdownUnavailable
+                    label="Rate snapshot"
+                    value="Unavailable"
+                    message={legacyBreakdownUnavailable
+                      ? "No immutable component-rate snapshot was stored for this legacy total."
+                      : "No matching price was found for this request."}
+                  />
+                ) : (
+                  <div className="divide-y divide-[var(--border)]">
+                    <DetailValueRow label="Regular input" value={fmtRate(record.input_rate_per_m)} />
+                    <DetailValueRow label="Cached input" value={fmtRate(record.cached_rate_per_m)} />
+                    <DetailValueRow label="Cache write" value={fmtRate(record.cache_write_rate_per_m)} />
+                    <DetailValueRow label="Regular output" value={fmtRate(record.output_rate_per_m)} />
+                    <DetailValueRow label="Reasoning output" value={fmtRate(record.reasoning_rate_per_m)} />
+                  </div>
+                )}
+              </DetailPanel>
+            </div>
+
+            <DetailPanel
+              icon={Info}
+              title="Audit identifiers"
+              description="Stable references for logs and reconciliation."
+            >
+              <div className="divide-y divide-[var(--border)]">
+                <KeyValue label="Request ID" value={<span className="break-all font-mono text-[11px]">{record.request_id || "—"}</span>} />
+                <KeyValue label="Usage row" value={<span className="break-all font-mono text-[11px]">{record.id}</span>} />
+                <KeyValue label="Recorded at" value={formatDateTime(record.created_at)} />
+                <KeyValue label="Provider key" value={<span className="font-mono text-[11px]">{record.provider || "—"}</span>} />
+              </div>
+            </DetailPanel>
+          </div>
         </div>
       )}
     </div>
   );
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function fmtNum(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toLocaleString();
+function DetailSummaryStrip({ items }: { items: { label: string; value: string; hint: string }[] }) {
+  return (
+    <div className="grid overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--border)] sm:grid-cols-3 sm:gap-px">
+      {items.map((item) => (
+        <div key={item.label} className="border-b border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-3 last:border-b-0 sm:border-b-0">
+          <div className="text-[9px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">{item.label}</div>
+          <div className="mt-1 text-lg font-semibold tabular-nums tracking-tight text-[var(--text)]">{item.value}</div>
+          <div className="mt-0.5 truncate text-[10px] text-[var(--text-muted)]" title={item.hint}>{item.hint}</div>
+        </div>
+      ))}
+    </div>
+  );
 }
 
-function fmtBytes(n: number): string {
-  if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(1)} MB`;
-  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
-  return `${n} B`;
+function RequestNoticeList({ notices }: { notices: RequestNotice[] }) {
+  if (notices.length === 0) return null;
+  const tone = notices.some((notice) => notice.tone === "danger")
+    ? "danger"
+    : notices.some((notice) => notice.tone === "warning")
+      ? "warning"
+      : "info";
+  const toneClasses = tone === "danger"
+    ? "border-red-300/50 bg-red-50/60 text-red-800 dark:border-red-500/30 dark:bg-red-950/20 dark:text-red-300"
+    : tone === "warning"
+      ? "border-amber-300/50 bg-amber-50/60 text-amber-800 dark:border-amber-500/30 dark:bg-amber-950/20 dark:text-amber-300"
+      : "border-blue-300/50 bg-blue-50/60 text-blue-800 dark:border-blue-500/30 dark:bg-blue-950/20 dark:text-blue-300";
+  const Icon = tone === "info" ? Info : AlertTriangle;
+
+  return (
+    <div className={`flex items-start gap-3 rounded-xl border px-4 py-3 ${toneClasses}`}>
+      <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+      <div className="min-w-0 space-y-1.5 text-[11px] leading-4">
+        {notices.map((notice) => (
+          <p key={`${notice.title}-${notice.message}`}>
+            <span className="font-semibold">{notice.title}:</span> {notice.message}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
 }
 
-function relTime(iso: string): string {
-  const t = new Date(iso).getTime();
-  if (Number.isNaN(t)) return "—";
-  const diff = Date.now() - t;
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h`;
-  return `${Math.floor(h / 24)}d`;
+function DetailPanel({
+  icon: Icon,
+  title,
+  description,
+  children,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)]">
+      <div className="flex items-start gap-2.5 border-b border-[var(--border)] px-4 py-3">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-subtle)] text-[var(--text-muted)]">
+          <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0">
+          <h3 className="text-xs font-semibold text-[var(--text)]">{title}</h3>
+          {description && <p className="mt-0.5 text-[10px] leading-4 text-[var(--text-muted)]">{description}</p>}
+        </div>
+      </div>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+function TokenBreakdown({
+  className = "",
+  label,
+  value,
+  rows,
+}: {
+  className?: string;
+  label: string;
+  value: string;
+  rows: { label: string; value: string }[];
+}) {
+  return (
+    <div className={className}>
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">{label}</span>
+        <span className="text-lg font-semibold tabular-nums text-[var(--text)]">{value}</span>
+      </div>
+      <div className="mt-2 divide-y divide-[var(--border)]">
+        {rows.map((row) => <DetailValueRow key={row.label} label={row.label} value={row.value} />)}
+      </div>
+    </div>
+  );
+}
+
+function DetailValueRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-2 text-xs first:pt-0 last:pb-0">
+      <span className="text-[var(--text-muted)]">{label}</span>
+      <span className="text-right font-semibold tabular-nums text-[var(--text)]">{value}</span>
+    </div>
+  );
+}
+
+function DetailMiniMetric({ label, value, tone = "normal" }: { label: string; value: string; tone?: "normal" | "good" }) {
+  return (
+    <div className="min-w-0 bg-[var(--bg-subtle)] px-3 py-2.5">
+      <div className="truncate text-[9px] font-semibold uppercase tracking-wider text-[var(--text-muted)]" title={label}>{label}</div>
+      <div className={`mt-1 truncate text-xs font-semibold tabular-nums ${tone === "good" ? "text-emerald-600 dark:text-emerald-300" : "text-[var(--text)]"}`} title={value}>{value}</div>
+    </div>
+  );
+}
+
+function BreakdownUnavailable({ label, value, message }: { label: string; value: string; message: string }) {
+  return (
+    <div className="rounded-lg bg-[var(--bg-subtle)] px-4 py-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">{label}</span>
+        <span className="text-sm font-semibold tabular-nums text-[var(--text)]">{value}</span>
+      </div>
+      <p className="mt-2 text-[10px] leading-4 text-[var(--text-muted)]">{message}</p>
+    </div>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-4 border-b border-[var(--border)] py-2 text-xs first:pt-0 last:border-0 last:pb-0">
+      <span className="shrink-0 text-[var(--text-muted)]">{label}</span>
+      <span className="min-w-0 text-right font-medium">{value}</span>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: UsageTerminalStatus }) {
+  const config: Record<UsageTerminalStatus, { label: string; tone: "success" | "accent" | "warning" | "danger" | "neutral" }> = {
+    success: { label: "Success", tone: "success" },
+    cache_hit: { label: "Cache hit", tone: "accent" },
+    blocked: { label: "Blocked", tone: "warning" },
+    failed: { label: "Failed", tone: "danger" },
+    cancelled: { label: "Cancelled", tone: "neutral" },
+  };
+  const item = config[status] ?? { label: humanize(String(status)) || "Unknown status", tone: "neutral" as const };
+  return <Badge tone={item.tone}>{item.label}</Badge>;
+}
+
+function PricingBadge({ status }: { status: PricingStatus }) {
+  const config: Record<PricingStatus, { label: string; tone: "success" | "accent" | "warning" | "danger" | "neutral" }> = {
+    priced: { label: "Priced", tone: "success" },
+    estimated: { label: "Pricing estimate", tone: "warning" },
+    free: { label: "Explicit free", tone: "accent" },
+    missing: { label: "Missing price", tone: "danger" },
+    partial: { label: "Partial", tone: "warning" },
+    legacy: { label: "Legacy total", tone: "neutral" },
+    none: { label: "No billable usage", tone: "neutral" },
+    mixed: { label: "Mixed snapshots", tone: "warning" },
+  };
+  const item = config[status] ?? { label: humanize(String(status)) || "Unknown pricing", tone: "neutral" as const };
+  return <Badge tone={item.tone}>{item.label}</Badge>;
+}
+
+function UsageSourceBadge({ source }: { source: UsageSource }) {
+  const config: Record<UsageSource, { label: string; tone: "success" | "warning" | "accent" | "neutral" }> = {
+    provider: { label: "Provider usage", tone: "success" },
+    estimated: { label: "Usage estimate", tone: "warning" },
+    cache: { label: "Cache replay", tone: "accent" },
+    legacy: { label: "Legacy usage", tone: "neutral" },
+    none: { label: "No usage reported", tone: "neutral" },
+  };
+  const item = config[source] ?? { label: humanize(String(source)) || "Unknown usage", tone: "neutral" as const };
+  return <Badge tone={item.tone}>{item.label}</Badge>;
+}
+
+function ProviderIcon({
+  provider,
+  src,
+  color,
+  className = "h-8 w-8",
+}: {
+  provider: string;
+  src?: string;
+  color?: string;
+  className?: string;
+}) {
+  const candidates = useMemo(() => providerIconCandidates(provider, src), [provider, src]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => setIndex(0), [provider, src]);
+
+  const current = candidates[index];
+  if (!current) {
+    const initials = provider.replace(/^custom-/, "").split(/[-_]/).filter(Boolean).slice(0, 2).map((part) => part[0]).join("").toUpperCase() || "AI";
+    return (
+      <span
+        className={`flex shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--bg-subtle)] text-[9px] font-bold text-[var(--text-muted)] ${className}`}
+        style={color ? { boxShadow: `inset 3px 0 0 ${color}` } : undefined}
+        aria-label={provider}
+      >
+        {initials}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`flex shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-white p-1 shadow-sm dark:bg-black/20 ${className}`}
+      style={color ? { boxShadow: `inset 3px 0 0 ${color}` } : undefined}
+    >
+      <img
+        src={current}
+        alt={provider}
+        className="h-full w-full object-contain"
+        onError={() => setIndex((currentIndex) => currentIndex + 1)}
+      />
+    </span>
+  );
+}
+
+function providerIconCandidates(provider: string, source?: string) {
+  const values: string[] = [];
+  const add = (value?: string) => {
+    if (value && !values.includes(value)) values.push(value);
+  };
+  add(source);
+  add(`/providers/${provider}.png`);
+  if (provider.startsWith("custom-openai")) add("/providers/custom-openai.png");
+  if (provider.startsWith("custom-anthropic")) add("/providers/custom-anthropic.png");
+  if (provider === "openai-codex") add("/providers/codex.png");
+  if (provider === "workers-ai") add("/providers/cloudflare-ai.png");
+  return values;
+}
+
+function safeExternalURL(value: string) {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatDurationSeconds(value?: number) {
+  if (value == null || !Number.isFinite(value) || value <= 0) return "";
+  const units = [
+    { seconds: 86_400, suffix: "d" },
+    { seconds: 3_600, suffix: "h" },
+    { seconds: 60, suffix: "m" },
+  ];
+  for (const unit of units) {
+    if (value >= unit.seconds) {
+      const amount = value / unit.seconds;
+      return `${Number.isInteger(amount) ? amount : Number(amount.toFixed(1))}${unit.suffix}`;
+    }
+  }
+  return `${Math.round(value)}s`;
+}
+
+function fmtInteger(value: number) {
+  if (!Number.isFinite(value)) return "—";
+  return Math.round(value).toLocaleString();
+}
+
+function fmtCompact(value: number) {
+  if (!Number.isFinite(value)) return "—";
+  const absolute = Math.abs(value);
+  if (absolute >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (absolute >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (absolute >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return Math.round(value).toLocaleString();
+}
+
+function fmtUSD(value: number) {
+  if (!Number.isFinite(value)) return "—";
+  if (value === 0) return "$0.00";
+  const absolute = Math.abs(value);
+  if (absolute < 0.0001) return value > 0 ? "<$0.0001" : ">-$0.0001";
+  if (absolute < 1) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+function fmtUSDCompact(value: number) {
+  if (!Number.isFinite(value)) return "—";
+  if (Math.abs(value) >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+  if (Math.abs(value) >= 1) return `$${value.toFixed(1)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+function fmtRate(value: number) {
+  if (!Number.isFinite(value)) return "—";
+  return `$${value.toLocaleString(undefined, { maximumFractionDigits: 6 })}`;
+}
+
+function fmtRatio(value?: number | null) {
+	if (value == null || !Number.isFinite(value)) return "—";
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function fmtHealthPercent(value?: number) {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return `${value.toFixed(1)}%`;
+}
+
+function fmtMs(value?: number) {
+  if (value == null || !Number.isFinite(value) || value <= 0) return "—";
+  if (value < 1) return "<1ms";
+  if (value < 1_000) return `${Math.round(value)}ms`;
+  return `${(value / 1_000).toFixed(2)}s`;
+}
+
+function fmtBytes(value: number) {
+  if (!Number.isFinite(value)) return "—";
+  if (value >= 1_048_576) return `${(value / 1_048_576).toFixed(1)} MB`;
+  if (value >= 1_024) return `${(value / 1_024).toFixed(1)} KB`;
+  return `${fmtInteger(value)} B`;
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString();
+}
+
+function relativeTime(value: string) {
+  const time = new Date(value).getTime();
+  if (Number.isNaN(time)) return "—";
+  const seconds = Math.max(0, Math.floor((Date.now() - time) / 1_000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function humanize(value?: string) {
+  if (!value) return "";
+  return value.replace(/[_-]+/g, " ").replace(/\b\w/g, (character) => character.toUpperCase());
 }


### PR DESCRIPTION
## Summary

- `buildModelPrices` now loads DB custom provider prices on top of the catalog and merges long-context + source metadata into `meter.Price`.
- Startup and pricing reload invoke `BackfillUnpriced` to reprice historical usage rows deterministically.
- Unknown/subscription-only models stay visibly unpriced instead of silently free.

## Changes

- **Pricing core**: new `meter/pricing.go`, extended `model_prices.go` + `model_prices_current.go`.
- **Usage accounting**: new `repo_usage_accuracy.go`, `repo_usage_details.go`, migrations `0027` + `0028` (SQLite + Postgres).
- **Gateway**: new `usage_v2.go` endpoint, updated `server.go`, `admin.go`, `insights.go`, `provider_health.go`.
- **Pipeline**: expanded `pipeline.go` with accurate metering + tests.
- **Telemetry**: enhanced `health/telemetry.go` + tests.
- **Transforms**: fixes across anthropic/gemini/openai/ollama/commandcode streaming paths.
- **Frontend**: reworked `Usage.tsx`, `Quota.tsx`, `Overview.tsx`, savings components, and `api.ts`.

## Test

- [x] `go test ./...` backend
- [x] Migrations apply on SQLite + Postgres
- [x] Manual smoke: usage dashboard shows correct pricing provenance