### PR TITLE
feat: add Cloudflare relay deployment and harden Kiro routing

### DIFF
--- a/backend/internal/connectors/connectors_test.go
+++ b/backend/internal/connectors/connectors_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 	"github.com/stretchr/testify/require"
@@ -94,6 +95,18 @@ func TestOpenAICompatible_MapsRateLimitError(t *testing.T) {
 	require.Equal(t, 429, pe.StatusCode)
 	require.Equal(t, "openai", pe.Provider)
 	require.True(t, pe.Fallbackable())
+}
+
+func TestHTTPStatusErrorParsesRetryAfterHTTPDate(t *testing.T) {
+	retryAt := time.Now().Add(90 * time.Second).UTC().Truncate(time.Second)
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{retryAt.Format(http.TimeFormat)}},
+	}
+
+	pe := core.AsProviderError(httpStatusError("kiro", "model", resp, []byte("limited")))
+	require.Greater(t, pe.RetryAfter, 85*time.Second)
+	require.LessOrEqual(t, pe.RetryAfter, 90*time.Second)
 }
 
 func TestOpenAICompatible_BadRequestNotFallbackable(t *testing.T) {

--- a/backend/internal/connectors/httpclient.go
+++ b/backend/internal/connectors/httpclient.go
@@ -566,6 +566,10 @@ func httpStatusError(provider, model string, resp *http.Response, body []byte) e
 	if ra := resp.Header.Get("Retry-After"); ra != "" {
 		if secs, err := strconv.Atoi(ra); err == nil {
 			pe.RetryAfter = time.Duration(secs) * time.Second
+		} else if retryAt, err := http.ParseTime(ra); err == nil {
+			if wait := time.Until(retryAt); wait > 0 {
+				pe.RetryAfter = wait
+			}
 		}
 	}
 	return pe

--- a/backend/internal/connectors/kiro.go
+++ b/backend/internal/connectors/kiro.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -27,6 +29,27 @@ type Kiro struct {
 	codec       transform.KiroCodec
 }
 
+const (
+	kiroModelCacheTTL = 5 * time.Minute
+	kiroQuotaCacheTTL = 30 * time.Second
+)
+
+type kiroModelCacheEntry struct {
+	expiresAt time.Time
+	models    []ModelSpec
+}
+
+type kiroQuotaCacheEntry struct {
+	expiresAt time.Time
+	quota     *QuotaResult
+}
+
+var (
+	kiroAccountSlots sync.Map
+	kiroModelCache   sync.Map
+	kiroQuotaCache   sync.Map
+)
+
 // NewKiro builds a Kiro connector.
 func NewKiro(id, defaultBaseURL string) *Kiro {
 	return &Kiro{id: id, defaultBase: defaultBaseURL}
@@ -36,11 +59,9 @@ func (c *Kiro) ID() string            { return c.id }
 func (c *Kiro) Dialect() core.Dialect { return core.DialectKiro }
 
 // kiroEndpoints are the interchangeable regional surfaces of the Kiro
-// generateAssistantResponse service. They are attempted in order so a transient
-// rate-limit or edge failure on one host can be retried on the next before the
-// account is taken out of rotation. The list is not extra quota: the hosts are
-// alternate front doors to one regional service, so rotating them is edge-level
-// failover only.
+// generateAssistantResponse service. They are attempted in order only for edge
+// and transport failures. The hosts share account-level limits, so a 429 must
+// never be retried against another host.
 var kiroEndpoints = []string{
 	"https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
 	"https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse",
@@ -192,16 +213,16 @@ func orderAmazonFirst(endpoints []string) []string {
 }
 
 // kiroEndpointRetryable reports whether an endpoint failure is worth retrying on
-// an alternate Kiro host. Only rate-limit, upstream 5xx, and transport/timeout
-// errors qualify; auth, bad-request, and quota errors are returned to the caller
-// immediately since another host would reject them the same way.
+// an alternate Kiro host. Only upstream 5xx and transport/timeout errors qualify;
+// account-level rate limits, auth, bad-request, and quota errors are returned to
+// the caller immediately since another host would reject them the same way.
 func kiroEndpointRetryable(err error) bool {
 	pe := core.AsProviderError(err)
 	if pe == nil {
 		return false
 	}
 	switch pe.Kind {
-	case core.ErrRateLimit, core.ErrUpstream, core.ErrTimeout:
+	case core.ErrUpstream, core.ErrTimeout:
 		return true
 	default:
 		return false
@@ -209,11 +230,9 @@ func kiroEndpointRetryable(err error) bool {
 }
 
 // openStreamWithFailover opens the binary eventstream POST against each
-// candidate endpoint in order. A retryable failure (rate-limit, 5xx, transport)
-// advances to the next host; non-retryable failures (auth, bad request, quota)
-// are returned at once. The last error is returned when every host is
-// exhausted, so the dispatcher only applies a cooldown after a genuine,
-// service-wide failure rather than a single edge hiccup.
+// candidate endpoint in order. A retryable edge failure (5xx or transport)
+// advances to the next host; account-level and request-level rejections are
+// returned at once. The last error is returned when every host is exhausted.
 func (c *Kiro) openStreamWithFailover(ctx context.Context, model string, body []byte, headers map[string]string, endpoints []string) (*http.Response, error) {
 	var lastErr error
 	for i, url := range endpoints {
@@ -228,6 +247,37 @@ func (c *Kiro) openStreamWithFailover(ctx context.Context, model string, body []
 		}
 	}
 	return nil, lastErr
+}
+
+// acquireAccountSlot limits an account to one in-flight upstream operation. This
+// closes the race where generations and metadata probes are dispatched before
+// the first 429 has had a chance to put the account into cooldown.
+func (c *Kiro) acquireAccountSlot(ctx context.Context, creds core.Credentials, model string) (func(), error) {
+	if creds.AccountID == "" {
+		return func() {}, nil
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	value, _ := kiroAccountSlots.LoadOrStore(creds.AccountID, make(chan struct{}, 1))
+	slot := value.(chan struct{})
+	select {
+	case slot <- struct{}{}:
+		var once sync.Once
+		return func() { once.Do(func() { <-slot }) }, nil
+	default:
+		return nil, &core.ProviderError{
+			Kind:       core.ErrRateLimit,
+			Provider:   c.id,
+			Model:      model,
+			StatusCode: http.StatusTooManyRequests,
+			RetryAfter: 2 * time.Second,
+			Message:    "another request is already in flight for this account",
+		}
+	}
 }
 
 // headers builds the AWS SDK + CodeWhisperer headers Kiro expects.
@@ -265,6 +315,11 @@ func (c *Kiro) Validate(ctx context.Context, creds core.Credentials) error {
 	if token == "" {
 		return fmt.Errorf("validation failed for %s: no access token", c.id)
 	}
+	releaseAccount, err := c.acquireAccountSlot(ctx, creds, "validate")
+	if err != nil {
+		return fmt.Errorf("validation failed for %s: %w", c.id, err)
+	}
+	defer releaseAccount()
 	// Use ListAvailableModels to verify the token. Region defaults to us-east-1.
 	region := creds.Extra["kiro_region"]
 	if region == "" {
@@ -281,7 +336,7 @@ func (c *Kiro) Validate(ctx context.Context, creds core.Credentials) error {
 	} else if isKiroExternalIDP(creds) {
 		h["TokenType"] = "EXTERNAL_IDP"
 	}
-	_, err := doJSONMethod(ctx, http.MethodGet, c.id, "validate", url, nil, h)
+	_, err = doJSONMethod(ctx, http.MethodGet, c.id, "validate", url, nil, h)
 	if err != nil {
 		return fmt.Errorf("validation failed for %s: %w", c.id, err)
 	}
@@ -308,6 +363,17 @@ func (c *Kiro) ListModels(ctx context.Context, creds core.Credentials) ([]ModelS
 	token := kiroAPIKey(creds)
 	if token == "" {
 		return nil, fmt.Errorf("kiro: ListModels: no access token")
+	}
+	if cached, ok := loadKiroModels(creds.AccountID); ok {
+		return cached, nil
+	}
+	releaseAccount, err := c.acquireAccountSlot(ctx, creds, "list-models")
+	if err != nil {
+		return nil, fmt.Errorf("kiro: ListModels: %w", err)
+	}
+	defer releaseAccount()
+	if cached, ok := loadKiroModels(creds.AccountID); ok {
+		return cached, nil
 	}
 	region := creds.Extra["kiro_region"]
 	if region == "" {
@@ -372,7 +438,34 @@ func (c *Kiro) ListModels(ctx context.Context, creds core.Credentials) ([]ModelS
 			out = append(out, ModelSpec{ID: upstream + "-thinking-agentic", Name: display + " (Thinking + Agentic)", Kind: core.ServiceLLM})
 		}
 	}
+	storeKiroModels(creds.AccountID, out)
 	return out, nil
+}
+
+func loadKiroModels(accountID string) ([]ModelSpec, bool) {
+	if accountID == "" {
+		return nil, false
+	}
+	value, ok := kiroModelCache.Load(accountID)
+	if !ok {
+		return nil, false
+	}
+	entry := value.(kiroModelCacheEntry)
+	if time.Now().After(entry.expiresAt) {
+		kiroModelCache.Delete(accountID)
+		return nil, false
+	}
+	return append([]ModelSpec(nil), entry.models...), true
+}
+
+func storeKiroModels(accountID string, models []ModelSpec) {
+	if accountID == "" {
+		return
+	}
+	kiroModelCache.Store(accountID, kiroModelCacheEntry{
+		expiresAt: time.Now().Add(kiroModelCacheTTL),
+		models:    append([]ModelSpec(nil), models...),
+	})
 }
 
 // ---- Quota fetching ---------------------------------------------------------
@@ -388,6 +481,17 @@ func (c *Kiro) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaRe
 	token := kiroAPIKey(creds)
 	if token == "" {
 		return &QuotaResult{Message: "No credential; cannot fetch quota."}, nil
+	}
+	if cached, ok := loadKiroQuota(creds.AccountID); ok {
+		return cached, nil
+	}
+	releaseAccount, err := c.acquireAccountSlot(ctx, creds, "quota")
+	if err != nil {
+		return nil, err
+	}
+	defer releaseAccount()
+	if cached, ok := loadKiroQuota(creds.AccountID); ok {
+		return cached, nil
 	}
 	region := creds.Extra["kiro_region"]
 	if region == "" {
@@ -422,10 +526,13 @@ func (c *Kiro) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaRe
 	url1 := fmt.Sprintf("https://codewhisperer.us-east-1.amazonaws.com/getUsageLimits?%s", params)
 	body, err := doJSONMethod(ctx, http.MethodGet, c.id, "quota", url1, nil, authHeaders)
 	if err == nil {
-		return parseKiroQuota(body)
+		return c.cacheKiroQuota(creds.AccountID, body)
 	}
 	if isAuthError(err) {
 		sawAuthError = true
+	}
+	if !kiroQuotaEndpointRetryable(err) {
+		return nil, err
 	}
 
 	// Attempt 2: POST on codewhisperer endpoint. Only include profileArn when
@@ -448,10 +555,13 @@ func (c *Kiro) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaRe
 	}
 	body, err = doJSON(ctx, c.id, "quota", "https://codewhisperer.us-east-1.amazonaws.com", postJSON, postHeaders)
 	if err == nil {
-		return parseKiroQuota(body)
+		return c.cacheKiroQuota(creds.AccountID, body)
 	}
 	if isAuthError(err) {
 		sawAuthError = true
+	}
+	if !kiroQuotaEndpointRetryable(err) {
+		return nil, err
 	}
 
 	// Attempt 3: GET on q endpoint, including profileArn only when set.
@@ -462,7 +572,7 @@ func (c *Kiro) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaRe
 	url3 := fmt.Sprintf("https://q.%s.amazonaws.com/getUsageLimits?%s", region, qParams)
 	body, err = doJSONMethod(ctx, http.MethodGet, c.id, "quota", url3, nil, authHeaders)
 	if err == nil {
-		return parseKiroQuota(body)
+		return c.cacheKiroQuota(creds.AccountID, body)
 	}
 	if isAuthError(err) {
 		sawAuthError = true
@@ -481,6 +591,53 @@ func (c *Kiro) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaRe
 		}
 	}
 	return &QuotaResult{Message: "Unable to fetch Kiro usage right now."}, nil
+}
+
+func kiroQuotaEndpointRetryable(err error) bool {
+	pe := core.AsProviderError(err)
+	switch pe.Kind {
+	case core.ErrAuth, core.ErrBadRequest, core.ErrUpstream, core.ErrTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func loadKiroQuota(accountID string) (*QuotaResult, bool) {
+	if accountID == "" {
+		return nil, false
+	}
+	value, ok := kiroQuotaCache.Load(accountID)
+	if !ok {
+		return nil, false
+	}
+	entry := value.(kiroQuotaCacheEntry)
+	if time.Now().After(entry.expiresAt) {
+		kiroQuotaCache.Delete(accountID)
+		return nil, false
+	}
+	return cloneKiroQuota(entry.quota), true
+}
+
+func (c *Kiro) cacheKiroQuota(accountID string, body []byte) (*QuotaResult, error) {
+	quota, err := parseKiroQuota(body)
+	if err != nil || accountID == "" {
+		return quota, err
+	}
+	kiroQuotaCache.Store(accountID, kiroQuotaCacheEntry{
+		expiresAt: time.Now().Add(kiroQuotaCacheTTL),
+		quota:     cloneKiroQuota(quota),
+	})
+	return quota, nil
+}
+
+func cloneKiroQuota(quota *QuotaResult) *QuotaResult {
+	if quota == nil {
+		return nil
+	}
+	copy := *quota
+	copy.Quotas = append([]QuotaEntry(nil), quota.Quotas...)
+	return &copy
 }
 
 // isAuthError checks if a provider error is an auth failure (401/403).
@@ -698,21 +855,27 @@ func (c *Kiro) Chat(ctx context.Context, req *core.ChatRequest, creds core.Crede
 // Stream performs a streaming call, parsing the AWS EventStream into canonical
 // chunks.
 func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Credentials, cfg core.StreamConfig) (<-chan core.StreamChunk, error) {
+	releaseAccount, err := c.acquireAccountSlot(ctx, creds, req.Model)
+	if err != nil {
+		return nil, err
+	}
+
 	// Account-bound auth uses only its resolved profile ARN; OAuth/social auth
 	// can fall back to the shared profile for its auth method.
 	profileArn := kiroResolveProfileArn(creds)
 	body, err := c.codec.RenderRequestWithProfile(req, profileArn)
 
 	if err != nil {
+		releaseAccount()
 		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}
 	}
 
 	// Kiro returns a binary eventstream, not SSE; use a plain streaming POST.
-	// Try each interchangeable endpoint in turn so a transient rate-limit or
-	// edge failure on one host is retried on the next before the error is
-	// surfaced to the dispatcher (which would otherwise cool the account down).
+	// Try an alternate endpoint only for transport or edge failures. Account-level
+	// rejections such as 429 are surfaced immediately so cooldown can take effect.
 	resp, err := c.openStreamWithFailover(ctx, req.Model, body, c.headers(creds), c.endpoints(creds))
 	if err != nil {
+		releaseAccount()
 		// On an upstream rejection (e.g. CodeWhisperer's 400 "Improperly formed
 		// request"), the offending field is opaque. When KIRO_DEBUG is set, dump
 		// the rendered request body so the exact payload can be inspected. The
@@ -724,6 +887,7 @@ func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cre
 	go func() {
 		defer close(out)
 		defer resp.Body.Close()
+		defer releaseAccount()
 
 		ttft := newTTFTTracker(cfg)
 

--- a/backend/internal/connectors/kiro.go
+++ b/backend/internal/connectors/kiro.go
@@ -53,10 +53,23 @@ func isKiroAPIKey(creds core.Credentials) bool {
 	return creds.Extra["kiro_auth_method"] == "api_key"
 }
 
+func isKiroExternalIDP(creds core.Credentials) bool {
+	return creds.Extra["kiro_auth_method"] == "external_idp"
+}
+
+func usesKiroCodeWhispererSurface(creds core.Credentials) bool {
+	switch creds.Extra["kiro_auth_method"] {
+	case "api_key", "external_idp", "idc":
+		return true
+	default:
+		return false
+	}
+}
+
 // Public default CodeWhisperer profile ARNs (us-east-1), keyed by auth method.
 // Used when an OAuth/social connection could not resolve its own profileArn.
-// Builder ID / IDC sign-ins and social (Google/GitHub/imported) sign-ins map to
-// different shared profiles. Kiro upstream now rejects a generateAssistantResponse
+// Builder ID and social (Google/GitHub/imported) sign-ins map to different
+// shared profiles. Kiro upstream now rejects a generateAssistantResponse
 // request without a profileArn (400 "profileArn is required for this request."),
 // so an OAuth/social connection must always carry one.
 const (
@@ -66,7 +79,7 @@ const (
 
 // kiroDefaultProfileArn resolves the shared default profileArn for a given OAuth
 // auth method. Social sign-ins (Google/GitHub/imported Kiro IDE tokens) map to
-// the social profile; Builder ID / IDC map to the builder-id profile.
+// the social profile; Builder ID maps to the builder-id profile.
 func kiroDefaultProfileArn(authMethod string) string {
 	switch authMethod {
 	case "google", "github", "imported", "social":
@@ -77,17 +90,15 @@ func kiroDefaultProfileArn(authMethod string) string {
 }
 
 // kiroResolveProfileArn returns the profileArn to attach to a chat request. For
-// API-key auth, only an ARN actually resolved for the key is used — never the
-// shared default, since an ARN not owned by the key's account is rejected with
-// 403. For OAuth/social auth the connection's resolved ARN is preferred, falling
-// back to the shared default keyed by auth method so the request always carries
-// a profileArn (the upstream 400s without one).
+// account-bound auth, only an ARN actually resolved for the credential is used.
+// For OAuth/social auth the connection's resolved ARN is preferred, falling
+// back to the shared default keyed by auth method.
 func kiroResolveProfileArn(creds core.Credentials) string {
 	resolved := creds.Extra["kiro_profile_arn"]
 	if resolved == "" {
 		resolved = creds.Extra["profile_arn"]
 	}
-	if isKiroAPIKey(creds) {
+	if usesKiroCodeWhispererSurface(creds) {
 		return resolved
 	}
 	if resolved != "" {
@@ -111,10 +122,8 @@ func kiroAPIKey(creds core.Credentials) string {
 // connector default) leads. The remaining known regional surfaces are appended
 // as failover hosts only when the primary is itself a known Kiro production
 // surface; a custom base URL (a relay, proxy, or test server) is used verbatim
-// so operator overrides are never bypassed. API-key credentials are validated
-// against the CodeWhisperer (amazonaws.com) surface and are rejected by the
-// kiro.dev gateway with 401/403, so for API-key auth the amazonaws hosts are
-// pulled to the front.
+// so operator overrides are never bypassed. Account-bound credentials use the
+// regional CodeWhisperer surface, so amazonaws.com hosts are pulled to the front.
 func (c *Kiro) endpoints(creds core.Credentials) []string {
 	primary := creds.BaseURL
 	if primary == "" {
@@ -133,10 +142,24 @@ func (c *Kiro) endpoints(creds core.Credentials) []string {
 			list = append(list, e)
 		}
 	}
-	if isKiroAPIKey(creds) {
+	if usesKiroCodeWhispererSurface(creds) {
+		region := strings.TrimSpace(creds.Extra["kiro_region"])
+		if region == "" {
+			region = "us-east-1"
+		}
+		for i, endpoint := range list {
+			list[i] = regionalizeKiroEndpoint(endpoint, region)
+		}
 		list = orderAmazonFirst(list)
 	}
 	return list
+}
+
+func regionalizeKiroEndpoint(endpoint, region string) string {
+	if region == "" || region == "us-east-1" || !strings.Contains(endpoint, "amazonaws.com") {
+		return endpoint
+	}
+	return strings.Replace(endpoint, ".us-east-1.amazonaws.com", "."+region+".amazonaws.com", 1)
 }
 
 // isKnownKiroEndpoint reports whether url is one of the built-in Kiro regional
@@ -228,6 +251,9 @@ func (c *Kiro) headers(creds core.Credentials) map[string]string {
 		}
 	} else if creds.AccessToken != "" {
 		h["Authorization"] = bearer(creds.AccessToken)
+		if isKiroExternalIDP(creds) {
+			h["TokenType"] = "EXTERNAL_IDP"
+		}
 	}
 	return mergeHeaders(h, creds.Headers)
 }
@@ -235,7 +261,8 @@ func (c *Kiro) headers(creds core.Credentials) map[string]string {
 // Validate probes the Kiro upstream by calling ListAvailableModels. If the
 // access token is missing or rejected, an error is returned.
 func (c *Kiro) Validate(ctx context.Context, creds core.Credentials) error {
-	if creds.AccessToken == "" {
+	token := kiroAPIKey(creds)
+	if token == "" {
 		return fmt.Errorf("validation failed for %s: no access token", c.id)
 	}
 	// Use ListAvailableModels to verify the token. Region defaults to us-east-1.
@@ -245,9 +272,14 @@ func (c *Kiro) Validate(ctx context.Context, creds core.Credentials) error {
 	}
 	url := fmt.Sprintf("https://q.%s.amazonaws.com/ListAvailableModels?origin=AI_EDITOR", region)
 	h := map[string]string{
-		"Authorization": bearer(creds.AccessToken),
+		"Authorization": bearer(token),
 		"Accept":        "application/json",
 		"User-Agent":    "AWS-SDK-JS/3.0.0 kiro-ide/1.0.0",
+	}
+	if isKiroAPIKey(creds) {
+		h["tokentype"] = "API_KEY"
+	} else if isKiroExternalIDP(creds) {
+		h["TokenType"] = "EXTERNAL_IDP"
 	}
 	_, err := doJSONMethod(ctx, http.MethodGet, c.id, "validate", url, nil, h)
 	if err != nil {
@@ -273,14 +305,15 @@ type kiroModelEntry struct {
 // model into synthetic variants (-thinking, -agentic, -thinking-agentic).
 // Implements LiveModelSource.
 func (c *Kiro) ListModels(ctx context.Context, creds core.Credentials) ([]ModelSpec, error) {
-	if creds.AccessToken == "" {
+	token := kiroAPIKey(creds)
+	if token == "" {
 		return nil, fmt.Errorf("kiro: ListModels: no access token")
 	}
 	region := creds.Extra["kiro_region"]
 	if region == "" {
 		region = "us-east-1"
 	}
-	profileArn := creds.Extra["kiro_profile_arn"]
+	profileArn := kiroResolveProfileArn(creds)
 
 	params := "origin=AI_EDITOR"
 	if profileArn != "" {
@@ -289,9 +322,14 @@ func (c *Kiro) ListModels(ctx context.Context, creds core.Credentials) ([]ModelS
 	url := fmt.Sprintf("https://q.%s.amazonaws.com/ListAvailableModels?%s", region, params)
 
 	h := map[string]string{
-		"Authorization": bearer(creds.AccessToken),
+		"Authorization": bearer(token),
 		"Accept":        "application/json",
 		"User-Agent":    "AWS-SDK-JS/3.0.0 kiro-ide/1.0.0",
+	}
+	if isKiroAPIKey(creds) {
+		h["tokentype"] = "API_KEY"
+	} else if isKiroExternalIDP(creds) {
+		h["TokenType"] = "EXTERNAL_IDP"
 	}
 	body, err := doJSONMethod(ctx, http.MethodGet, c.id, "list-models", url, nil, h)
 	if err != nil {
@@ -358,17 +396,9 @@ func (c *Kiro) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaRe
 	authMethod := creds.Extra["kiro_auth_method"]
 	isAPIKey := authMethod == "api_key"
 
-	profileArn := creds.Extra["profile_arn"]
-	if profileArn == "" {
-		profileArn = creds.Extra["kiro_profile_arn"]
-	}
-	// For API-key auth, only ever send a profileArn that was actually resolved
-	// for this connection — injecting the shared placeholder ARN makes
-	// CodeWhisperer 403 the request ("bearer token invalid"). OAuth/social may
-	// fall back to the default placeholder.
-	if profileArn == "" && !isAPIKey {
-		profileArn = kiroDefaultProfileArn(authMethod)
-	}
+	profileArn := kiroResolveProfileArn(creds)
+	// Account-bound auth only sends a profileArn resolved for the credential.
+	// OAuth/social connections may use their shared profile fallback.
 
 	authHeaders := map[string]string{
 		"Authorization":    bearer(token),
@@ -381,6 +411,8 @@ func (c *Kiro) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaRe
 	// is rejected (401/403).
 	if isAPIKey {
 		authHeaders["tokentype"] = "API_KEY"
+	} else if isKiroExternalIDP(creds) {
+		authHeaders["TokenType"] = "EXTERNAL_IDP"
 	}
 
 	sawAuthError := false
@@ -411,6 +443,8 @@ func (c *Kiro) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaRe
 	}
 	if isAPIKey {
 		postHeaders["tokentype"] = "API_KEY"
+	} else if isKiroExternalIDP(creds) {
+		postHeaders["TokenType"] = "EXTERNAL_IDP"
 	}
 	body, err = doJSON(ctx, c.id, "quota", "https://codewhisperer.us-east-1.amazonaws.com", postJSON, postHeaders)
 	if err == nil {
@@ -664,11 +698,8 @@ func (c *Kiro) Chat(ctx context.Context, req *core.ChatRequest, creds core.Crede
 // Stream performs a streaming call, parsing the AWS EventStream into canonical
 // chunks.
 func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Credentials, cfg core.StreamConfig) (<-chan core.StreamChunk, error) {
-	// Every Kiro chat request must carry a profileArn — the upstream rejects a
-	// request without one (400 "profileArn is required for this request."). For
-	// API-key auth only the ARN resolved for the key is sent (a foreign ARN
-	// 403s). For OAuth/social the connection's resolved ARN is used, falling
-	// back to the shared default profile for the auth method.
+	// Account-bound auth uses only its resolved profile ARN; OAuth/social auth
+	// can fall back to the shared profile for its auth method.
 	profileArn := kiroResolveProfileArn(creds)
 	body, err := c.codec.RenderRequestWithProfile(req, profileArn)
 

--- a/backend/internal/connectors/kiro_test.go
+++ b/backend/internal/connectors/kiro_test.go
@@ -2,9 +2,16 @@ package connectors
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
@@ -395,7 +402,7 @@ func TestKiroEndpointRetryable(t *testing.T) {
 		kind core.ErrorKind
 		want bool
 	}{
-		{core.ErrRateLimit, true},
+		{core.ErrRateLimit, false},
 		{core.ErrUpstream, true},
 		{core.ErrTimeout, true},
 		{core.ErrAuth, false},
@@ -408,4 +415,81 @@ func TestKiroEndpointRetryable(t *testing.T) {
 			t.Errorf("kiroEndpointRetryable(%s) = %v, want %v", tc.kind, got, tc.want)
 		}
 	}
+}
+
+func TestKiroRateLimitDoesNotFailOverToAnotherHost(t *testing.T) {
+	var secondCalls atomic.Int32
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer second.Close()
+
+	c := NewKiro("kiro", "")
+	_, err := c.openStreamWithFailover(context.Background(), "model", []byte("{}"), nil,
+		[]string{first.URL, second.URL})
+	require.Error(t, err)
+	require.Equal(t, core.ErrRateLimit, core.AsProviderError(err).Kind)
+	require.Equal(t, int32(0), secondCalls.Load())
+}
+
+func TestKiroAccountSlotRejectsConcurrentRequest(t *testing.T) {
+	c := NewKiro("kiro", "")
+	secondConnector := NewKiro("kiro", "")
+	creds := core.Credentials{AccountID: "account-1"}
+
+	release, err := c.acquireAccountSlot(context.Background(), creds, "model")
+	require.NoError(t, err)
+
+	_, err = secondConnector.acquireAccountSlot(context.Background(), creds, "model")
+	require.Error(t, err)
+	pe := core.AsProviderError(err)
+	require.Equal(t, core.ErrRateLimit, pe.Kind)
+	require.Equal(t, 2*time.Second, pe.RetryAfter)
+
+	release()
+	releaseAgain, err := c.acquireAccountSlot(context.Background(), creds, "model")
+	require.NoError(t, err)
+	releaseAgain()
+}
+
+func TestKiroQuotaEndpointRetryableStopsOnRateLimit(t *testing.T) {
+	require.False(t, kiroQuotaEndpointRetryable(&core.ProviderError{Kind: core.ErrRateLimit}))
+	require.False(t, kiroQuotaEndpointRetryable(&core.ProviderError{Kind: core.ErrQuotaExhausted}))
+	require.True(t, kiroQuotaEndpointRetryable(&core.ProviderError{Kind: core.ErrAuth}))
+	require.True(t, kiroQuotaEndpointRetryable(&core.ProviderError{Kind: core.ErrUpstream}))
+}
+
+func TestKiroMetadataCachesReturnCopies(t *testing.T) {
+	accountID := "cache-account"
+	kiroModelCache.Delete(accountID)
+	kiroQuotaCache.Delete(accountID)
+	t.Cleanup(func() {
+		kiroModelCache.Delete(accountID)
+		kiroQuotaCache.Delete(accountID)
+	})
+
+	storeKiroModels(accountID, []ModelSpec{{ID: "model-1"}})
+	models, ok := loadKiroModels(accountID)
+	require.True(t, ok)
+	models[0].ID = "mutated"
+	modelsAgain, ok := loadKiroModels(accountID)
+	require.True(t, ok)
+	require.Equal(t, "model-1", modelsAgain[0].ID)
+
+	kiroQuotaCache.Store(accountID, kiroQuotaCacheEntry{
+		expiresAt: time.Now().Add(time.Minute),
+		quota:     &QuotaResult{PlanName: "plan", Quotas: []QuotaEntry{{ResourceType: "credit", Limit: 100}}},
+	})
+	quota, ok := loadKiroQuota(accountID)
+	require.True(t, ok)
+	quota.Quotas[0].Limit = 0
+	quotaAgain, ok := loadKiroQuota(accountID)
+	require.True(t, ok)
+	require.Equal(t, 100, quotaAgain.Quotas[0].Limit)
 }

--- a/backend/internal/connectors/kiro_test.go
+++ b/backend/internal/connectors/kiro_test.go
@@ -229,6 +229,17 @@ func TestKiroEndpoints_APIKeyPrefersAmazon(t *testing.T) {
 	}
 }
 
+func TestKiroEndpoints_ExternalIDPUsesRegionalAmazonSurface(t *testing.T) {
+	c := NewKiro("kiro", kiroEndpoints[0])
+	got := c.endpoints(core.Credentials{Extra: map[string]string{
+		"kiro_auth_method": "external_idp",
+		"kiro_region":      "eu-west-1",
+	}})
+	if !strings.Contains(got[0], "amazonaws.com") || !strings.Contains(got[0], ".eu-west-1.") {
+		t.Fatalf("external_idp should lead with the regional amazon endpoint, got %v", got)
+	}
+}
+
 func TestKiroEndpoints_CredentialBaseURLLeads(t *testing.T) {
 	c := NewKiro("kiro", kiroEndpoints[0])
 	custom := "https://relay.example.com/generateAssistantResponse"
@@ -289,6 +300,20 @@ func TestKiroHeaders_OAuthHasNoTokenType(t *testing.T) {
 	}
 }
 
+func TestKiroHeaders_ExternalIDPMarker(t *testing.T) {
+	c := NewKiro("kiro", kiroEndpoints[0])
+	h := c.headers(core.Credentials{
+		AccessToken: "microsoft-token",
+		Extra:       map[string]string{"kiro_auth_method": "external_idp"},
+	})
+	if h["Authorization"] != "Bearer microsoft-token" {
+		t.Errorf("external identity token should be sent as bearer, got %q", h["Authorization"])
+	}
+	if h["TokenType"] != "EXTERNAL_IDP" {
+		t.Errorf("external identity requests must carry TokenType=EXTERNAL_IDP, got %q", h["TokenType"])
+	}
+}
+
 func TestKiroResolveProfileArn(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -301,9 +326,9 @@ func TestKiroResolveProfileArn(t *testing.T) {
 			want:  kiroDefaultProfileArnBuilderID,
 		},
 		{
-			name:  "oauth idc falls back to builder-id default",
+			name:  "idc without resolved arn injects no default",
 			creds: core.Credentials{Extra: map[string]string{"kiro_auth_method": "idc"}},
-			want:  kiroDefaultProfileArnBuilderID,
+			want:  "",
 		},
 		{
 			name:  "imported social falls back to social default",
@@ -347,6 +372,11 @@ func TestKiroResolveProfileArn(t *testing.T) {
 		{
 			name:  "api_key without resolved arn injects no default",
 			creds: core.Credentials{Extra: map[string]string{"kiro_auth_method": "api_key"}},
+			want:  "",
+		},
+		{
+			name:  "external_idp without resolved arn injects no default",
+			creds: core.Credentials{Extra: map[string]string{"kiro_auth_method": "external_idp"}},
 			want:  "",
 		},
 	}

--- a/backend/internal/dispatch/dispatch.go
+++ b/backend/internal/dispatch/dispatch.go
@@ -402,9 +402,6 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 		cooldown = d.exponentialCooldown(ctx, accountID)
 	case core.ErrQuotaExhausted:
 		cooldown = 30 * time.Minute
-		if err.RetryAfter > 0 {
-			cooldown = err.RetryAfter
-		}
 	case core.ErrAuth:
 		cooldown = 5 * time.Minute
 	case core.ErrUpstream, core.ErrTimeout:
@@ -415,7 +412,10 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 		return
 	}
 
-	if err.RetryAfter > 0 && err.Kind != core.ErrRateLimit {
+	// An upstream reset time is a lower bound. Never replace it with the much
+	// shorter local exponential delay, and never shorten a stricter local
+	// cooldown when an upstream sends a small Retry-After value.
+	if err.RetryAfter > cooldown {
 		cooldown = err.RetryAfter
 	}
 

--- a/backend/internal/dispatch/dispatch_test.go
+++ b/backend/internal/dispatch/dispatch_test.go
@@ -265,6 +265,22 @@ func TestPlanWith_BuiltInProviderVisionStrippableSkipsGuard(t *testing.T) {
 	require.NotEmpty(t, attempts)
 }
 
+func TestNoteFailureHonorsRateLimitRetryAfter(t *testing.T) {
+	ctx := context.Background()
+	d, db := newDispatchTest(t, testAccount("acc-rate-limited", 10))
+	started := time.Now()
+
+	d.NoteFailure(ctx, "acc-rate-limited", &core.ProviderError{
+		Kind:       core.ErrRateLimit,
+		RetryAfter: 4 * time.Minute,
+	})
+
+	account, err := db.Accounts().Get(ctx, "acc-rate-limited")
+	require.NoError(t, err)
+	require.NotNil(t, account.CooldownUntil)
+	require.WithinDuration(t, started.Add(4*time.Minute), *account.CooldownUntil, 2*time.Second)
+}
+
 func testAccountWithProvider(id, provider string, priority int) store.Account {
 	now := time.Now()
 	return store.Account{

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -83,6 +83,7 @@ func (s *Server) mountAdmin(r chi.Router) {
 
 	r.Get("/proxy-pools", s.adminListProxyPools)
 	r.Post("/proxy-pools", s.adminCreateProxyPool)
+	r.Post("/proxy-pools/cloudflare-deploy", s.adminDeployCloudflareRelay)
 	r.Patch("/proxy-pools/{id}", s.adminUpdateProxyPool)
 	r.Delete("/proxy-pools/{id}", s.adminDeleteProxyPool)
 	r.Post("/proxy-pools/{id}/test", s.adminTestProxyPool)
@@ -677,6 +678,10 @@ func (s *Server) adminCreateAccount(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "vault not configured")
 		return
 	}
+	if err := s.validateProxyPoolID(r.Context(), body.ProxyPoolID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	authKind := accountAuthKind(spec, body.APIKey)
 	if authKind != store.AuthNone && strings.TrimSpace(body.APIKey) == "" {
 		writeError(w, http.StatusBadRequest, "api_key is required")
@@ -728,7 +733,7 @@ func (s *Server) adminCreateAccount(w http.ResponseWriter, r *http.Request) {
 		UpdatedAt: now,
 	}
 	if body.ProxyPoolID != "" {
-		acc.ProxyPoolID = body.ProxyPoolID
+		acc.ProxyPoolID = strings.TrimSpace(body.ProxyPoolID)
 	}
 	if err := s.vault.Seal(&acc, vault.NewSecret{APIKey: body.APIKey, Metadata: meta}); err != nil {
 		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "vault seal failed"))
@@ -817,6 +822,10 @@ func (s *Server) adminBulkCreateAccounts(w http.ResponseWriter, r *http.Request)
 	}
 	if len(body.Items) > bulkMaxItems {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("too many items: %d (max %d)", len(body.Items), bulkMaxItems))
+		return
+	}
+	if err := s.validateProxyPoolID(r.Context(), body.ProxyPoolID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -920,7 +929,7 @@ func (s *Server) adminBulkCreateAccounts(w http.ResponseWriter, r *http.Request)
 				UpdatedAt: now,
 			}
 			if body.ProxyPoolID != "" {
-				acc.ProxyPoolID = body.ProxyPoolID
+				acc.ProxyPoolID = strings.TrimSpace(body.ProxyPoolID)
 			}
 			if err := s.vault.Seal(&acc, vault.NewSecret{APIKey: key, Metadata: meta}); err != nil {
 				results[i].Status = "error"
@@ -1071,9 +1080,10 @@ func (s *Server) adminUpdateAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		Label    *string `json:"label"`
-		Priority *int    `json:"priority"`
-		Disabled *bool   `json:"disabled"`
+		Label       *string `json:"label"`
+		Priority    *int    `json:"priority"`
+		Disabled    *bool   `json:"disabled"`
+		ProxyPoolID *string `json:"proxy_pool_id"`
 	}
 	if !decodeJSON(w, r, &body) {
 		return
@@ -1087,6 +1097,14 @@ func (s *Server) adminUpdateAccount(w http.ResponseWriter, r *http.Request) {
 	if body.Disabled != nil {
 		acc.Disabled = *body.Disabled
 	}
+	if body.ProxyPoolID != nil {
+		poolID := strings.TrimSpace(*body.ProxyPoolID)
+		if err := s.validateProxyPoolID(r.Context(), poolID); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		acc.ProxyPoolID = poolID
+	}
 	if err := s.accounts.Update(r.Context(), acc); err != nil {
 		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "internal server error"))
 		return
@@ -1094,7 +1112,22 @@ func (s *Server) adminUpdateAccount(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"id": acc.ID, "provider": acc.Provider, "label": acc.Label,
 		"priority": acc.Priority, "disabled": acc.Disabled,
+		"proxy_pool_id": acc.ProxyPoolID,
 	})
+}
+
+func (s *Server) validateProxyPoolID(ctx context.Context, id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
+	}
+	if s.pools == nil {
+		return fmt.Errorf("proxy pools not configured")
+	}
+	if _, err := s.pools.Get(ctx, id); err != nil {
+		return fmt.Errorf("proxy pool not found")
+	}
+	return nil
 }
 
 func (s *Server) adminTestAccount(w http.ResponseWriter, r *http.Request) {
@@ -2657,7 +2690,8 @@ func (s *Server) adminExportDatabase(w http.ResponseWriter, r *http.Request) {
 	poolsOut := make([]map[string]any, 0, len(pools))
 	for _, p := range pools {
 		poolsOut = append(poolsOut, map[string]any{
-			"name": p.Name, "proxy_url": p.ProxyURL, "no_proxy": p.NoProxy,
+			"id": p.ID, "name": p.Name, "type": p.Type,
+			"proxy_url": p.ProxyURL, "no_proxy": p.NoProxy,
 			"strict": p.Strict, "is_active": p.IsActive,
 		})
 	}
@@ -2838,23 +2872,25 @@ func (s *Server) adminImportDatabase(w http.ResponseWriter, r *http.Request) {
 	// Import proxy pools.
 	if raw, ok := payload["proxy_pools"]; ok {
 		var pools []struct {
+			ID       string `json:"id"`
 			Name     string `json:"name"`
+			Type     string `json:"type"`
 			ProxyURL string `json:"proxy_url"`
 			NoProxy  string `json:"no_proxy"`
 			Strict   bool   `json:"strict"`
-			IsActive bool   `json:"is_active"`
+			IsActive *bool  `json:"is_active"`
 		}
 		if err := json.Unmarshal(raw, &pools); err == nil {
 			for _, p := range pools {
 				now := time.Now()
 				pool := store.ProxyPool{
-					ID:         uuid.NewString(),
+					ID:         defaultStr(p.ID, uuid.NewString()),
 					Name:       p.Name,
-					Type:       "http",
+					Type:       defaultStr(p.Type, "http"),
 					ProxyURL:   p.ProxyURL,
 					NoProxy:    p.NoProxy,
 					Strict:     p.Strict,
-					IsActive:   defaultBool(p.IsActive, true),
+					IsActive:   p.IsActive == nil || *p.IsActive,
 					TestStatus: "unknown",
 					CreatedAt:  now,
 					UpdatedAt:  now,

--- a/backend/internal/gateway/admin_account_proxy_test.go
+++ b/backend/internal/gateway/admin_account_proxy_test.go
@@ -1,0 +1,48 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mydisha/keirouter/backend/internal/store"
+	"github.com/mydisha/keirouter/backend/internal/vault"
+)
+
+func TestAdminUpdateAccountProxyPool(t *testing.T) {
+	s, db := newBulkTestServer(t)
+	s.pools = db.ProxyPools()
+	now := time.Now()
+	pool := store.ProxyPool{
+		ID: uuid.NewString(), Name: "relay", Type: "cloudflare",
+		ProxyURL: "https://relay.example.com", IsActive: true,
+		TestStatus: "unknown", CreatedAt: now, UpdatedAt: now,
+	}
+	require.NoError(t, s.pools.Create(context.Background(), pool))
+	acc := store.Account{
+		ID: uuid.NewString(), TenantID: adminTenant, Provider: "openai",
+		Label: "account", AuthKind: store.AuthAPIKey, Priority: 100,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	require.NoError(t, s.vault.Seal(&acc, vault.NewSecret{APIKey: "secret", Metadata: map[string]string{}}))
+	require.NoError(t, s.accounts.Create(context.Background(), acc))
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", acc.ID)
+	req := httptest.NewRequest(http.MethodPatch, "/accounts/"+acc.ID, strings.NewReader(`{"proxy_pool_id":"`+pool.ID+`"}`))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	s.adminUpdateAccount(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	updated, err := s.accounts.Get(context.Background(), acc.ID)
+	require.NoError(t, err)
+	require.Equal(t, pool.ID, updated.ProxyPoolID)
+}

--- a/backend/internal/gateway/admin_foreign_import.go
+++ b/backend/internal/gateway/admin_foreign_import.go
@@ -274,19 +274,20 @@ func nodeDialectToken(t string) string {
 
 // n9routerConnection mirrors the exported providerConnection shape.
 type n9routerConnection struct {
-	ID           string         `json:"id"`
-	Provider     string         `json:"provider"`
-	AuthType     string         `json:"authType"`
-	Name         string         `json:"name"`
-	DisplayName  string         `json:"displayName"`
-	Email        string         `json:"email"`
-	Priority     int            `json:"priority"`
-	IsActive     *bool          `json:"isActive"`
-	APIKey       string         `json:"apiKey"`
-	AccessToken  string         `json:"accessToken"`
-	RefreshToken string         `json:"refreshToken"`
-	ExpiresAt    string         `json:"expiresAt"`
-	Data         map[string]any `json:"-"`
+	ID                   string         `json:"id"`
+	Provider             string         `json:"provider"`
+	AuthType             string         `json:"authType"`
+	Name                 string         `json:"name"`
+	DisplayName          string         `json:"displayName"`
+	Email                string         `json:"email"`
+	Priority             int            `json:"priority"`
+	IsActive             *bool          `json:"isActive"`
+	APIKey               string         `json:"apiKey"`
+	AccessToken          string         `json:"accessToken"`
+	RefreshToken         string         `json:"refreshToken"`
+	ExpiresAt            string         `json:"expiresAt"`
+	ProviderSpecificData map[string]any `json:"providerSpecificData"`
+	Data                 map[string]any `json:"-"`
 }
 
 func (s *Server) importN9routerConnections(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult, nodeIDMap map[string]string) {
@@ -318,6 +319,11 @@ func (s *Server) importN9routerConnections(ctx context.Context, doc map[string]j
 				}
 				if c.ExpiresAt == "" {
 					c.ExpiresAt = strVal(c.Data["expiresAt"])
+				}
+				if c.ProviderSpecificData == nil {
+					if psd, ok := c.Data["providerSpecificData"].(map[string]any); ok {
+						c.ProviderSpecificData = psd
+					}
 				}
 			}
 		}
@@ -358,7 +364,7 @@ func (s *Server) importN9routerConnections(ctx context.Context, doc map[string]j
 		// codex workspaceId, base_url overrides, azure details, ...). These
 		// surface as creds.Extra at request time, so they MUST transfer for
 		// connectors like Qoder that require user_id to sign requests.
-		meta := psdToMetadata(provider, c.Data)
+		meta := psdToMetadata(provider, c.ProviderSpecificData)
 		// Top-level email is the canonical account email for OAuth providers;
 		// ensure it lands in metadata (qoder/cursor/cloudcode read it).
 		if c.Email != "" && meta["email"] == "" {
@@ -377,9 +383,8 @@ func (s *Server) importN9routerConnections(ctx context.Context, doc map[string]j
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
-		if t := parseRFC3339(c.ExpiresAt); t != nil {
-			acc.TokenExpiresAt = t
-		}
+		secret.ExpiresAt = parseRFC3339(c.ExpiresAt)
+		secret.Metadata = meta
 		if err := s.vault.Seal(&acc, secret); err != nil {
 			res.Skipped++
 			res.Errors = append(res.Errors, fmt.Sprintf("connection %s: seal failed: %v", c.ID, err))
@@ -414,8 +419,11 @@ func n9routerAuthSecret(c n9routerConnection, spec connectors.ProviderSpec, spec
 			return store.AuthAPIKey, sec
 		}
 		return store.AuthOAuth, sec
-	case "apikey":
+	case "apikey", "api_key", "api-key":
 		sec.APIKey = c.APIKey
+		if sec.APIKey == "" {
+			sec.APIKey = c.AccessToken
+		}
 		if specOK && spec.AuthKind == "none" && c.APIKey == "" {
 			return store.AuthNone, sec
 		}
@@ -931,9 +939,14 @@ func normalizeOmniPayload(doc map[string]json.RawMessage) map[string]json.RawMes
 // looks for kiro_auth_method / kiro_region and finds auth_method / region.
 var psdKeyRemap = map[string]map[string]string{
 	"kiro": {
-		"authMethod": "kiro_auth_method",
-		"region":     "kiro_region",
-		"profileArn": "profile_arn",
+		"authMethod":    "kiro_auth_method",
+		"region":        "kiro_region",
+		"profileArn":    "kiro_profile_arn",
+		"clientId":      "kiro_client_id",
+		"clientSecret":  "kiro_client_secret",
+		"tokenEndpoint": "kiro_token_endpoint",
+		"scope":         "kiro_scope",
+		"scopes":        "kiro_scope",
 	},
 	"cursor": {
 		"machineId": "machine_id",

--- a/backend/internal/gateway/admin_foreign_import_kiro_test.go
+++ b/backend/internal/gateway/admin_foreign_import_kiro_test.go
@@ -1,0 +1,50 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestForeignKiroAPIKeyUsesExportedAccessToken(t *testing.T) {
+	s, db := newBulkTestServer(t)
+	payload := []byte(`[{"id":"source-1","provider":"kiro","authType":"api_key","name":"Kiro key","accessToken":"headless-token","providerSpecificData":{"authMethod":"api_key","profileArn":"arn:aws:codewhisperer:us-east-1:123:profile/ABC","region":"us-east-1"}}]`)
+	doc := map[string]json.RawMessage{"providerConnections": payload}
+	result := &foreignImportResult{}
+	s.importN9routerConnections(context.Background(), doc, result, nil)
+	require.Equal(t, 1, result.Accounts, result.Errors)
+
+	accounts, err := db.Accounts().ListByProvider(context.Background(), adminTenant, "kiro")
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
+	creds, err := s.vault.Open(accounts[0])
+	require.NoError(t, err)
+	require.Equal(t, "headless-token", creds.APIKey)
+	require.Equal(t, "api_key", creds.Extra["kiro_auth_method"])
+	require.Equal(t, "arn:aws:codewhisperer:us-east-1:123:profile/ABC", creds.Extra["kiro_profile_arn"])
+}
+
+func TestForeignKiroExternalIDPPreservesBearerAndRefreshConfig(t *testing.T) {
+	s, db := newBulkTestServer(t)
+	payload := []byte(`[{"id":"source-2","provider":"kiro","authType":"oauth","email":"person@example.com","accessToken":"bearer-token","refreshToken":"refresh-token","providerSpecificData":{"authMethod":"external_idp","profileArn":"arn:aws:codewhisperer:eu-west-1:123:profile/XYZ","region":"eu-west-1","clientId":"client-id","tokenEndpoint":"https://login.microsoftonline.com/tenant/oauth2/v2.0/token","scope":"openid offline_access"}}]`)
+	doc := map[string]json.RawMessage{"providerConnections": payload}
+	result := &foreignImportResult{}
+	s.importN9routerConnections(context.Background(), doc, result, nil)
+	require.Equal(t, 1, result.Accounts, result.Errors)
+
+	accounts, err := db.Accounts().ListByProvider(context.Background(), adminTenant, "kiro")
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
+	creds, err := s.vault.Open(accounts[0])
+	require.NoError(t, err)
+	require.Equal(t, "bearer-token", creds.AccessToken)
+	require.Equal(t, "external_idp", creds.Extra["kiro_auth_method"])
+	require.Equal(t, "client-id", creds.Extra["kiro_client_id"])
+	require.Equal(t, "eu-west-1", creds.Extra["kiro_region"])
+
+	refreshToken, err := s.vault.OpenRefreshToken(accounts[0])
+	require.NoError(t, err)
+	require.Equal(t, "refresh-token", refreshToken)
+}

--- a/backend/internal/gateway/cloudflare_relay.go
+++ b/backend/internal/gateway/cloudflare_relay.go
@@ -1,0 +1,331 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+const cloudflareAPIBase = "https://api.cloudflare.com/client/v4"
+
+const (
+	cloudflareReadinessAttempts     = 12
+	cloudflareReadinessInterval     = 3 * time.Second
+	cloudflareReadinessProbeTimeout = 8 * time.Second
+)
+
+const cloudflareRelayWorker = `export default {
+  async fetch(request) {
+    const target = request.headers.get("x-relay-target");
+    const relayPath = request.headers.get("x-relay-path") || "/";
+
+    if (!target) {
+      return new Response(JSON.stringify({ error: "Missing x-relay-target header" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    const targetUrl = target.replace(/\/$/, "") + relayPath;
+    const headers = new Headers(request.headers);
+    headers.delete("x-relay-target");
+    headers.delete("x-relay-path");
+    headers.delete("host");
+
+    const init = { method: request.method, headers };
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      init.body = request.body;
+      init.duplex = "half";
+    }
+
+    try {
+      const response = await fetch(targetUrl, init);
+      return new Response(response.body, {
+        status: response.status,
+        headers: response.headers,
+      });
+    } catch (error) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 502,
+        headers: { "content-type": "application/json" },
+      });
+    }
+  },
+};
+`
+
+var cloudflareWorkerName = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
+var cloudflareAccountID = regexp.MustCompile(`^[a-f0-9]{32}$`)
+
+type cloudflareDeployInput struct {
+	AccountID        string `json:"account_id"`
+	AccountIDCamel   string `json:"accountId"`
+	APIToken         string `json:"api_token"`
+	APITokenCamel    string `json:"apiToken"`
+	ProjectName      string `json:"project_name"`
+	ProjectNameCamel string `json:"projectName"`
+}
+
+type cloudflareEnvelope struct {
+	Success *bool `json:"success"`
+	Result  struct {
+		Subdomain string `json:"subdomain"`
+	} `json:"result"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func (s *Server) adminDeployCloudflareRelay(w http.ResponseWriter, r *http.Request) {
+	var body cloudflareDeployInput
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if err := normalizeCloudflareDeployInput(&body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if s.pools == nil {
+		writeError(w, http.StatusInternalServerError, "proxy pools not configured")
+		return
+	}
+
+	client := &http.Client{Timeout: 45 * time.Second}
+	deployURL, err := deployCloudflareWorker(r, client, cloudflareAPIBase, body)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	now := time.Now()
+	pool := store.ProxyPool{
+		ID:         uuid.NewString(),
+		Name:       body.ProjectName,
+		Type:       "cloudflare",
+		ProxyURL:   deployURL,
+		IsActive:   false,
+		TestStatus: "testing",
+		LastError:  "Waiting for Worker propagation; readiness will retry automatically",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.pools.Create(r.Context(), pool); err != nil {
+		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "relay deployed but proxy pool creation failed"))
+		return
+	}
+	go s.monitorRelayReadiness(pool.ID)
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"id": pool.ID, "name": pool.Name, "deploy_url": deployURL,
+		"deployUrl": deployURL, "test_status": pool.TestStatus,
+		"proxyPool": map[string]any{
+			"id": pool.ID, "name": pool.Name, "type": pool.Type,
+			"proxyUrl": pool.ProxyURL, "noProxy": pool.NoProxy,
+			"isActive": pool.IsActive, "strictProxy": pool.Strict,
+		},
+	})
+}
+
+func normalizeCloudflareDeployInput(input *cloudflareDeployInput) error {
+	input.AccountID = strings.ToLower(strings.TrimSpace(defaultStr(input.AccountID, input.AccountIDCamel)))
+	input.APIToken = strings.TrimSpace(defaultStr(input.APIToken, input.APITokenCamel))
+	input.ProjectName = strings.ToLower(strings.TrimSpace(defaultStr(input.ProjectName, input.ProjectNameCamel)))
+	if input.AccountID == "" || input.APIToken == "" {
+		return fmt.Errorf("account_id and api_token are required")
+	}
+	if !cloudflareAccountID.MatchString(input.AccountID) {
+		return fmt.Errorf("account_id must be a 32-character Cloudflare account ID")
+	}
+	if len(input.APIToken) < 20 || len(strings.Fields(input.APIToken)) != 1 {
+		return fmt.Errorf("api_token is not a valid Cloudflare API token")
+	}
+	if input.ProjectName == "" {
+		input.ProjectName = "relay-" + strings.ToLower(uuid.NewString()[:8])
+	}
+	if !cloudflareWorkerName.MatchString(input.ProjectName) {
+		return fmt.Errorf("project_name must be 1-63 lowercase letters, numbers, or hyphens and cannot start or end with a hyphen")
+	}
+	return nil
+}
+
+func (s *Server) monitorRelayReadiness(poolID string) {
+	maxDuration := time.Duration(cloudflareReadinessAttempts)*cloudflareReadinessProbeTimeout +
+		time.Duration(cloudflareReadinessAttempts-1)*cloudflareReadinessInterval + 5*time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), maxDuration)
+	defer cancel()
+	s.runRelayReadiness(ctx, poolID, cloudflareReadinessAttempts, cloudflareReadinessInterval, testRelayPool)
+}
+
+func (s *Server) runRelayReadiness(
+	ctx context.Context,
+	poolID string,
+	attempts int,
+	interval time.Duration,
+	probe func(string, time.Duration) proxyTestResult,
+) {
+	if attempts < 1 {
+		attempts = 1
+	}
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if attempt > 1 {
+			timer := time.NewTimer(interval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+
+		pool, err := s.pools.Get(ctx, poolID)
+		if err != nil {
+			return
+		}
+		result := probe(pool.ProxyURL, cloudflareReadinessProbeTimeout)
+		now := time.Now()
+		pool.LastTested = &now
+		pool.IsActive = result.status == "active"
+		if pool.IsActive {
+			pool.TestStatus = "active"
+			pool.LastError = ""
+			_ = s.pools.Update(ctx, pool)
+			return
+		}
+
+		if attempt == attempts || !retryableRelayReadiness(result) {
+			pool.TestStatus = "error"
+			pool.LastError = result.lastError
+			_ = s.pools.Update(ctx, pool)
+			return
+		}
+		pool.TestStatus = "testing"
+		pool.LastError = fmt.Sprintf("Worker propagation in progress (%s); retry %d/%d is scheduled automatically", result.lastError, attempt+1, attempts)
+		if err := s.pools.Update(ctx, pool); err != nil {
+			return
+		}
+	}
+}
+
+func retryableRelayReadiness(result proxyTestResult) bool {
+	if result.httpStatus == 0 {
+		return true
+	}
+	switch result.httpStatus {
+	case http.StatusNotFound, http.StatusRequestTimeout, http.StatusTooEarly,
+		http.StatusTooManyRequests, http.StatusInternalServerError,
+		http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return result.httpStatus >= 520 && result.httpStatus <= 527
+	}
+}
+
+func deployCloudflareWorker(r *http.Request, client *http.Client, apiBase string, input cloudflareDeployInput) (string, error) {
+	scriptURL := strings.TrimRight(apiBase, "/") + "/accounts/" + url.PathEscape(input.AccountID) + "/workers/scripts/" + url.PathEscape(input.ProjectName)
+
+	var form bytes.Buffer
+	writer := multipart.NewWriter(&form)
+	jsHeader := make(textproto.MIMEHeader)
+	jsHeader.Set("Content-Disposition", `form-data; name="index.js"; filename="index.js"`)
+	jsHeader.Set("Content-Type", "application/javascript+module")
+	part, err := writer.CreatePart(jsHeader)
+	if err != nil {
+		return "", fmt.Errorf("build worker upload: %w", err)
+	}
+	if _, err := io.WriteString(part, cloudflareRelayWorker); err != nil {
+		return "", fmt.Errorf("build worker upload: %w", err)
+	}
+
+	metadataHeader := make(textproto.MIMEHeader)
+	metadataHeader.Set("Content-Disposition", `form-data; name="metadata"; filename="metadata.json"`)
+	metadataHeader.Set("Content-Type", "application/json")
+	part, err = writer.CreatePart(metadataHeader)
+	if err != nil {
+		return "", fmt.Errorf("build worker metadata: %w", err)
+	}
+	metadata := `{"main_module":"index.js","compatibility_date":"2024-03-20","observability":{"enabled":true}}`
+	if _, err := io.WriteString(part, metadata); err != nil {
+		return "", fmt.Errorf("build worker metadata: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return "", fmt.Errorf("finish worker upload: %w", err)
+	}
+
+	if _, err := cloudflareRequest(r, client, http.MethodPut, scriptURL, input.APIToken, writer.FormDataContentType(), &form); err != nil {
+		return "", fmt.Errorf("worker upload failed: %w", err)
+	}
+
+	enableBody := bytes.NewBufferString(`{"enabled":true}`)
+	_, _ = cloudflareRequest(r, client, http.MethodPost, scriptURL+"/subdomain", input.APIToken, "application/json", enableBody)
+
+	raw, err := cloudflareRequest(r, client, http.MethodGet,
+		strings.TrimRight(apiBase, "/")+"/accounts/"+url.PathEscape(input.AccountID)+"/workers/subdomain",
+		input.APIToken, "", nil)
+	if err != nil {
+		return "", fmt.Errorf("retrieve workers.dev subdomain: %w", err)
+	}
+	var envelope cloudflareEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil || strings.TrimSpace(envelope.Result.Subdomain) == "" {
+		return "", fmt.Errorf("worker deployed but workers.dev subdomain could not be determined")
+	}
+	subdomain := strings.ToLower(strings.TrimSpace(envelope.Result.Subdomain))
+	if !cloudflareWorkerName.MatchString(subdomain) {
+		return "", fmt.Errorf("worker deployed but Cloudflare returned an invalid workers.dev subdomain")
+	}
+	deployURL := "https://" + input.ProjectName + "." + subdomain + ".workers.dev"
+	if err := validateProxyPoolURL("cloudflare", deployURL); err != nil {
+		return "", fmt.Errorf("worker deployed but the relay URL is invalid: %w", err)
+	}
+	return deployURL, nil
+}
+
+func cloudflareRequest(r *http.Request, client *http.Client, method, endpoint, token, contentType string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequestWithContext(r.Context(), method, endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		var envelope cloudflareEnvelope
+		_ = json.Unmarshal(raw, &envelope)
+		message := "request rejected"
+		if len(envelope.Errors) > 0 && strings.TrimSpace(envelope.Errors[0].Message) != "" {
+			message = envelope.Errors[0].Message
+		}
+		return nil, fmt.Errorf("%s (HTTP %d)", message, resp.StatusCode)
+	}
+	var envelope cloudflareEnvelope
+	if json.Unmarshal(raw, &envelope) == nil && envelope.Success != nil && !*envelope.Success {
+		message := "request rejected"
+		if len(envelope.Errors) > 0 && strings.TrimSpace(envelope.Errors[0].Message) != "" {
+			message = envelope.Errors[0].Message
+		}
+		return nil, fmt.Errorf("%s", message)
+	}
+	return raw, nil
+}

--- a/backend/internal/gateway/cloudflare_relay_test.go
+++ b/backend/internal/gateway/cloudflare_relay_test.go
@@ -1,0 +1,112 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+type relayRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f relayRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestDeployCloudflareWorker(t *testing.T) {
+	var uploaded bool
+	client := &http.Client{Transport: relayRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			t.Fatalf("missing API authorization")
+		}
+		response := map[string]any{"success": true}
+		switch {
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/workers/scripts/my-relay"):
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatal(err)
+			}
+			file, _, err := r.FormFile("index.js")
+			if err != nil {
+				t.Fatal(err)
+			}
+			worker, _ := io.ReadAll(file)
+			_ = file.Close()
+			if !strings.Contains(string(worker), "x-relay-target") {
+				t.Fatalf("worker is missing relay protocol")
+			}
+			uploaded = true
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/workers/scripts/my-relay/subdomain"):
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/workers/subdomain"):
+			response["result"] = map[string]string{"subdomain": "team"}
+		default:
+			return &http.Response{StatusCode: http.StatusNotFound, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+		}
+		raw, _ := json.Marshal(response)
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(string(raw)))}, nil
+	})}
+
+	req := httptest.NewRequest(http.MethodPost, "/proxy-pools/cloudflare-deploy", nil)
+	deployURL, err := deployCloudflareWorker(req, client, "https://api.example", cloudflareDeployInput{
+		AccountID: "account", APIToken: "token", ProjectName: "my-relay",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !uploaded || deployURL != "https://my-relay.team.workers.dev" {
+		t.Fatalf("uploaded=%v deployURL=%q", uploaded, deployURL)
+	}
+}
+
+func TestNormalizeCloudflareDeployInput(t *testing.T) {
+	input := cloudflareDeployInput{
+		AccountIDCamel: "ABCDEF0123456789ABCDEF0123456789",
+		APITokenCamel:  "token_abcdefghijklmnopqrstuvwxyz",
+		ProjectName:    " My-Relay ",
+	}
+	if err := normalizeCloudflareDeployInput(&input); err != nil {
+		t.Fatal(err)
+	}
+	if input.AccountID != "abcdef0123456789abcdef0123456789" || input.ProjectName != "my-relay" {
+		t.Fatalf("input was not normalized: %+v", input)
+	}
+
+	invalid := cloudflareDeployInput{AccountID: "short", APIToken: input.APIToken}
+	if err := normalizeCloudflareDeployInput(&invalid); err == nil {
+		t.Fatal("expected invalid account ID to be rejected")
+	}
+}
+
+func TestRelayReadinessRetriesTransientFailure(t *testing.T) {
+	s, db := newBulkTestServer(t)
+	s.pools = db.ProxyPools()
+	now := time.Now()
+	pool := store.ProxyPool{
+		ID: "relay-pool", Name: "relay", Type: "cloudflare",
+		ProxyURL: "https://relay.example.com", TestStatus: "testing",
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.pools.Create(context.Background(), pool); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	s.runRelayReadiness(context.Background(), pool.ID, 3, 0, func(string, time.Duration) proxyTestResult {
+		calls++
+		if calls == 1 {
+			return proxyTestResult{status: "error", lastError: "relay returned HTTP 503", httpStatus: http.StatusServiceUnavailable}
+		}
+		return proxyTestResult{status: "active", httpStatus: http.StatusOK}
+	})
+
+	updated, err := s.pools.Get(context.Background(), pool.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || updated.TestStatus != "active" || !updated.IsActive || updated.LastError != "" || updated.LastTested == nil {
+		t.Fatalf("unexpected readiness result: calls=%d pool=%+v", calls, updated)
+	}
+}

--- a/backend/internal/gateway/insights.go
+++ b/backend/internal/gateway/insights.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -620,19 +622,17 @@ func (s *Server) adminCreateProxyPool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// SSRF Protection: Validate proxy URL before use
-	if err := httputil.ValidateProxyURL(body.ProxyURL); err != nil {
-		s.log.Warn("blocked suspicious proxy URL", "url", body.ProxyURL, "error", err)
-		writeError(w, http.StatusBadRequest, "invalid proxy_url: URL blocked by security policy")
-		return
-	}
-
 	poolType := body.Type
 	if poolType == "" {
 		poolType = "http"
 	}
 	if !validProxyPoolTypes[poolType] {
 		writeError(w, http.StatusBadRequest, "invalid pool type: must be http, vercel, cloudflare, or deno")
+		return
+	}
+	if err := validateProxyPoolURL(poolType, body.ProxyURL); err != nil {
+		s.log.Warn("blocked invalid proxy URL", "url", body.ProxyURL, "type", poolType, "error", err)
+		writeError(w, http.StatusBadRequest, "invalid proxy_url: "+err.Error())
 		return
 	}
 	active := true
@@ -676,9 +676,18 @@ func (s *Server) adminUpdateProxyPool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if body.Name != nil {
-		pool.Name = *body.Name
+		name := strings.TrimSpace(*body.Name)
+		if name == "" {
+			writeError(w, http.StatusBadRequest, "name cannot be empty")
+			return
+		}
+		pool.Name = name
 	}
 	if body.ProxyURL != nil {
+		if err := validateProxyPoolURL(pool.Type, *body.ProxyURL); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid proxy_url: "+err.Error())
+			return
+		}
 		pool.ProxyURL = *body.ProxyURL
 	}
 	if body.NoProxy != nil {
@@ -696,6 +705,23 @@ func (s *Server) adminUpdateProxyPool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func validateProxyPoolURL(poolType, rawURL string) error {
+	if strings.TrimSpace(rawURL) == "" {
+		return fmt.Errorf("URL is required")
+	}
+	if err := httputil.ValidateProxyURL(rawURL); err != nil {
+		return fmt.Errorf("URL blocked by security policy")
+	}
+	if poolType == "http" {
+		return nil
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("relay URL must use http or https")
+	}
+	return nil
 }
 
 func (s *Server) adminDeleteProxyPool(w http.ResponseWriter, r *http.Request) {
@@ -738,7 +764,7 @@ func (s *Server) adminTestProxyPool(w http.ResponseWriter, r *http.Request) {
 
 	pool.TestStatus = result.status
 	pool.LastError = result.lastError
-	// Preserve current is_active — don't force-enable on test pass.
+	pool.IsActive = result.status == "active"
 	_ = s.pools.Update(r.Context(), pool)
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -750,9 +776,10 @@ func (s *Server) adminTestProxyPool(w http.ResponseWriter, r *http.Request) {
 }
 
 type proxyTestResult struct {
-	status    string
-	lastError string
-	elapsedMS int64
+	status     string
+	lastError  string
+	elapsedMS  int64
+	httpStatus int
 }
 
 // testProxyPoolConnectivity performs a real connectivity check against a proxy
@@ -788,9 +815,9 @@ func testHTTPPool(proxyURL string, timeout time.Duration) proxyTestResult {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		return proxyTestResult{status: "error", lastError: fmt.Sprintf("proxy returned HTTP %d", resp.StatusCode), elapsedMS: elapsed}
+		return proxyTestResult{status: "error", lastError: fmt.Sprintf("proxy returned HTTP %d", resp.StatusCode), elapsedMS: elapsed, httpStatus: resp.StatusCode}
 	}
-	return proxyTestResult{status: "active", elapsedMS: elapsed}
+	return proxyTestResult{status: "active", elapsedMS: elapsed, httpStatus: resp.StatusCode}
 }
 
 func testRelayPool(relayURL string, timeout time.Duration) proxyTestResult {
@@ -800,18 +827,39 @@ func testRelayPool(relayURL string, timeout time.Duration) proxyTestResult {
 	if err != nil {
 		return proxyTestResult{status: "error", lastError: err.Error()}
 	}
-	req.Header.Set("x-relay-target", "https://httpbin.org")
-	req.Header.Set("x-relay-path", "/get")
+	req.Header.Set("x-relay-target", "https://echo.free.beeceptor.com")
+	req.Header.Set("x-relay-path", "/")
+	probeID := uuid.NewString()
+	req.Header.Set("x-keirouter-relay-probe", probeID)
 	resp, err := client.Do(req)
 	elapsed := time.Since(start).Milliseconds()
 	if err != nil {
 		return proxyTestResult{status: "error", lastError: err.Error(), elapsedMS: elapsed}
 	}
 	defer resp.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if resp.StatusCode >= 400 {
-		return proxyTestResult{status: "error", lastError: fmt.Sprintf("relay returned HTTP %d", resp.StatusCode), elapsedMS: elapsed}
+		return proxyTestResult{status: "error", lastError: fmt.Sprintf("relay returned HTTP %d", resp.StatusCode), elapsedMS: elapsed, httpStatus: resp.StatusCode}
 	}
-	return proxyTestResult{status: "active", elapsedMS: elapsed}
+	if readErr != nil {
+		return proxyTestResult{status: "error", lastError: "could not read relay probe response", elapsedMS: elapsed, httpStatus: resp.StatusCode}
+	}
+	var echoed struct {
+		Headers map[string]any `json:"headers"`
+	}
+	if json.Unmarshal(raw, &echoed) != nil || !relayProbeHeaderMatches(echoed.Headers, probeID) {
+		return proxyTestResult{status: "error", lastError: "relay response did not confirm request forwarding", elapsedMS: elapsed, httpStatus: resp.StatusCode}
+	}
+	return proxyTestResult{status: "active", elapsedMS: elapsed, httpStatus: resp.StatusCode}
+}
+
+func relayProbeHeaderMatches(headers map[string]any, probeID string) bool {
+	for key, value := range headers {
+		if strings.EqualFold(key, "x-keirouter-relay-probe") && fmt.Sprint(value) == probeID {
+			return true
+		}
+	}
+	return false
 }
 
 // ---- skills -----------------------------------------------------------------

--- a/backend/internal/gateway/kiro.go
+++ b/backend/internal/gateway/kiro.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"time"
 
@@ -23,6 +24,7 @@ func (s *Server) mountKiro(r chi.Router) {
 	r.Post("/kiro/device-start", s.kiroDeviceStart)
 	r.Post("/kiro/device-poll", s.kiroDevicePoll)
 	r.Post("/kiro/import", s.kiroImport)
+	r.Post("/kiro/import-cli-proxy", s.kiroImportCLIProxy)
 	r.Post("/kiro/api-key", s.kiroAPIKey)
 	r.Get("/kiro/health", s.kiroHealth)
 }
@@ -156,18 +158,47 @@ func (s *Server) kiroDevicePoll(w http.ResponseWriter, r *http.Request) {
 // SSO client credentials are stored.
 func (s *Server) kiroImport(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		RefreshToken string `json:"refresh_token"`
-		Label        string `json:"label"`
+		RefreshToken      string `json:"refresh_token"`
+		RefreshTokenCamel string `json:"refreshToken"`
+		Label             string `json:"label"`
+		ClientID          string `json:"client_id"`
+		ClientIDCamel     string `json:"clientId"`
+		ClientSecret      string `json:"client_secret"`
+		ClientSecretCamel string `json:"clientSecret"`
+		Region            string `json:"region"`
+		ProfileARN        string `json:"profile_arn"`
+		ProfileARNCamel   string `json:"profileArn"`
 	}
 	if !decodeJSON(w, r, &body) {
 		return
 	}
+	body.RefreshToken = defaultStr(body.RefreshToken, body.RefreshTokenCamel)
+	body.ClientID = defaultStr(body.ClientID, body.ClientIDCamel)
+	body.ClientSecret = defaultStr(body.ClientSecret, body.ClientSecretCamel)
+	body.ProfileARN = defaultStr(body.ProfileARN, body.ProfileARNCamel)
 	if body.RefreshToken == "" {
 		writeError(w, http.StatusBadRequest, "refresh_token is required")
 		return
 	}
 
-	tokens, err := oauth.KiroValidateImportToken(r.Context(), body.RefreshToken)
+	if (body.ClientID == "") != (body.ClientSecret == "") {
+		writeError(w, http.StatusBadRequest, "client_id and client_secret must be provided together")
+		return
+	}
+
+	var tokens *oauth.Tokens
+	var err error
+	authMethod := "imported"
+	if body.ClientID != "" {
+		client := &oauth.KiroClient{
+			ClientID: body.ClientID, ClientSecret: body.ClientSecret,
+			Region: body.Region,
+		}
+		tokens, err = client.Refresh(r.Context(), body.RefreshToken)
+		authMethod = "idc"
+	} else {
+		tokens, err = oauth.KiroSocialRefresh(r.Context(), body.RefreshToken)
+	}
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -175,15 +206,73 @@ func (s *Server) kiroImport(w http.ResponseWriter, r *http.Request) {
 	if tokens.Extra == nil {
 		tokens.Extra = map[string]string{}
 	}
-	tokens.Extra["kiro_auth_method"] = "imported"
+	tokens.Extra["kiro_auth_method"] = authMethod
+	if body.ProfileARN != "" {
+		tokens.Extra["kiro_profile_arn"] = body.ProfileARN
+	}
+	if body.ClientID != "" {
+		tokens.Extra["kiro_client_id"] = body.ClientID
+		tokens.Extra["kiro_client_secret"] = body.ClientSecret
+		tokens.Extra["kiro_region"] = defaultStr(body.Region, "us-east-1")
+	}
 
-	label := defaultStr(body.Label, "Kiro (imported)")
+	label := defaultStr(body.Label, kiroLabel(authMethod))
 	id, perr := s.persistOAuthAccount(r, "kiro", label, tokens)
 	if perr != nil {
 		writeError(w, http.StatusInternalServerError, perr.Error())
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{"id": id, "provider": "kiro"})
+}
+
+func (s *Server) kiroImportCLIProxy(w http.ResponseWriter, r *http.Request) {
+	if s.vault == nil {
+		writeError(w, http.StatusInternalServerError, errVaultUnconfigured.Error())
+		return
+	}
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "could not read auth JSON")
+		return
+	}
+	tokens, err := oauth.NormalizeKiroExternalIDPAuth(raw)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	now := time.Now()
+	expiresAt := now.Add(time.Duration(tokens.ExpiresIn) * time.Second)
+	label := "Kiro (External IdP)"
+	if tokens.Email != "" {
+		label = tokens.Email
+	}
+	acc := store.Account{
+		ID: uuid.NewString(), TenantID: adminTenant, Provider: "kiro",
+		Label: label, AuthKind: store.AuthOAuth, Priority: 100,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.vault.Seal(&acc, vault.NewSecret{
+		AccessToken: tokens.AccessToken, RefreshToken: tokens.RefreshToken,
+		ExpiresAt: &expiresAt, Metadata: tokens.Extra,
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "vault seal failed"))
+		return
+	}
+	if err := s.accounts.Create(r.Context(), acc); err != nil {
+		writeError(w, http.StatusInternalServerError, sanitizeError(s.log, err, "account creation failed"))
+		return
+	}
+	s.clearStaleProviderCooldowns(r.Context(), adminTenant, "kiro")
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"success":  true,
+		"id":       acc.ID,
+		"provider": "kiro",
+		"email":    tokens.Email,
+		"connection": map[string]any{
+			"id": acc.ID, "provider": "kiro", "email": tokens.Email,
+		},
+	})
 }
 
 // kiroAPIKey validates a long-lived CodeWhisperer API key and stores it as a

--- a/backend/internal/gateway/kiro_import_test.go
+++ b/backend/internal/gateway/kiro_import_test.go
@@ -1,0 +1,42 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+func TestKiroImportCLIProxyPersistsExternalIDPCredential(t *testing.T) {
+	s, db := newBulkTestServer(t)
+	authJSON := `{"auth_method":"external_idp","access_token":"access-token","refresh_token":"refresh-token","client_id":"client-id","token_endpoint":"https://login.microsoftonline.com/tenant/oauth2/v2.0/token","profile_arn":"arn:aws:codewhisperer:us-east-1:123:profile/ABC","region":"us-east-1","scopes":["openid","offline_access"]}`
+	body, err := json.Marshal(map[string]string{"json": authJSON})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/kiro/import-cli-proxy", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	s.kiroImportCLIProxy(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	accounts, err := db.Accounts().ListByProvider(context.Background(), adminTenant, "kiro")
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
+	require.Equal(t, store.AuthOAuth, accounts[0].AuthKind)
+	require.NotNil(t, accounts[0].TokenExpiresAt)
+
+	creds, err := s.vault.Open(accounts[0])
+	require.NoError(t, err)
+	require.Equal(t, "access-token", creds.AccessToken)
+	refreshToken, err := s.vault.OpenRefreshToken(accounts[0])
+	require.NoError(t, err)
+	require.Equal(t, "refresh-token", refreshToken)
+	require.Equal(t, "external_idp", creds.Extra["kiro_auth_method"])
+	require.Equal(t, "client-id", creds.Extra["kiro_client_id"])
+	require.Equal(t, "openid offline_access", creds.Extra["kiro_scope"])
+}

--- a/backend/internal/oauth/kiro_external.go
+++ b/backend/internal/oauth/kiro_external.go
@@ -1,0 +1,282 @@
+package oauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const kiroExternalDefaultExpiry = 3600
+
+var microsoftTokenEndpointHosts = map[string]bool{
+	"login.microsoftonline.com": true,
+	"login.microsoft.com":       true,
+	"login.windows.net":         true,
+}
+
+func NormalizeKiroExternalIDPAuth(raw []byte) (*Tokens, error) {
+	var input any
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return nil, fmt.Errorf("kiro: CLI proxy auth JSON is invalid")
+	}
+	for {
+		switch value := input.(type) {
+		case string:
+			if err := json.Unmarshal([]byte(value), &input); err != nil {
+				return nil, fmt.Errorf("kiro: CLI proxy auth JSON is invalid")
+			}
+			continue
+		case map[string]any:
+			for _, key := range []string{"cliProxyAuth", "auth", "json"} {
+				if nested, ok := value[key]; ok {
+					input = nested
+					goto unwrap
+				}
+			}
+			return normalizeKiroExternalMap(value)
+		default:
+			return nil, fmt.Errorf("kiro: CLI proxy auth JSON is required")
+		}
+	unwrap:
+	}
+}
+
+func normalizeKiroExternalMap(input map[string]any) (*Tokens, error) {
+	authMethod := firstString(input, "auth_method", "authMethod")
+	if authMethod != "" && authMethod != "external_idp" {
+		return nil, fmt.Errorf("kiro: only external_idp auth is supported by this importer")
+	}
+	accessToken := firstString(input, "access_token", "accessToken")
+	refreshToken := firstString(input, "refresh_token", "refreshToken")
+	clientID := firstString(input, "client_id", "clientId")
+	tokenEndpoint, err := validateMicrosoftTokenEndpoint(firstString(input, "token_endpoint", "tokenEndpoint"))
+	if err != nil {
+		return nil, err
+	}
+	profileARN := firstString(input, "profile_arn", "profileArn")
+	region := firstString(input, "region")
+	if region == "" {
+		region = kiroDefaultRegion
+	}
+	scope := normalizeKiroScope(firstValue(input, "scopes", "scope"))
+
+	for field, value := range map[string]string{
+		"access_token":  accessToken,
+		"refresh_token": refreshToken,
+		"client_id":     clientID,
+		"scopes":        scope,
+		"profile_arn":   profileARN,
+	} {
+		if value == "" {
+			return nil, fmt.Errorf("kiro: %s is required", field)
+		}
+	}
+
+	expiresIn := externalExpiresIn(input, accessToken)
+	email := firstString(input, "email")
+	if email == "" {
+		email = externalJWTIdentity(accessToken)
+	}
+	return &Tokens{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		ExpiresIn:    expiresIn,
+		Email:        email,
+		Extra: map[string]string{
+			"kiro_auth_method":    "external_idp",
+			"kiro_profile_arn":    profileARN,
+			"kiro_region":         region,
+			"kiro_client_id":      clientID,
+			"kiro_token_endpoint": tokenEndpoint,
+			"kiro_scope":          scope,
+		},
+	}, nil
+}
+
+func KiroExternalIDPRefresh(ctx context.Context, refreshToken string, metadata map[string]string) (*Tokens, error) {
+	if strings.TrimSpace(refreshToken) == "" {
+		return nil, fmt.Errorf("kiro: no refresh token")
+	}
+	clientID := strings.TrimSpace(metadata["kiro_client_id"])
+	if clientID == "" {
+		return nil, fmt.Errorf("kiro: client id is required for external_idp refresh")
+	}
+	tokenEndpoint, err := validateMicrosoftTokenEndpoint(metadata["kiro_token_endpoint"])
+	if err != nil {
+		return nil, err
+	}
+	scope := normalizeKiroScope(metadata["kiro_scope"])
+	if scope == "" {
+		return nil, fmt.Errorf("kiro: scope is required for external_idp refresh")
+	}
+
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"refresh_token": {refreshToken},
+		"scope":         {scope},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("kiro: build external_idp refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("kiro: external_idp refresh request: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("kiro: read external_idp refresh response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("kiro: external_idp refresh failed (%d): %s", resp.StatusCode, truncate(raw, 300))
+	}
+	var parsed struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("kiro: parse external_idp refresh response: %w", err)
+	}
+	if strings.TrimSpace(parsed.AccessToken) == "" {
+		return nil, fmt.Errorf("kiro: external_idp refresh response missing access token")
+	}
+	if parsed.RefreshToken == "" {
+		parsed.RefreshToken = refreshToken
+	}
+	if parsed.ExpiresIn <= 0 {
+		parsed.ExpiresIn = kiroExternalDefaultExpiry
+	}
+	return &Tokens{AccessToken: parsed.AccessToken, RefreshToken: parsed.RefreshToken, ExpiresIn: parsed.ExpiresIn}, nil
+}
+
+func validateMicrosoftTokenEndpoint(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("kiro: token_endpoint is required")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return "", fmt.Errorf("kiro: token_endpoint must be a valid HTTPS URL")
+	}
+	if parsed.User != nil || !microsoftTokenEndpointHosts[strings.ToLower(parsed.Hostname())] {
+		return "", fmt.Errorf("kiro: token_endpoint must be a Microsoft login endpoint")
+	}
+	return parsed.String(), nil
+}
+
+func normalizeKiroScope(value any) string {
+	switch scope := value.(type) {
+	case string:
+		return strings.Join(strings.Fields(scope), " ")
+	case []any:
+		parts := make([]string, 0, len(scope))
+		for _, entry := range scope {
+			if item, ok := entry.(string); ok && strings.TrimSpace(item) != "" {
+				parts = append(parts, strings.TrimSpace(item))
+			}
+		}
+		return strings.Join(parts, " ")
+	default:
+		return ""
+	}
+}
+
+func externalExpiresIn(input map[string]any, accessToken string) int {
+	now := time.Now()
+	if value := firstValue(input, "expired", "expires_at", "expiresAt"); value != nil {
+		var expiry time.Time
+		switch typed := value.(type) {
+		case string:
+			expiry, _ = time.Parse(time.RFC3339, typed)
+			if expiry.IsZero() {
+				if n, err := strconv.ParseInt(typed, 10, 64); err == nil {
+					expiry = unixExpiry(n)
+				}
+			}
+		case float64:
+			expiry = unixExpiry(int64(typed))
+		}
+		if !expiry.IsZero() {
+			return max(1, int(time.Until(expiry).Seconds()))
+		}
+	}
+	if value := firstValue(input, "expires_in", "expiresIn"); value != nil {
+		switch typed := value.(type) {
+		case float64:
+			if typed > 0 {
+				return int(typed)
+			}
+		case string:
+			if n, err := strconv.Atoi(typed); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+	if payload := decodeExternalJWT(accessToken); payload != nil {
+		if exp, ok := payload["exp"].(float64); ok {
+			return max(1, int(time.Unix(int64(exp), 0).Sub(now).Seconds()))
+		}
+	}
+	return kiroExternalDefaultExpiry
+}
+
+func unixExpiry(value int64) time.Time {
+	if value > 1_000_000_000_000 {
+		return time.UnixMilli(value)
+	}
+	return time.Unix(value, 0)
+}
+
+func externalJWTIdentity(token string) string {
+	payload := decodeExternalJWT(token)
+	for _, key := range []string{"email", "preferred_username", "upn", "sub"} {
+		if value, ok := payload[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func decodeExternalJWT(token string) map[string]any {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil
+	}
+	var payload map[string]any
+	if json.NewDecoder(bytes.NewReader(raw)).Decode(&payload) != nil {
+		return nil
+	}
+	return payload
+}
+
+func firstString(input map[string]any, keys ...string) string {
+	value := firstValue(input, keys...)
+	text, _ := value.(string)
+	return strings.TrimSpace(text)
+}
+
+func firstValue(input map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := input[key]; ok && value != nil {
+			return value
+		}
+	}
+	return nil
+}

--- a/backend/internal/oauth/kiro_external_test.go
+++ b/backend/internal/oauth/kiro_external_test.go
@@ -1,0 +1,91 @@
+package oauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestNormalizeKiroExternalIDPAuth(t *testing.T) {
+	payload, _ := json.Marshal(map[string]any{
+		"preferred_username": "user@example.com",
+		"exp":                4_102_444_800,
+	})
+	jwt := "header." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+	raw, _ := json.Marshal(map[string]any{"json": `{
+		"auth_method":"external_idp",
+		"access_token":"` + jwt + `",
+		"refresh_token":"refresh-token",
+		"client_id":"client-id",
+		"token_endpoint":"https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+		"profile_arn":"arn:aws:codewhisperer:us-east-1:123:profile/ABC",
+		"region":"us-east-1",
+		"scopes":["offline_access","api://client/conversations"]
+	}`})
+
+	tokens, err := NormalizeKiroExternalIDPAuth(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokens.AccessToken != jwt || tokens.RefreshToken != "refresh-token" {
+		t.Fatalf("tokens were not normalized: %+v", tokens)
+	}
+	if tokens.Email != "user@example.com" {
+		t.Fatalf("email = %q", tokens.Email)
+	}
+	if tokens.Extra["kiro_auth_method"] != "external_idp" || tokens.Extra["kiro_scope"] != "offline_access api://client/conversations" {
+		t.Fatalf("metadata was not normalized: %+v", tokens.Extra)
+	}
+}
+
+func TestNormalizeKiroExternalIDPAuthRejectsEndpoint(t *testing.T) {
+	raw := []byte(`{"auth_method":"external_idp","access_token":"a","refresh_token":"r","client_id":"c","token_endpoint":"https://example.com/token","profile_arn":"arn","scopes":"offline_access"}`)
+	if _, err := NormalizeKiroExternalIDPAuth(raw); err == nil || !strings.Contains(err.Error(), "Microsoft") {
+		t.Fatalf("expected Microsoft endpoint error, got %v", err)
+	}
+}
+
+func TestKiroExternalIDPRefresh(t *testing.T) {
+	original := httpClient
+	t.Cleanup(func() { httpClient = original })
+	httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host != "login.microsoftonline.com" {
+			t.Fatalf("unexpected endpoint: %s", req.URL)
+		}
+		if req.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+			t.Fatalf("unexpected content type: %s", req.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(req.Body)
+		values := string(body)
+		for _, expected := range []string{"grant_type=refresh_token", "client_id=client-id", "refresh_token=old-token", "scope=offline_access"} {
+			if !strings.Contains(values, expected) {
+				t.Fatalf("refresh body %q missing %q", values, expected)
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"new-token","refresh_token":"new-refresh","expires_in":3600}`)),
+		}, nil
+	})}
+
+	tokens, err := KiroExternalIDPRefresh(context.Background(), "old-token", map[string]string{
+		"kiro_client_id":      "client-id",
+		"kiro_token_endpoint": "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+		"kiro_scope":          "offline_access",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokens.AccessToken != "new-token" || tokens.RefreshToken != "new-refresh" || tokens.ExpiresIn != 3600 {
+		t.Fatalf("unexpected refreshed tokens: %+v", tokens)
+	}
+}

--- a/backend/internal/oauth/manager.go
+++ b/backend/internal/oauth/manager.go
@@ -235,6 +235,9 @@ func refreshKiro(ctx context.Context, acc store.Account, refreshToken string) (*
 	if acc.Metadata != "" {
 		_ = json.Unmarshal([]byte(acc.Metadata), &meta)
 	}
+	if meta["kiro_auth_method"] == "external_idp" {
+		return KiroExternalIDPRefresh(ctx, refreshToken, meta)
+	}
 	clientID := meta["kiro_client_id"]
 	clientSecret := meta["kiro_client_secret"]
 	if clientID != "" && clientSecret != "" {

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -424,21 +424,24 @@ type StreamResult struct {
 	DirectCompleteFunc func(error)
 }
 
-// maxRateLimitRetries is how many times the pipeline will re-plan and retry
-// after a rate-limit (429) error, waiting for the per-account cooldown to
-// expire between attempts. With a single account this avoids giving up
-// immediately on a transient 429.
+// maxRateLimitRetries is how many times the pipeline will re-plan and retry a
+// transient rate-limit that has no explicit upstream reset time. Providers with
+// account-wide limits can opt out so one inbound request is never amplified.
 const maxRateLimitRetries = 3
+
+func shouldRetryStreamRateLimit(pe *core.ProviderError, retries int) bool {
+	return pe != nil && pe.Kind == core.ErrRateLimit && pe.Fallbackable() &&
+		pe.Provider != "kiro" && pe.RetryAfter <= 0 && retries < maxRateLimitRetries
+}
 
 // Stream runs a streaming request with fallback. Fallback applies only to the
 // connection-establishment phase; once the first attempt's channel is returned,
 // errors surface as ChunkError on that channel. Usage metering happens in a
 // goroutine that observes the final usage chunk.
 //
-// When all attempts fail with a rate-limit (429) and the error is fallbackable,
-// the pipeline re-plans after a short wait (letting the account cooldown
-// expire) and retries up to maxRateLimitRetries times. This prevents transient
-// 429s from being fatal when only a single account is configured.
+// When all attempts fail with a transient rate-limit (429) and the error is
+// fallbackable, the pipeline may re-plan after a short wait. Explicit upstream
+// reset times and account-wide Kiro limits are returned immediately.
 func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Options) (*StreamResult, error) {
 	requestStarted := time.Now()
 	if err := p.preflight(ctx, req, opts); err != nil {
@@ -493,9 +496,11 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 			return sr, nil
 		}
 
-		// Only retry on rate-limit errors that are still fallbackable.
+		// Never turn an account-wide Kiro limit into another upstream request.
+		// An explicit reset time is also authoritative and must be returned to the
+		// caller instead of being replaced by this short local retry loop.
 		pe := providerErrorForAttempt(sErr, lastAttempt)
-		if pe.Kind != core.ErrRateLimit || !pe.Fallbackable() || rlRetries >= maxRateLimitRetries {
+		if !shouldRetryStreamRateLimit(pe, rlRetries) {
 			release(0)
 			if !budgetReleased {
 				p.budgetRelease(scope)

--- a/backend/internal/pipeline/pipeline_test.go
+++ b/backend/internal/pipeline/pipeline_test.go
@@ -2,9 +2,33 @@ package pipeline
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
+
+func TestShouldRetryStreamRateLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		error   *core.ProviderError
+		retries int
+		want    bool
+	}{
+		{name: "transient other provider", error: &core.ProviderError{Kind: core.ErrRateLimit, Provider: "openai"}, want: true},
+		{name: "kiro account limit", error: &core.ProviderError{Kind: core.ErrRateLimit, Provider: "kiro"}, want: false},
+		{name: "explicit reset", error: &core.ProviderError{Kind: core.ErrRateLimit, Provider: "openai", RetryAfter: time.Minute}, want: false},
+		{name: "retry budget exhausted", error: &core.ProviderError{Kind: core.ErrRateLimit, Provider: "openai"}, retries: maxRateLimitRetries, want: false},
+		{name: "not a rate limit", error: &core.ProviderError{Kind: core.ErrUpstream, Provider: "openai"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRetryStreamRateLimit(tt.error, tt.retries); got != tt.want {
+				t.Fatalf("shouldRetryStreamRateLimit() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestExtractUsageFromStream_OpenAI(t *testing.T) {
 	// OpenAI format: usage in the last chunk before [DONE].

--- a/backend/internal/store/repo_pools.go
+++ b/backend/internal/store/repo_pools.go
@@ -17,7 +17,7 @@ type ProxyPool struct {
 	NoProxy    string
 	Strict     bool
 	IsActive   bool
-	TestStatus string // unknown | active | error
+	TestStatus string // unknown | testing | active | error
 	LastTested *time.Time
 	LastError  string
 	CreatedAt  time.Time

--- a/frontend/src/components/KiroConnectModal.tsx
+++ b/frontend/src/components/KiroConnectModal.tsx
@@ -5,7 +5,7 @@ import { api, type DeviceCode } from "../lib/api";
 import { Button, Input, Field, ErrorBanner } from "./ui";
 import { useToast } from "./Toast";
 
-type Method = "builder-id" | "idc" | "import" | "api-key";
+type Method = "builder-id" | "idc" | "import" | "cli-proxy" | "api-key";
 
 
 // KiroConnectModal implements the "Connect Kiro" flow: pick an auth method,
@@ -61,6 +61,7 @@ export function KiroConnectModal({ onClose }: { onClose: () => void }) {
         {method === "builder-id" && <DeviceFlow method="builder-id" onClose={onClose} />}
         {method === "idc" && <IDCFlow onClose={onClose} />}
         {method === "import" && <ImportFlow onClose={onClose} />}
+        {method === "cli-proxy" && <CLIProxyImportFlow onClose={onClose} />}
         {method === "api-key" && <APIKeyFlow onClose={onClose} />}
       </div>
 
@@ -90,6 +91,12 @@ function MethodSelect({ onSelect }: { onSelect: (m: Method) => void }) {
         title="Import Token"
         description="Paste refresh token from Kiro IDE."
         onClick={() => onSelect("import")}
+      />
+      <MethodCard
+        icon={FileUp}
+        title="Import CLIProxy API JSON"
+        description="Paste an external_idp auth JSON from a Microsoft login."
+        onClick={() => onSelect("cli-proxy")}
       />
       <MethodCard
         icon={KeyRound}
@@ -402,6 +409,61 @@ function ImportFlow({ onClose }: { onClose: () => void }) {
       {error && <ErrorBanner message={error} />}
       <Button className="w-full" onClick={submit} disabled={busy || !token.trim()}>
         {busy ? "Importing…" : "Import Token"}
+      </Button>
+    </div>
+  );
+}
+
+function CLIProxyImportFlow({ onClose }: { onClose: () => void }) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const [rawJSON, setRawJSON] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [done, setDone] = useState(false);
+
+  const submit = async () => {
+    if (!rawJSON.trim()) {
+      setError("Please paste the auth JSON");
+      return;
+    }
+    setBusy(true);
+    setError("");
+    try {
+      await api.kiroImportCLIProxy(rawJSON.trim());
+      setDone(true);
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      toast.success("Kiro connected", "External identity credential imported successfully.");
+      setTimeout(onClose, 1200);
+    } catch (e) {
+      setError((e as Error).message);
+      toast.error("Import failed", (e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (done) {
+    return <div className="px-6 py-6 text-sm">Connected. Refreshing accounts…</div>;
+  }
+
+  return (
+    <div className="space-y-4 px-6 py-5">
+      <p className="text-sm text-[var(--text-muted)]">
+        Paste the Kiro auth JSON containing <span className="font-mono">auth_method=external_idp</span>.
+        Only Microsoft login token endpoints are accepted.
+      </p>
+      <Field label="CLIProxy API Auth JSON">
+        <textarea
+          value={rawJSON}
+          onChange={(event) => setRawJSON(event.target.value)}
+          placeholder={'{"auth_method":"external_idp","access_token":"...","refresh_token":"...","client_id":"...","token_endpoint":"https://login.microsoftonline.com/.../oauth2/v2.0/token","profile_arn":"...","scopes":"..."}'}
+          className="min-h-44 w-full rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] p-3 font-mono text-xs focus:border-accent-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/30"
+        />
+      </Field>
+      {error && <ErrorBanner message={error} />}
+      <Button className="w-full" onClick={submit} disabled={busy || !rawJSON.trim()}>
+        {busy ? "Importing…" : "Import CLIProxy API JSON"}
       </Button>
     </div>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -670,7 +670,7 @@ export interface ProxyPool {
   no_proxy: string;
   strict: boolean;
   is_active: boolean;
-  test_status: string; // unknown | active | error
+  test_status: string; // unknown | testing | active | error
   last_tested?: string;
   last_error?: string;
 }
@@ -1332,6 +1332,8 @@ export const api = {
   listProxyPools: () => request<{ pools: ProxyPool[] }>("GET", "/proxy-pools"),
   createProxyPool: (input: { name: string; type?: string; proxy_url: string; no_proxy?: string; strict?: boolean; is_active?: boolean }) =>
     request<{ id: string }>("POST", "/proxy-pools", input),
+  deployCloudflareRelay: (input: { account_id: string; api_token: string; project_name?: string }) =>
+    request<{ id: string; name: string; deploy_url: string; test_status: string }>("POST", "/proxy-pools/cloudflare-deploy", input),
   updateProxyPool: (id: string, patch: { name?: string; proxy_url?: string; no_proxy?: string; strict?: boolean; is_active?: boolean }) =>
     request<void>("PATCH", `/proxy-pools/${id}`, patch),
   deleteProxyPool: (id: string) => request<void>("DELETE", `/proxy-pools/${id}`),
@@ -1410,7 +1412,7 @@ export const api = {
 
   // Proxy pool test.
   testProxyPool: (id: string) =>
-    request<{ status: string; last_tested?: string }>("POST", `/proxy-pools/${id}/test`),
+    request<{ status: string; last_tested?: string; elapsed_ms?: number; error?: string }>("POST", `/proxy-pools/${id}/test`),
 
   // OAuth provider connections.
   oauthProviders: () => request<{ providers: OAuthProvider[] }>("GET", "/oauth/providers"),
@@ -1454,6 +1456,8 @@ export const api = {
       refresh_token: refreshToken,
       label,
     }),
+  kiroImportCLIProxy: (json: string) =>
+    request<{ id: string; provider: string; email?: string }>("POST", "/kiro/import-cli-proxy", { json }),
 
 
   // Qoder connect flow (PKCE device-token poll). Mounted under /qoder (not

--- a/frontend/src/pages/ProxyPools.tsx
+++ b/frontend/src/pages/ProxyPools.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Network, Plus, Trash2, Play, Upload, Pencil, X, Check,
   ToggleLeft, ToggleRight, Loader2, CheckCircle2, XCircle, CircleDot,
-  RefreshCw, AlertCircle, FileText,
+  RefreshCw, AlertCircle, FileText, ExternalLink, Cloud, Zap, Globe,
 } from "lucide-react";
 import { api, type ProxyPool } from "../lib/api";
 import { PageHeader } from "../components/Layout";
@@ -16,10 +16,15 @@ import {
 export function ProxyPoolsPage() {
   const qc = useQueryClient();
   const toast = useToast();
-  const pools = useQuery({ queryKey: ["proxy-pools"], queryFn: () => api.listProxyPools() });
+  const pools = useQuery({
+    queryKey: ["proxy-pools"],
+    queryFn: () => api.listProxyPools(),
+    refetchInterval: (query) => query.state.data?.pools.some((pool) => pool.test_status === "testing") ? 2000 : false,
+  });
 
   const [showCreate, setShowCreate] = useState(false);
   const [showBatch, setShowBatch] = useState(false);
+  const [showCloudflareDeploy, setShowCloudflareDeploy] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
 
   // Selection state
@@ -44,10 +49,11 @@ export function ProxyPoolsPage() {
     mutationFn: (id: string) => api.testProxyPool(id),
     onSuccess: (data) => {
       qc.invalidateQueries({ queryKey: ["proxy-pools"] });
-      toast.success(
-        "Connectivity test passed",
-        `Proxy is reachable and responding. Status: ${data.status}.`,
-      );
+      if (data.status === "active") {
+        toast.success("Connectivity test passed", "Proxy is reachable and responding.");
+      } else {
+        toast.error("Connectivity test failed", data.error || `Proxy status: ${data.status}`);
+      }
     },
     onError: (e: Error) => toast.error("Connectivity test failed", e.message),
   });
@@ -94,6 +100,10 @@ export function ProxyPoolsPage() {
         description="Route upstream traffic through proxy pools for resilience and geo-distribution."
         action={
           <div className="flex items-center gap-2">
+            <Button variant="ghost" onClick={() => setShowCloudflareDeploy(true)}>
+              <Cloud className="h-4 w-4 text-orange-500" />
+              Deploy Relay
+            </Button>
             <Button variant="ghost" onClick={() => setShowBatch(!showBatch)}>
               <Upload className="h-4 w-4" />
               Batch Import
@@ -107,6 +117,7 @@ export function ProxyPoolsPage() {
       />
 
       <div className="space-y-4">
+        <CloudflareDeployModal open={showCloudflareDeploy} onClose={() => setShowCloudflareDeploy(false)} />
         {/* Create / Edit form */}
         {(showCreate || editingId) && (
           <PoolForm
@@ -213,25 +224,43 @@ function PoolRow({ pool, selected, onSelect, onEdit, onDelete, onTest, onToggle,
           <span className="text-sm font-medium">{pool.name}</span>
           <StatusBadge status={pool.test_status} />
           {!pool.is_active && <Badge tone="neutral">inactive</Badge>}
-          {pool.type !== "http" && <Badge tone="accent">{pool.type} relay</Badge>}
+          {pool.type === "cloudflare" && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-orange-100 px-2 py-0.5 text-[10px] font-medium text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
+              <Cloud className="h-3 w-3" /> cloudflare relay
+            </span>
+          )}
+          {pool.type === "vercel" && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+              <Zap className="h-3 w-3" /> vercel relay
+            </span>
+          )}
+          {pool.type === "deno" && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+              <Globe className="h-3 w-3" /> deno relay
+            </span>
+          )}
         </div>
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-[var(--text-muted)]">
           <span className="truncate font-mono">{maskUrl(pool.proxy_url)}</span>
           {pool.no_proxy && <span>no-proxy: {pool.no_proxy}</span>}
           {pool.last_tested && <span>tested {relTime(pool.last_tested)}</span>}
-          {pool.last_error && <span className="text-red-500 dark:text-red-400">{pool.last_error}</span>}
+          {pool.last_error && (
+            <span className={pool.test_status === "testing" ? "text-amber-600 dark:text-amber-400" : "text-red-500 dark:text-red-400"}>
+              {pool.last_error}
+            </span>
+          )}
           {pool.strict && <span className="font-medium">strict</span>}
         </div>
       </div>
 
       {/* Actions */}
       <div className="flex shrink-0 items-center gap-0.5">
-        <button onClick={onToggle}
-          className="rounded-lg p-1.5 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
-          title={pool.is_active ? "Deactivate" : "Activate"}>
+        <button onClick={onToggle} disabled={pool.test_status === "testing"}
+          className="rounded-lg p-1.5 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)] disabled:cursor-not-allowed disabled:opacity-50"
+          title={pool.test_status === "testing" ? "Waiting for relay readiness" : pool.is_active ? "Deactivate" : "Activate"}>
           {pool.is_active ? <ToggleRight className="h-4 w-4 text-emerald-500 dark:text-emerald-400" /> : <ToggleLeft className="h-4 w-4" />}
         </button>
-        <button onClick={onTest} disabled={testing}
+        <button onClick={onTest} disabled={testing || pool.test_status === "testing"}
           className="rounded-lg p-1.5 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]" title="Test">
           {testing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
         </button>
@@ -288,7 +317,7 @@ function PoolForm({ pool, onClose }: { pool?: ProxyPool; onClose: () => void }) 
       open
       onClose={onClose}
       title={isEdit ? "Edit Proxy Pool" : "Add Proxy Pool"}
-      subtitle={isEdit ? `Editing "${pool?.name}"` : "Configure a new proxy endpoint for upstream routing."}
+      subtitle={isEdit ? `Editing "${pool?.name}"` : "Configure a proxy endpoint for upstream routing."}
     >
       <div className="space-y-4 px-6 py-5">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -299,9 +328,11 @@ function PoolForm({ pool, onClose }: { pool?: ProxyPool; onClose: () => void }) 
             <Input value={proxyUrl} onChange={(e) => setProxyUrl(e.target.value)} placeholder="http://user:pass@host:port" className="font-mono" />
           </Field>
         </div>
+
         <Field label="No Proxy (comma-separated hosts to bypass)">
           <Input value={noProxy} onChange={(e) => setNoProxy(e.target.value)} placeholder="localhost,127.0.0.1,.internal" />
         </Field>
+
         <div className="flex items-center gap-6">
           <label className="flex items-center gap-2 text-xs">
             <input type="checkbox" checked={isActive} onChange={(e) => setIsActive(e.target.checked)}
@@ -323,6 +354,71 @@ function PoolForm({ pool, onClose }: { pool?: ProxyPool; onClose: () => void }) 
             {isEdit ? "Save changes" : "Create pool"}
           </Button>
           <Button variant="ghost" onClick={onClose}>Cancel</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function CloudflareDeployModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const [accountID, setAccountID] = useState("");
+  const [apiToken, setAPIToken] = useState("");
+  const [projectName, setProjectName] = useState("");
+
+  const deploy = useMutation({
+    mutationFn: () => api.deployCloudflareRelay({
+      account_id: accountID.trim(),
+      api_token: apiToken.trim(),
+      project_name: projectName.trim() || undefined,
+    }),
+    onSuccess: (result) => {
+      qc.invalidateQueries({ queryKey: ["proxy-pools"] });
+      toast.success("Relay deployment started", `${result.name} was deployed. Readiness is checked automatically.`);
+      setAccountID("");
+      setAPIToken("");
+      setProjectName("");
+      onClose();
+    },
+    onError: (error: Error) => toast.error("Relay deployment failed", error.message),
+  });
+
+  return (
+    <Modal open={open} onClose={() => !deploy.isPending && onClose()} title="Deploy Cloudflare Relay">
+      <div className="space-y-4 px-6 py-5">
+        <div className="space-y-2 rounded-xl border border-orange-500/20 bg-orange-500/5 p-4 text-xs text-[var(--text-muted)]">
+          <p className="font-semibold text-[var(--text)]">Cloudflare Workers edge relay</p>
+          <p>Provider requests are forwarded through the deployed Worker and the resulting relay is added to this proxy pool automatically.</p>
+          <ol className="list-decimal space-y-1 pl-4">
+            <li>Create an API token with Account → Workers Scripts → Edit.</li>
+            <li>Select the account that owns the Worker.</li>
+            <li>Ensure the account has a workers.dev subdomain configured.</li>
+          </ol>
+        </div>
+        <Field label="Account ID">
+          <Input value={accountID} onChange={(event) => setAccountID(event.target.value)} placeholder="Cloudflare account ID" className="font-mono" />
+        </Field>
+        <Field label="API Token">
+          <Input type="password" value={apiToken} onChange={(event) => setAPIToken(event.target.value)} placeholder="Workers Scripts: Edit token" className="font-mono" />
+          <a
+            href="https://dash.cloudflare.com/profile/api-tokens"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-1.5 inline-flex items-center gap-1 text-xs font-medium text-orange-500 hover:underline"
+          >
+            Get Cloudflare API token <ExternalLink className="h-3 w-3" />
+          </a>
+        </Field>
+        <Field label="Worker Name (optional)">
+          <Input value={projectName} onChange={(event) => setProjectName(event.target.value.toLowerCase())} placeholder="my-relay" className="font-mono" />
+        </Field>
+        <div className="flex gap-2 border-t border-[var(--border)] pt-4">
+          <Button onClick={() => deploy.mutate()} disabled={!accountID.trim() || !apiToken.trim() || deploy.isPending}>
+            {deploy.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Cloud className="h-4 w-4" />}
+            {deploy.isPending ? "Deploying…" : "Deploy Worker"}
+          </Button>
+          <Button variant="ghost" onClick={onClose} disabled={deploy.isPending}>Cancel</Button>
         </div>
       </div>
     </Modal>
@@ -498,6 +594,13 @@ function BatchImport({ onClose }: { onClose: () => void }) {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function StatusBadge({ status }: { status: string }) {
+  if (status === "testing") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+        <Loader2 className="h-3 w-3 animate-spin" /> deploying
+      </span>
+    );
+  }
   if (status === "active") {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">


### PR DESCRIPTION
## Summary

- add Cloudflare relay deployment, readiness checks, and stricter proxy pool validation
- support imported external identity credentials and regional authentication routing
- harden Kiro request scheduling, cooldown handling, metadata caching, and endpoint failover
- add regression coverage for proxy binding, credential import, relay deployment, and rate-limit behavior

## Validation

- `go test ./...`
- `npm run build`