### PR TITLE
Reject non-JSON responses from compatible connectors

### DIFF
--- a/backend/internal/connectors/anthropic.go
+++ b/backend/internal/connectors/anthropic.go
@@ -91,6 +91,13 @@ func (c *Anthropic) Validate(ctx context.Context, creds core.Credentials) error 
 	// Try GET /models first (cheap, no token cost).
 	modelsURL := base + "/models"
 	_, err := doJSONMethod(ctx, http.MethodGet, c.id, "validate", modelsURL, nil, c.headers(creds))
+	// An HTML response means the base URL points at a web frontend, not the API
+	// (e.g. a custom base URL missing the "/v1" path). Fail hard rather than
+	// falling through to the messages probe, which is skipped for custom
+	// providers and would otherwise report a false-positive success.
+	if isNonJSONResponseError(err) {
+		return fmt.Errorf("validation failed for %s: %w", c.id, err)
+	}
 	if err == nil {
 		// The official Anthropic API auth-protects GET /models, so a 200 proves
 		// the key. Anthropic-compatible third-party gateways may list models
@@ -140,7 +147,7 @@ func (c *Anthropic) messagesAuthProbe(ctx context.Context, creds core.Credential
 	if err == nil {
 		return nil
 	}
-	if validationAuthError(err) || !validationReachedUpstream(err) {
+	if isNonJSONResponseError(err) || validationAuthError(err) || !validationReachedUpstream(err) {
 		return err
 	}
 	return nil

--- a/backend/internal/connectors/connectors_test.go
+++ b/backend/internal/connectors/connectors_test.go
@@ -230,6 +230,47 @@ func TestAnthropic_Chat(t *testing.T) {
 	require.Equal(t, 7, resp.Usage.TotalTokens)
 }
 
+// TestAnthropic_Chat_HTMLResponse covers a custom anthropic-compatible base URL
+// that points at the provider's web frontend (e.g. missing the "/v1" path
+// segment). The frontend answers POST /messages with HTTP 200 and an HTML body;
+// the connector must surface an actionable error instead of a raw JSON
+// "Syntax error at index 0".
+func TestAnthropic_Chat_HTMLResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "<!doctype html>\n<html lang=\"zh-CN\"><head><title>Gateway</title></head></html>")
+	}))
+	defer srv.Close()
+
+	c := NewAnthropic("custom-anthropic-test", srv.URL)
+	_, err := c.Chat(context.Background(), textReq("claude-opus-4-8", false), core.Credentials{APIKey: "sk-x"})
+	require.Error(t, err)
+	pe := core.AsProviderError(err)
+	require.Equal(t, core.ErrUpstream, pe.Kind)
+	require.Equal(t, 0, pe.StatusCode)
+	require.Contains(t, err.Error(), "non-JSON response")
+	require.Contains(t, err.Error(), "/v1")
+	// The raw HTML must not leak into the JSON parser path.
+	require.NotContains(t, err.Error(), "Syntax error")
+}
+
+// TestAnthropic_Validate_HTMLResponse ensures validation of a custom provider
+// pointed at a web frontend fails rather than false-positively passing (the
+// frontend returns HTTP 200 HTML for both GET /models and POST /messages).
+func TestAnthropic_Validate_HTMLResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "<!doctype html><html><body>frontend</body></html>")
+	}))
+	defer srv.Close()
+
+	c := NewAnthropic("custom-anthropic-test", srv.URL)
+	err := c.Validate(context.Background(), core.Credentials{APIKey: "sk-x", BaseURL: srv.URL})
+	require.Error(t, err)
+}
+
 func TestOllama_ValidateProbesTags(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/tags", r.URL.Path)

--- a/backend/internal/connectors/httpclient.go
+++ b/backend/internal/connectors/httpclient.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -25,6 +26,13 @@ import (
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
+
+// errNonJSONResponse marks a successful HTTP response whose body was not JSON
+// (typically an HTML page from a provider's web frontend). It is set as the
+// Cause on the ProviderError returned by checkNonJSONResponse so validation can
+// distinguish it from an ordinary non-auth upstream response and fail rather
+// than false-positively accepting the credential. Test with isNonJSONResponseError.
+var errNonJSONResponse = errors.New("upstream returned a non-JSON (HTML) response")
 
 // maxResponseBodyBytes caps the size of upstream response bodies read into
 // memory. This prevents a single large response from causing an OOM spike.
@@ -156,6 +164,9 @@ func doJSON(ctx context.Context, provider, model, url string, body []byte, heade
 	if resp.StatusCode >= 400 {
 		return nil, httpStatusError(provider, model, resp, respBody)
 	}
+	if perr := checkNonJSONResponse(provider, model, resp, respBody); perr != nil {
+		return nil, perr
+	}
 	return respBody, nil
 }
 
@@ -185,6 +196,13 @@ func doJSONDecode(ctx context.Context, provider, model, url string, body []byte,
 		defer resp.Body.Close()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 		return nil, nil, httpStatusError(provider, model, resp, errBody)
+	}
+	// Guard against an HTML page (web frontend) served with HTTP 200 before
+	// handing the body to the streaming JSON decoder. Body is not buffered here,
+	// so detect by content-type only.
+	if perr := checkNonJSONResponse(provider, model, resp, nil); perr != nil {
+		resp.Body.Close()
+		return nil, nil, perr
 	}
 	dec := json.NewDecoder(resp.Body)
 	return dec, resp.Body, nil
@@ -247,6 +265,9 @@ func doJSONMethod(ctx context.Context, method, provider, model, url string, body
 	}
 	if resp.StatusCode >= 400 {
 		return nil, httpStatusError(provider, model, resp, respBody)
+	}
+	if perr := checkNonJSONResponse(provider, model, resp, respBody); perr != nil {
+		return nil, perr
 	}
 	return respBody, nil
 }
@@ -394,6 +415,13 @@ func openStream(ctx context.Context, provider, model, url string, body []byte, h
 		defer resp.Body.Close()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 		return nil, httpStatusError(provider, model, resp, errBody)
+	}
+	// An HTML page served with HTTP 200 on the stream endpoint means the base URL
+	// points at a web frontend, not the SSE API. Detect by content-type before
+	// the caller starts scanning for "data:" events (which would never arrive).
+	if perr := checkNonJSONResponse(provider, model, resp, nil); perr != nil {
+		resp.Body.Close()
+		return nil, perr
 	}
 	return resp, nil
 }
@@ -573,6 +601,51 @@ func httpStatusError(provider, model string, resp *http.Response, body []byte) e
 		}
 	}
 	return pe
+}
+
+// checkNonJSONResponse detects a successful (non-error) HTTP response whose
+// body is not JSON — almost always an HTML page served when the configured base
+// URL points at a provider's web frontend instead of its API (for example a
+// custom base URL missing the "/v1" path segment, so POST {base}/messages hits
+// the SPA and returns "<!doctype html>..." with HTTP 200). Without this guard
+// the HTML body is handed to the JSON parser, producing a confusing
+// "parse response: Syntax error at index 0" and, during validation, a false
+// positive because any non-auth HTTP response is otherwise treated as proof the
+// credential works.
+//
+// It returns a ProviderError (nil when the body looks like JSON). StatusCode is
+// deliberately left 0: no valid API response was received, so credential
+// validation must treat this as "did not reach the API" rather than a
+// key-accepted signal. Pass a nil body to check by content-type only (used on
+// paths that stream the body instead of buffering it).
+func checkNonJSONResponse(provider, model string, resp *http.Response, body []byte) *core.ProviderError {
+	ct := strings.ToLower(resp.Header.Get("Content-Type"))
+	isHTML := strings.Contains(ct, "text/html")
+	if !isHTML {
+		trimmed := bytes.TrimSpace(body)
+		// Empty/unknown bodies (e.g. header-only checks) and JSON bodies (which
+		// start with '{', '[', '"', a digit, or t/f/n) are accepted. Only an
+		// HTML document, which starts with '<', is rejected here.
+		if len(trimmed) == 0 || trimmed[0] != '<' {
+			return nil
+		}
+	}
+	return &core.ProviderError{
+		Kind:     core.ErrUpstream,
+		Provider: provider,
+		Model:    model,
+		Message: fmt.Sprintf("upstream returned a non-JSON response (HTTP %d, content-type %q); "+
+			"the base URL likely points at a web page rather than the API endpoint — "+
+			"check that it includes the API path segment (e.g. ends with /v1)",
+			resp.StatusCode, resp.Header.Get("Content-Type")),
+		Cause: errNonJSONResponse,
+	}
+}
+
+// isNonJSONResponseError reports whether err originates from a non-JSON (HTML)
+// upstream response detected by checkNonJSONResponse.
+func isNonJSONResponseError(err error) bool {
+	return errors.Is(err, errNonJSONResponse)
 }
 
 func truncateError(body []byte) string {

--- a/backend/internal/connectors/openai_compatible.go
+++ b/backend/internal/connectors/openai_compatible.go
@@ -334,6 +334,13 @@ func (c *OpenAICompatible) Validate(ctx context.Context, creds core.Credentials)
 
 	url := joinURL(c.baseURL(creds), "models")
 	_, err := doJSONMethod(ctx, http.MethodGet, c.id, "validate", url, nil, c.headers(creds))
+	// An HTML response means the base URL points at a web frontend, not the API
+	// (e.g. a custom base URL missing the "/v1" path). Fail hard rather than
+	// falling through to the chat probe, which is skipped for custom providers
+	// and would otherwise report a false-positive success.
+	if isNonJSONResponseError(err) {
+		return fmt.Errorf("validation failed for %s: %w", c.id, err)
+	}
 	if err == nil {
 		// GET /models reached the upstream. For no-auth accounts (e.g. a local
 		// gateway) reachability is all we can verify. For strict providers the
@@ -409,7 +416,7 @@ func validateProbe(ctx context.Context, provider, endpoint string, body []byte, 
 	if err == nil {
 		return nil
 	}
-	if validationAuthError(err) || !validationReachedUpstream(err) {
+	if isNonJSONResponseError(err) || validationAuthError(err) || !validationReachedUpstream(err) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Summary

- detect successful HTTP responses that contain HTML instead of JSON across buffered, decoded, and streaming connector paths
- return an actionable upstream error that points users toward a missing API path such as `/v1`
- prevent custom Anthropic-compatible and OpenAI-compatible credential validation from false-positively accepting web frontend responses
- cover Anthropic chat and credential validation against HTTP 200 HTML responses

## Test plan

- `go test ./backend/internal/connectors`

## Scope

This PR contains only connector validation changes. Provider usage, Endpoints, and API Key UI work remains isolated in #48.
