### PR TITLE
Add response integrity gate and persist conversationId per session

### DIFF
--- a/backend/internal/connectors/kiro.go
+++ b/backend/internal/connectors/kiro.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,24 @@ type Kiro struct {
 const (
 	kiroModelCacheTTL = 5 * time.Minute
 	kiroQuotaCacheTTL = 30 * time.Second
+
+	kiroShortFinalMaxChars = 800
+)
+
+var (
+	kiroRepairInstructions = map[string]string{
+		"tool":        "Retry the previous response because its tool_call wrapper was malformed. The tool name and arguments fields must both be present and non-empty.",
+		"ellipsis":    "Retry the previous response because it ended with only an ellipsis. Return the complete final answer.",
+		"short_final": "Retry the previous response because it only announced a future action without completing it. Complete the work now and return the result.",
+	}
+
+	reShortFutureActionEN = regexp.MustCompile(`(?i)^(?:(?:next|now|then)\b[\s,:-]*)?(?:i(?:'ll| will| am going to| need to)|let me)\s+(?:verify|check|confirm|validate|investigate|trace|continue|follow up|test)\b`)
+	reShortFutureActionZH = regexp.MustCompile(`^(?:(?:現在|接著|接下來|下一步)[，,:：\s]*(?:我(?:只)?(?:會|要|將|再)?\s*)?|我只再|我(?:會|要|將)(?:再|重新)?)(?:補|抓取|查|確認|驗證|追|繼續|檢查|測試)`)
+	reResultClauseEN      = regexp.MustCompile(`(?i)[:;\n]|[.!?]\s+\S|\b(?:status|checksum|response|deployment)\s+(?:is|are|was|were|matches?|equals?|returned)\b`)
+	reResultClauseZH      = regexp.MustCompile(`[。！？]\s*\S|(?:版本|狀態|回應|結果|部署|校驗碼)(?:是|為|等於|顯示)`)
+	reCompletedFinal      = regexp.MustCompile(`(?i)已(?:經)?完成|完成(?:了|驗證|確認)|修復完成|確認無誤|驗證(?:完成|通過)|測試(?:均)?通過|結論|總結|\b(?:done|completed|fixed|verified|confirmed|passed|in conclusion|summary)\b|\b(?:is|are) complete\b`)
+	reResultEvidence      = regexp.MustCompile(`(?i)顯示|發現|因此|成功|失敗|正常|無錯誤|沒有錯誤|\b(?:found|shows?|showed|because|therefore|succeeded|failed|healthy|green|no errors?)\b`)
+	reUserWait            = regexp.MustCompile(`(?i)請(?:你|先)|你(?:先|需要|可以|提供|確認|批准|允許)|等待(?:你|使用者)|等你|核准|同意|授權|\b(?:after|when|once)\s+you\b|\byour\s+(?:approval|confirmation|permission|input)\b|\bwait(?:ing)?\s+for\s+you\b|\bplease\s+(?:approve|confirm|provide|send)\b`)
 )
 
 type kiroModelCacheEntry struct {
@@ -853,103 +872,242 @@ func (c *Kiro) Chat(ctx context.Context, req *core.ChatRequest, creds core.Crede
 }
 
 // Stream performs a streaming call, parsing the AWS EventStream into canonical
-// chunks.
+// chunks. After the first response is fully buffered it is passed through the
+// integrity gate: if the model returned only an ellipsis, a short future-action
+// announcement, or a malformed tool call, a single retry is issued with a
+// repair instruction appended to the system prompt. The buffered chunks of the
+// winning attempt are then forwarded to the caller.
 func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Credentials, cfg core.StreamConfig) (<-chan core.StreamChunk, error) {
 	releaseAccount, err := c.acquireAccountSlot(ctx, creds, req.Model)
 	if err != nil {
 		return nil, err
 	}
 
-	// Account-bound auth uses only its resolved profile ARN; OAuth/social auth
-	// can fall back to the shared profile for its auth method.
 	profileArn := kiroResolveProfileArn(creds)
 	body, err := c.codec.RenderRequestWithProfile(req, profileArn)
-
 	if err != nil {
 		releaseAccount()
 		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}
 	}
 
-	// Kiro returns a binary eventstream, not SSE; use a plain streaming POST.
-	// Try an alternate endpoint only for transport or edge failures. Account-level
-	// rejections such as 429 are surfaced immediately so cooldown can take effect.
 	resp, err := c.openStreamWithFailover(ctx, req.Model, body, c.headers(creds), c.endpoints(creds))
 	if err != nil {
 		releaseAccount()
-		// On an upstream rejection (e.g. CodeWhisperer's 400 "Improperly formed
-		// request"), the offending field is opaque. When KIRO_DEBUG is set, dump
-		// the rendered request body so the exact payload can be inspected. The
-		// body may contain prompt content, so this is opt-in only.
 		return nil, err
 	}
 
 	out := make(chan core.StreamChunk, 16)
 	go func() {
 		defer close(out)
-		defer resp.Body.Close()
 		defer releaseAccount()
 
-		ttft := newTTFTTracker(cfg)
-
-		parser := newEventStreamParser(resp.Body)
-		seenTools := map[string]bool{}
-		hasTool := false
-
-		// Kiro does not always emit a metricsEvent/usageEvent frame (varies by
-		// model and backend). Track whether real usage arrived and how much
-		// text we streamed so we can synthesize an estimate at EOF — otherwise
-		// the request bills upstream credit but records zero tokens locally.
-		usageSeen := false
-		outputChars := 0
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			frame, err := parser.next()
-			if err != nil {
-				if err != errEventStreamEOF {
-					out <- core.StreamChunk{
-						Type: core.ChunkError,
-						Err:  &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err},
-					}
-				}
-				break
-			}
-			if frame == nil {
-				continue
-			}
-
-			for _, ch := range kiroFrameToChunks(frame, seenTools, &hasTool) {
-				if ch.Type == core.ChunkUsage {
-					usageSeen = true
-				}
-				if ch.Type == core.ChunkText || ch.Type == core.ChunkThinking {
-					outputChars += len(ch.Delta)
-				}
-				ttft.maybeReport(ch)
+		// Drain the first attempt into a buffer so the integrity gate can
+		// inspect the full response before committing to the client.
+		firstCh := make(chan core.StreamChunk, 64)
+		go func() {
+			defer close(firstCh)
+			defer resp.Body.Close()
+			ttft := newTTFTTracker(cfg)
+			parser := newEventStreamParser(resp.Body)
+			seenTools := map[string]bool{}
+			hasTool := false
+			usageSeen := false
+			outputChars := 0
+			for {
 				select {
-				case out <- ch:
 				case <-ctx.Done():
 					return
+				default:
+				}
+				frame, ferr := parser.next()
+				if ferr != nil {
+					if ferr != errEventStreamEOF {
+						firstCh <- core.StreamChunk{
+							Type: core.ChunkError,
+							Err:  &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Model: req.Model, Message: ferr.Error(), Cause: ferr},
+						}
+					}
+					break
+				}
+				if frame == nil {
+					continue
+				}
+				for _, ch := range kiroFrameToChunks(frame, seenTools, &hasTool) {
+					if ch.Type == core.ChunkUsage {
+						usageSeen = true
+					}
+					if ch.Type == core.ChunkText || ch.Type == core.ChunkThinking {
+						outputChars += len(ch.Delta)
+					}
+					ttft.maybeReport(ch)
+					select {
+					case firstCh <- ch:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+			if !usageSeen {
+				if u := estimateKiroUsage(req, outputChars); u != nil {
+					select {
+					case firstCh <- core.StreamChunk{Type: core.ChunkUsage, Usage: u}:
+					case <-ctx.Done():
+					}
+				}
+			}
+		}()
+
+		chunks, content, hasTool, toolErr := drainKiroStream(firstCh)
+
+		// Integrity gate: check whether a retry is warranted.
+		kind := kiroIntegrityKind(content, hasTool, toolErr)
+		if kind != "" {
+			repairedReq := kiroAppendRepair(req, kind)
+			repairedBody, rerr := c.codec.RenderRequestWithProfile(repairedReq, profileArn)
+			if rerr == nil {
+				resp2, rerr2 := c.openStreamWithFailover(ctx, req.Model, repairedBody, c.headers(creds), c.endpoints(creds))
+				if rerr2 == nil {
+					retryCh := make(chan core.StreamChunk, 64)
+					go func() {
+						defer close(retryCh)
+						defer resp2.Body.Close()
+						parser2 := newEventStreamParser(resp2.Body)
+						seenTools2 := map[string]bool{}
+						hasTool2 := false
+						usageSeen2 := false
+						outputChars2 := 0
+						for {
+							select {
+							case <-ctx.Done():
+								return
+							default:
+							}
+							frame, ferr := parser2.next()
+							if ferr != nil {
+								if ferr != errEventStreamEOF {
+									retryCh <- core.StreamChunk{
+										Type: core.ChunkError,
+										Err:  &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Model: req.Model, Message: ferr.Error(), Cause: ferr},
+									}
+								}
+								break
+							}
+							if frame == nil {
+								continue
+							}
+							for _, ch := range kiroFrameToChunks(frame, seenTools2, &hasTool2) {
+								if ch.Type == core.ChunkUsage {
+									usageSeen2 = true
+								}
+								if ch.Type == core.ChunkText || ch.Type == core.ChunkThinking {
+									outputChars2 += len(ch.Delta)
+								}
+								select {
+								case retryCh <- ch:
+								case <-ctx.Done():
+									return
+								}
+							}
+						}
+						if !usageSeen2 {
+							if u := estimateKiroUsage(repairedReq, outputChars2); u != nil {
+								select {
+								case retryCh <- core.StreamChunk{Type: core.ChunkUsage, Usage: u}:
+								case <-ctx.Done():
+								}
+							}
+						}
+					}()
+					retryChunks, _, _, _ := drainKiroStream(retryCh)
+					if len(retryChunks) > 0 {
+						chunks = retryChunks
+					}
 				}
 			}
 		}
 
-		if !usageSeen {
-			if u := estimateKiroUsage(req, outputChars); u != nil {
-				select {
-				case out <- core.StreamChunk{Type: core.ChunkUsage, Usage: u}:
-				case <-ctx.Done():
-					return
-				}
+		// Forward the winning buffer to the caller.
+		for _, ch := range chunks {
+			select {
+			case out <- ch:
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
 	return out, nil
+}
+
+// kiroIntegrityKind inspects accumulated stream output and returns the repair
+// kind needed ("ellipsis", "short_final", "tool"), or "" when the response is
+// acceptable. hasTool indicates a tool call was present; toolErr is set when a
+// tool payload was malformed.
+func kiroIntegrityKind(content string, hasTool bool, toolErr string) string {
+	if toolErr != "" {
+		return "tool"
+	}
+	text := strings.TrimSpace(strings.ReplaceAll(content, "\u2019", "'"))
+	if text == "..." || text == "\u2026" {
+		return "ellipsis"
+	}
+	if hasTool || len([]rune(text)) > kiroShortFinalMaxChars {
+		return ""
+	}
+	if reCompletedFinal.MatchString(text) || reResultEvidence.MatchString(text) || reUserWait.MatchString(text) {
+		return ""
+	}
+	isEN := reShortFutureActionEN.MatchString(text)
+	isZH := reShortFutureActionZH.MatchString(text)
+	if isEN && reResultClauseEN.MatchString(text) {
+		return ""
+	}
+	if isZH && reResultClauseZH.MatchString(text) {
+		return ""
+	}
+	if isEN || isZH {
+		return "short_final"
+	}
+	return ""
+}
+
+// kiroAppendRepair returns a copy of req with the repair instruction appended
+// to the system prompt.
+func kiroAppendRepair(req *core.ChatRequest, kind string) *core.ChatRequest {
+	instruction, ok := kiroRepairInstructions[kind]
+	if !ok {
+		instruction = "Retry the previous incomplete response."
+	}
+	copy := *req
+	if copy.System != "" {
+		copy.System = copy.System + "\n\n" + instruction
+	} else {
+		copy.System = instruction
+	}
+	return &copy
+}
+
+// drainKiroStream drains a stream channel into a buffer slice and tracks
+// content/tool state needed by the integrity gate. Returns collected chunks,
+// accumulated text content, whether a tool call was seen, and any tool error.
+func drainKiroStream(ch <-chan core.StreamChunk) ([]core.StreamChunk, string, bool, string) {
+	var chunks []core.StreamChunk
+	var content strings.Builder
+	hasTool := false
+	toolErr := ""
+	for c := range ch {
+		chunks = append(chunks, c)
+		switch c.Type {
+		case core.ChunkText:
+			content.WriteString(c.Delta)
+		case core.ChunkToolCall:
+			hasTool = true
+		case core.ChunkError:
+			if c.Err != nil {
+				toolErr = c.Err.Error()
+			}
+		}
+	}
+	return chunks, content.String(), hasTool, toolErr
 }
 
 // estimateKiroUsage produces a best-effort token estimate for a Kiro response

--- a/backend/internal/connectors/kiro.go
+++ b/backend/internal/connectors/kiro.go
@@ -871,6 +871,67 @@ func (c *Kiro) Chat(ctx context.Context, req *core.ChatRequest, creds core.Crede
 	return &core.ChatResponse{Model: req.Model, Message: msg, FinishReason: finish, Usage: usage}, nil
 }
 
+// pipeKiroResponse reads an HTTP eventstream response into a buffered channel,
+// converting frames to canonical chunks. The caller is responsible for closing
+// resp.Body after draining the returned channel.
+func (c *Kiro) pipeKiroResponse(ctx context.Context, resp *http.Response, req *core.ChatRequest, ttft *ttftTracker) <-chan core.StreamChunk {
+	ch := make(chan core.StreamChunk, 64)
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+		parser := newEventStreamParser(resp.Body)
+		seenTools := map[string]bool{}
+		hasTool := false
+		usageSeen := false
+		outputChars := 0
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			frame, ferr := parser.next()
+			if ferr != nil {
+				if ferr != errEventStreamEOF {
+					ch <- core.StreamChunk{
+						Type: core.ChunkError,
+						Err:  &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Model: req.Model, Message: ferr.Error(), Cause: ferr},
+					}
+				}
+				break
+			}
+			if frame == nil {
+				continue
+			}
+			for _, chunk := range kiroFrameToChunks(frame, seenTools, &hasTool) {
+				if chunk.Type == core.ChunkUsage {
+					usageSeen = true
+				}
+				if chunk.Type == core.ChunkText || chunk.Type == core.ChunkThinking {
+					outputChars += len(chunk.Delta)
+				}
+				if ttft != nil {
+					ttft.maybeReport(chunk)
+				}
+				select {
+				case ch <- chunk:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		if !usageSeen {
+			if u := estimateKiroUsage(req, outputChars); u != nil {
+				select {
+				case ch <- core.StreamChunk{Type: core.ChunkUsage, Usage: u}:
+				case <-ctx.Done():
+				}
+			}
+		}
+	}()
+	return ch
+}
+
 // Stream performs a streaming call, parsing the AWS EventStream into canonical
 // chunks. After the first response is fully buffered it is passed through the
 // integrity gate: if the model returned only an ellipsis, a short future-action
@@ -901,65 +962,9 @@ func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cre
 		defer close(out)
 		defer releaseAccount()
 
-		// Drain the first attempt into a buffer so the integrity gate can
-		// inspect the full response before committing to the client.
-		firstCh := make(chan core.StreamChunk, 64)
-		go func() {
-			defer close(firstCh)
-			defer resp.Body.Close()
-			ttft := newTTFTTracker(cfg)
-			parser := newEventStreamParser(resp.Body)
-			seenTools := map[string]bool{}
-			hasTool := false
-			usageSeen := false
-			outputChars := 0
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-				}
-				frame, ferr := parser.next()
-				if ferr != nil {
-					if ferr != errEventStreamEOF {
-						firstCh <- core.StreamChunk{
-							Type: core.ChunkError,
-							Err:  &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Model: req.Model, Message: ferr.Error(), Cause: ferr},
-						}
-					}
-					break
-				}
-				if frame == nil {
-					continue
-				}
-				for _, ch := range kiroFrameToChunks(frame, seenTools, &hasTool) {
-					if ch.Type == core.ChunkUsage {
-						usageSeen = true
-					}
-					if ch.Type == core.ChunkText || ch.Type == core.ChunkThinking {
-						outputChars += len(ch.Delta)
-					}
-					ttft.maybeReport(ch)
-					select {
-					case firstCh <- ch:
-					case <-ctx.Done():
-						return
-					}
-				}
-			}
-			if !usageSeen {
-				if u := estimateKiroUsage(req, outputChars); u != nil {
-					select {
-					case firstCh <- core.StreamChunk{Type: core.ChunkUsage, Usage: u}:
-					case <-ctx.Done():
-					}
-				}
-			}
-		}()
+		ttft := newTTFTTracker(cfg)
+		chunks, content, hasTool, toolErr := drainKiroStream(c.pipeKiroResponse(ctx, resp, req, ttft))
 
-		chunks, content, hasTool, toolErr := drainKiroStream(firstCh)
-
-		// Integrity gate: check whether a retry is warranted.
 		kind := kiroIntegrityKind(content, hasTool, toolErr)
 		if kind != "" {
 			repairedReq := kiroAppendRepair(req, kind)
@@ -967,58 +972,7 @@ func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cre
 			if rerr == nil {
 				resp2, rerr2 := c.openStreamWithFailover(ctx, req.Model, repairedBody, c.headers(creds), c.endpoints(creds))
 				if rerr2 == nil {
-					retryCh := make(chan core.StreamChunk, 64)
-					go func() {
-						defer close(retryCh)
-						defer resp2.Body.Close()
-						parser2 := newEventStreamParser(resp2.Body)
-						seenTools2 := map[string]bool{}
-						hasTool2 := false
-						usageSeen2 := false
-						outputChars2 := 0
-						for {
-							select {
-							case <-ctx.Done():
-								return
-							default:
-							}
-							frame, ferr := parser2.next()
-							if ferr != nil {
-								if ferr != errEventStreamEOF {
-									retryCh <- core.StreamChunk{
-										Type: core.ChunkError,
-										Err:  &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Model: req.Model, Message: ferr.Error(), Cause: ferr},
-									}
-								}
-								break
-							}
-							if frame == nil {
-								continue
-							}
-							for _, ch := range kiroFrameToChunks(frame, seenTools2, &hasTool2) {
-								if ch.Type == core.ChunkUsage {
-									usageSeen2 = true
-								}
-								if ch.Type == core.ChunkText || ch.Type == core.ChunkThinking {
-									outputChars2 += len(ch.Delta)
-								}
-								select {
-								case retryCh <- ch:
-								case <-ctx.Done():
-									return
-								}
-							}
-						}
-						if !usageSeen2 {
-							if u := estimateKiroUsage(repairedReq, outputChars2); u != nil {
-								select {
-								case retryCh <- core.StreamChunk{Type: core.ChunkUsage, Usage: u}:
-								case <-ctx.Done():
-								}
-							}
-						}
-					}()
-					retryChunks, _, _, _ := drainKiroStream(retryCh)
+					retryChunks, _, _, _ := drainKiroStream(c.pipeKiroResponse(ctx, resp2, repairedReq, nil))
 					if len(retryChunks) > 0 {
 						chunks = retryChunks
 					}
@@ -1026,7 +980,6 @@ func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cre
 			}
 		}
 
-		// Forward the winning buffer to the caller.
 		for _, ch := range chunks {
 			select {
 			case out <- ch:

--- a/backend/internal/connectors/kiro_test.go
+++ b/backend/internal/connectors/kiro_test.go
@@ -465,6 +465,69 @@ func TestKiroQuotaEndpointRetryableStopsOnRateLimit(t *testing.T) {
 	require.True(t, kiroQuotaEndpointRetryable(&core.ProviderError{Kind: core.ErrUpstream}))
 }
 
+func TestKiroIntegrityKind(t *testing.T) {
+	cases := []struct {
+		content string
+		hasTool bool
+		toolErr string
+		want    string
+	}{
+		{"hello world", false, "", ""},
+		{"...", false, "", "ellipsis"},
+		{"\u2026", false, "", "ellipsis"},
+		{"", false, "malformed tool", "tool"},
+		{"Let me check the status", false, "", "short_final"},
+		{"I will verify the deployment", false, "", "short_final"},
+		{"Done. The deployment is complete.", false, "", ""},
+		{"Let me check the status", true, "", ""},
+		{"現在我確認一下", false, "", "short_final"},
+		{"Let me verify: status is 200 OK", false, "", ""},
+	}
+	for _, tc := range cases {
+		got := kiroIntegrityKind(tc.content, tc.hasTool, tc.toolErr)
+		if got != tc.want {
+			t.Errorf("kiroIntegrityKind(%q, hasTool=%v, toolErr=%q) = %q, want %q",
+				tc.content, tc.hasTool, tc.toolErr, got, tc.want)
+		}
+	}
+}
+
+func TestKiroAppendRepair(t *testing.T) {
+	req := &core.ChatRequest{Model: "claude-sonnet-4.5", System: "be helpful"}
+	out := kiroAppendRepair(req, "ellipsis")
+	if !strings.Contains(out.System, "be helpful") {
+		t.Error("original system should be preserved")
+	}
+	if !strings.Contains(out.System, "ellipsis") {
+		t.Error("repair instruction should mention ellipsis")
+	}
+	if req.System == out.System {
+		t.Error("original req must not be mutated")
+	}
+
+	noSystem := &core.ChatRequest{Model: "claude-sonnet-4.5"}
+	out2 := kiroAppendRepair(noSystem, "short_final")
+	if out2.System == "" {
+		t.Error("repair should set system even when originally empty")
+	}
+}
+
+func TestDrainKiroStream(t *testing.T) {
+	ch := make(chan core.StreamChunk, 4)
+	ch <- core.StreamChunk{Type: core.ChunkText, Delta: "hello "}
+	ch <- core.StreamChunk{Type: core.ChunkText, Delta: "world"}
+	ch <- core.StreamChunk{Type: core.ChunkToolCall, ToolCall: &core.ToolCall{ID: "t1", Name: "fn"}}
+	ch <- core.StreamChunk{Type: core.ChunkFinish, FinishReason: core.FinishStop}
+	close(ch)
+
+	chunks, content, hasTool, toolErr := drainKiroStream(ch)
+	require.Equal(t, 4, len(chunks))
+	require.Equal(t, "hello world", content)
+	require.True(t, hasTool)
+	require.Equal(t, "", toolErr)
+}
+
+
 func TestKiroMetadataCachesReturnCopies(t *testing.T) {
 	accountID := "cache-account"
 	kiroModelCache.Delete(accountID)

--- a/backend/internal/transform/kiro.go
+++ b/backend/internal/transform/kiro.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	json "github.com/mydisha/keirouter/backend/internal/fastjson"
@@ -12,6 +13,17 @@ import (
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
+
+var kiroSessionIDs sync.Map
+
+func kiroResolveConversationID(affinityKey string) string {
+	if affinityKey == "" {
+		return uuid.NewString()
+	}
+	id := uuid.NewString()
+	actual, _ := kiroSessionIDs.LoadOrStore(affinityKey, id)
+	return actual.(string)
+}
 
 // KiroCodec renders canonical requests to AWS CodeWhisperer's
 // generateAssistantResponse format used by Kiro. The wire shape is a
@@ -242,7 +254,7 @@ func (KiroCodec) RenderRequestWithProfile(req *core.ChatRequest, profileArn stri
 	payload := map[string]any{
 		"conversationState": map[string]any{
 			"chatTriggerType": "MANUAL",
-			"conversationId":  uuid.NewString(),
+			"conversationId":  kiroResolveConversationID(req.Metadata.ContextAffinityKey),
 			"currentMessage":  map[string]any{"userInputMessage": current},
 			"history":         history,
 		},

--- a/backend/internal/transform/kiro_test.go
+++ b/backend/internal/transform/kiro_test.go
@@ -1233,3 +1233,79 @@ func TestNormalizeKiroVersionDashes(t *testing.T) {
 		}
 	}
 }
+
+func TestKiroResolveConversationID_StickyPerKey(t *testing.T) {
+	key := "test-affinity-key-" + t.Name()
+	kiroSessionIDs.Delete(key)
+	t.Cleanup(func() { kiroSessionIDs.Delete(key) })
+
+	id1 := kiroResolveConversationID(key)
+	id2 := kiroResolveConversationID(key)
+	if id1 != id2 {
+		t.Errorf("same affinity key should return same conversationId: %q != %q", id1, id2)
+	}
+	if id1 == "" {
+		t.Error("conversationId should not be empty")
+	}
+}
+
+func TestKiroResolveConversationID_EmptyKeyNewEachTime(t *testing.T) {
+	id1 := kiroResolveConversationID("")
+	id2 := kiroResolveConversationID("")
+	if id1 == id2 {
+		t.Error("empty affinity key should produce distinct conversationIds each call")
+	}
+}
+
+func TestKiroResolveConversationID_DifferentKeysDistinct(t *testing.T) {
+	k1 := "session-a-" + t.Name()
+	k2 := "session-b-" + t.Name()
+	kiroSessionIDs.Delete(k1)
+	kiroSessionIDs.Delete(k2)
+	t.Cleanup(func() {
+		kiroSessionIDs.Delete(k1)
+		kiroSessionIDs.Delete(k2)
+	})
+
+	id1 := kiroResolveConversationID(k1)
+	id2 := kiroResolveConversationID(k2)
+	if id1 == id2 {
+		t.Errorf("different affinity keys should produce different conversationIds: both %q", id1)
+	}
+}
+
+func TestKiro_RenderRequest_UsesAffinityKeyForConversationID(t *testing.T) {
+	key := "render-affinity-" + t.Name()
+	kiroSessionIDs.Delete(key)
+	t.Cleanup(func() { kiroSessionIDs.Delete(key) })
+
+	req := &core.ChatRequest{
+		Model:    "claude-sonnet-4.5",
+		Messages: []core.Message{{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}}},
+		Metadata: core.RequestMetadata{ContextAffinityKey: key},
+	}
+
+	body1, err := KiroCodec{}.RenderRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body2, err := KiroCodec{}.RenderRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var env1, env2 map[string]any
+	if err := json.Unmarshal(body1, &env1); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(body2, &env2); err != nil {
+		t.Fatal(err)
+	}
+
+	cs1 := env1["conversationState"].(map[string]any)
+	cs2 := env2["conversationState"].(map[string]any)
+	if cs1["conversationId"] != cs2["conversationId"] {
+		t.Errorf("same affinity key should produce same conversationId across renders: %q != %q",
+			cs1["conversationId"], cs2["conversationId"])
+	}
+}


### PR DESCRIPTION
This pull request introduces two major improvements to the Kiro connector: (1) it adds an integrity gate to detect and automatically repair incomplete or malformed model responses by retrying with an appended system instruction, and (2) it implements sticky conversation IDs based on an affinity key, ensuring session consistency across requests. Comprehensive unit tests are also added for these new behaviors.

**Kiro response integrity and auto-repair:**

* Added an integrity gate in `Kiro.Stream` to detect incomplete responses (ellipsis, short future-action, malformed tool calls) and automatically retry with a repair instruction appended to the system prompt. This includes new helper functions (`kiroIntegrityKind`, `kiroAppendRepair`, `drainKiroStream`) and regex-based detection for various response anomalies. [[1]](diffhunk://#diff-51a6c5498beb504720886861db0bfd05b47da8ace810303a5bc1749ca73f103cR36-R53) [[2]](diffhunk://#diff-51a6c5498beb504720886861db0bfd05b47da8ace810303a5bc1749ca73f103cR874-R1063)
* Added unit tests in `kiro_test.go` to verify the integrity gate logic, repair instruction appending, and stream draining.

**Sticky conversation IDs for session affinity:**

* Implemented `kiroResolveConversationID`, which generates and caches a unique conversation ID per affinity key using a `sync.Map`, ensuring requests with the same key share a session.
* Updated `KiroCodec.RenderRequestWithProfile` to use the resolved conversation ID, maintaining session stickiness in requests.
* Added tests in `kiro_test.go` to verify sticky conversation ID behavior for same, empty, and different affinity keys, and to ensure request rendering uses the correct conversation ID.

**Miscellaneous:**

* Added necessary imports for `regexp` and `sync` to support the new features. [[1]](diffhunk://#diff-51a6c5498beb504720886861db0bfd05b47da8ace810303a5bc1749ca73f103cR10) [[2]](diffhunk://#diff-9b3a4a47990f681744196658a65e323a42f27c7af7d59af5e2730cd872e1f356R7)