### PR TITLE
feat: harden provider routing and stream reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ backend/dist/
 coverage.txt
 /keirouter
 /keirouter.exe
+/keirouter-test
 /backend/keirouter
+/backend/keirouter-test
 
 # Go build cache / vendor
 vendor/

--- a/backend/internal/connectors/catalog.go
+++ b/backend/internal/connectors/catalog.go
@@ -60,7 +60,6 @@ type ProviderSpec struct {
 	Custom bool `json:"custom,omitempty"`
 }
 
-
 // llm is shorthand for the default LLM-only service kind slice.
 func llm(extra ...core.ServiceKind) []core.ServiceKind {
 	return append([]core.ServiceKind{core.ServiceLLM}, extra...)
@@ -87,7 +86,6 @@ func Catalog() []ProviderSpec {
 	// discovery, account management, and provider/alias resolution.
 	return append(built, dynamicSpecs()...)
 }
-
 
 // pinnedProviders are always-visible entries shown at the top of the listing.
 func pinnedProviders() []ProviderSpec {
@@ -125,7 +123,7 @@ func freeTierProviders() []ProviderSpec {
 	return []ProviderSpec{
 		{ID: "openrouter", DisplayName: "OpenRouter", Alias: "openrouter", Dialect: core.DialectOpenAI,
 			BaseURL: "https://openrouter.ai/api/v1", AuthKind: "api_key",
-			ServiceKinds: llm(core.ServiceEmbedding), Color: "#F97316",
+			ServiceKinds: llm(core.ServiceEmbedding, core.ServiceImageToText), Color: "#F97316",
 			Website: "https://openrouter.ai", APIKeyURL: "https://openrouter.ai/settings/keys",
 			Notice: "Free tier: 27+ free models, no credit card, 200 req/day."},
 		{ID: "nvidia", DisplayName: "NVIDIA NIM", Alias: "nvidia", Dialect: core.DialectOpenAI,
@@ -145,10 +143,10 @@ func freeTierProviders() []ProviderSpec {
 			Notice:  "Self-hosted vLLM OpenAI-compatible server. Set base URL to your vLLM endpoint; provide an API key only if you started vLLM with --api-key. Requires KEIROUTER_SECURITY__ALLOW_PRIVATE_BASE_URL=true when pointing at loopback or LAN hosts."},
 		{ID: "gemini", DisplayName: "Gemini", Alias: "gemini", Dialect: core.DialectGemini,
 			BaseURL: "https://generativelanguage.googleapis.com/v1beta", AuthKind: "api_key",
-			ServiceKinds: llm(core.ServiceEmbedding, core.ServiceImage, core.ServiceSearch, core.ServiceTTS, core.ServiceSTT),
+			ServiceKinds: llm(core.ServiceEmbedding, core.ServiceImage, core.ServiceSearch, core.ServiceTTS, core.ServiceSTT, core.ServiceImageToText),
 			Color:        "#4285F4", Website: "https://ai.google.dev", APIKeyURL: "https://aistudio.google.com/app/apikey"},
 		{ID: "vertex", DisplayName: "Vertex AI", Alias: "vx", Dialect: core.DialectVertex,
-			BaseURL: "https://aiplatform.googleapis.com", AuthKind: "oauth", AuthModes: []string{"oauth"}, ServiceKinds: llm(),
+			BaseURL: "https://aiplatform.googleapis.com", AuthKind: "oauth", AuthModes: []string{"oauth"}, ServiceKinds: llm(core.ServiceImageToText),
 			Color: "#4285F4", Website: "https://cloud.google.com/vertex-ai", Hidden: true},
 		{ID: "vertex-partner", DisplayName: "Vertex Partner", Alias: "vxp", Dialect: core.DialectVertex,
 			BaseURL: "https://aiplatform.googleapis.com", AuthKind: "oauth", AuthModes: []string{"oauth"}, ServiceKinds: llm(),
@@ -203,11 +201,17 @@ func oauthProviders() []ProviderSpec {
 			BaseURL: "https://api.kimi.com/coding/v1", AuthKind: "oauth", AuthModes: []string{"oauth", "api_key"}, ServiceKinds: llm(),
 			Color: "#1E3A8A", Website: "https://kimi.moonshot.cn", Deprecated: true, Notice: risk},
 		{ID: "kimchi", DisplayName: "Kimchi", Alias: "kimchi", Dialect: core.DialectOpenAI,
-			BaseURL: "https://llm.kimchi.dev/openai/v1", AuthKind: "oauth", AuthModes: []string{"oauth"}, ServiceKinds: llm(),
+			BaseURL: "https://llm.kimchi.dev/openai/v1", AuthKind: "oauth", AuthModes: []string{"oauth"}, ServiceKinds: llm(core.ServiceImageToText),
 			Color: "#FF521D", Website: "https://kimchi.dev", Deprecated: true, Notice: risk},
 		{ID: "codebuddy", DisplayName: "CodeBuddy", Alias: "cb", Dialect: core.DialectOpenAI,
 			BaseURL: "https://copilot.tencent.com/v2/chat/completions", AuthKind: "oauth", AuthModes: []string{"oauth", "api_key"}, ServiceKinds: llm(),
 			Color: "#006EFF", Website: "https://copilot.tencent.com", Deprecated: true, Notice: risk},
+		{ID: "clinepass", DisplayName: "ClinePass", Alias: "clinepass", Dialect: core.DialectOpenAI,
+			BaseURL: "https://api.cline.bot/api/v1", AuthKind: "oauth", AuthModes: []string{"oauth", "api_key"}, ServiceKinds: llm(),
+			Color: "#5B9BD5", Website: "https://cline.bot"},
+		{ID: "grok-cli", DisplayName: "Grok CLI (Grok Build)", Alias: "gcli", Dialect: core.DialectOpenAIResponses,
+			BaseURL: "https://cli-chat-proxy.grok.com/v1/responses", AuthKind: "oauth", AuthModes: []string{"oauth"}, ServiceKinds: llm(),
+			Color: "#1DA1F2", Website: "https://x.ai", Deprecated: true, Notice: risk, SkipValidation: true},
 	}
 }
 
@@ -220,7 +224,7 @@ func apiKeyProviders() []ProviderSpec {
 			Color:        "#10A37F", Website: "https://platform.openai.com", APIKeyURL: "https://platform.openai.com/api-keys",
 			InputPerM: 2.5, OutputPerM: 10},
 		{ID: "anthropic", DisplayName: "Anthropic", Alias: "anthropic", Dialect: core.DialectAnthropic,
-			BaseURL: "https://api.anthropic.com/v1", AuthKind: "api_key", ServiceKinds: llm(),
+			BaseURL: "https://api.anthropic.com/v1", AuthKind: "api_key", ServiceKinds: llm(core.ServiceImageToText),
 			Color: "#D97757", Website: "https://console.anthropic.com", APIKeyURL: "https://console.anthropic.com/settings/keys",
 			InputPerM: 3, OutputPerM: 15},
 		{ID: "deepseek", DisplayName: "DeepSeek", Alias: "ds", Dialect: core.DialectOpenAI,
@@ -240,7 +244,7 @@ func apiKeyProviders() []ProviderSpec {
 			Color: "#1E3A8A", Website: "https://kimi.moonshot.cn", APIKeyURL: "https://platform.moonshot.ai/console/api-keys"},
 		{ID: "minimax", DisplayName: "MiniMax Coding", Alias: "minimax", Dialect: core.DialectAnthropic,
 			BaseURL: "https://api.minimax.io/anthropic/v1", AuthKind: "api_key",
-			ServiceKinds: llm(core.ServiceImage, core.ServiceSearch, core.ServiceTTS), Color: "#7C3AED",
+			ServiceKinds: llm(core.ServiceImage, core.ServiceSearch, core.ServiceTTS, core.ServiceImageToText), Color: "#7C3AED",
 			Website: "https://www.minimaxi.com", APIKeyURL: "https://platform.minimaxi.com/user-center/basic-information/interface-key",
 			InputPerM: 0.2, OutputPerM: 1.1},
 		{ID: "minimax-cn", DisplayName: "MiniMax (China)", Alias: "minimax-cn", Dialect: core.DialectAnthropic,
@@ -270,7 +274,7 @@ func apiKeyProviders() []ProviderSpec {
 			BaseURL: "https://ark.cn-beijing.volces.com/api/coding/v3", AuthKind: "api_key", ServiceKinds: llm(),
 			Color: "#1677FF", Website: "https://ark.cn-beijing.volces.com"},
 		{ID: "vercel-ai-gateway", DisplayName: "Vercel AI Gateway", Alias: "vercel", Dialect: core.DialectOpenAI,
-			BaseURL: "https://ai-gateway.vercel.sh/v1", AuthKind: "api_key", ServiceKinds: llm(),
+			BaseURL: "https://ai-gateway.vercel.sh/v1", AuthKind: "api_key", ServiceKinds: llm(core.ServiceImageToText),
 			Color: "#111827", Website: "https://vercel.com/ai-gateway"},
 		{ID: "azure", DisplayName: "Azure OpenAI", Alias: "azure", Dialect: core.DialectOpenAI,
 			BaseURL: "", AuthKind: "api_key", ServiceKinds: llm(), Color: "#0078D4",
@@ -281,15 +285,15 @@ func apiKeyProviders() []ProviderSpec {
 			Color: "#000000", Website: "https://commandcode.ai", APIKeyURL: "https://commandcode.ai/studio",
 			Notice: "Use your Command Code API key from commandcode.ai/studio or run `cmd login` to get a CLI token. CLI subscriptions (Go, Pro, Max, Ultra) are supported."},
 		{ID: "groq", DisplayName: "Groq", Alias: "groq", Dialect: core.DialectOpenAI,
-			BaseURL: "https://api.groq.com/openai/v1", AuthKind: "api_key", ServiceKinds: llm(core.ServiceSTT),
+			BaseURL: "https://api.groq.com/openai/v1", AuthKind: "api_key", ServiceKinds: llm(core.ServiceSTT, core.ServiceImageToText),
 			Color: "#F55036", Website: "https://groq.com", APIKeyURL: "https://console.groq.com/keys",
 			InputPerM: 0.59, OutputPerM: 0.79},
 		{ID: "xai", DisplayName: "xAI (Grok)", Alias: "xai", Dialect: core.DialectOpenAI,
 			BaseURL: "https://api.x.ai/v1", AuthKind: "api_key", AuthModes: []string{"oauth", "api_key"},
-			ServiceKinds: llm(core.ServiceSearch, core.ServiceImage), Color: "#1DA1F2", Website: "https://x.ai",
+			ServiceKinds: llm(core.ServiceSearch, core.ServiceImage, core.ServiceVideo, core.ServiceImageToText), Color: "#1DA1F2", Website: "https://x.ai",
 			APIKeyURL: "https://console.x.ai"},
 		{ID: "mistral", DisplayName: "Mistral", Alias: "mistral", Dialect: core.DialectOpenAI,
-			BaseURL: "https://api.mistral.ai/v1", AuthKind: "api_key", ServiceKinds: llm(core.ServiceEmbedding),
+			BaseURL: "https://api.mistral.ai/v1", AuthKind: "api_key", ServiceKinds: llm(core.ServiceEmbedding, core.ServiceImageToText),
 			Color: "#FF7000", Website: "https://mistral.ai", APIKeyURL: "https://console.mistral.ai/api-keys"},
 		{ID: "perplexity", DisplayName: "Perplexity", Alias: "pplx", Dialect: core.DialectOpenAI,
 			BaseURL: "https://api.perplexity.ai", AuthKind: "api_key", ServiceKinds: llm(core.ServiceSearch),
@@ -330,7 +334,8 @@ func apiKeyProviders() []ProviderSpec {
 		// --- Additional providers ---
 		{ID: "gitlab", DisplayName: "GitLab Duo", Alias: "gitlab", Dialect: core.DialectOpenAI,
 			BaseURL: "https://gitlab.com/api/v4", AuthKind: "api_key", ServiceKinds: llm(),
-			Color: "#FC6D26", Website: "https://gitlab.com"},
+			Color: "#FC6D26", Website: "https://gitlab.com", Hidden: true,
+			Notice: "Connect with a GitLab personal access token (Bearer) scoped for Duo."},
 		// Browser-session cookie providers. Connected by pasting a session cookie
 		// from the provider's web app. The web_cookie dialect has no connector
 		// yet, so these are discovery/account-management only until one lands.
@@ -345,7 +350,7 @@ func apiKeyProviders() []ProviderSpec {
 		{ID: "agentrouter", DisplayName: "AgentRouter", Alias: "ar", Dialect: core.DialectOpenAI,
 			BaseURL: "https://agentrouter.org/v1", AuthKind: "api_key", ServiceKinds: llm(),
 			Color: "#10B981", Website: "https://agentrouter.org",
-			APIKeyURL: "https://agentrouter.org", SkipValidation:true},
+			APIKeyURL: "https://agentrouter.org", SkipValidation: true},
 		{ID: "aimlapi", DisplayName: "AIML API", Alias: "aimlapi", Dialect: core.DialectOpenAI,
 			BaseURL: "https://api.aimlapi.com/v1", AuthKind: "api_key", ServiceKinds: llm(),
 			Color: "#6366F1", Website: "https://aimlapi.com", APIKeyURL: "https://aimlapi.com/api-keys", Hidden: true},
@@ -433,6 +438,23 @@ func apiKeyProviders() []ProviderSpec {
 		{ID: "sumopod", DisplayName: "SumoPod", Alias: "sumopod", Dialect: core.DialectOpenAI,
 			BaseURL: "https://ai.sumopod.com/v1", AuthKind: "api_key", ServiceKinds: llm(),
 			Color: "#3B82F6", Website: "https://sumopod.com", APIKeyURL: "https://sumopod.com", Hidden: true},
+		{ID: "venice", DisplayName: "Venice AI", Alias: "vn", Dialect: core.DialectOpenAI,
+			BaseURL: "https://api.venice.ai/api/v1", AuthKind: "api_key",
+			ServiceKinds: llm(core.ServiceEmbedding, core.ServiceImage), Color: "#DC2626",
+			Website: "https://venice.ai", APIKeyURL: "https://venice.ai/settings/api",
+			Notice: "OpenAI-compatible. Private inference and uncensored models."},
+		{ID: "featherless", DisplayName: "Featherless", Alias: "fl", Dialect: core.DialectOpenAI,
+			BaseURL: "https://api.featherless.ai/v1", AuthKind: "api_key", ServiceKinds: llm(),
+			Color: "#111827", Website: "https://featherless.ai", APIKeyURL: "https://featherless.ai/account/api-keys"},
+		{ID: "perplexity-agent", DisplayName: "Perplexity Agent", Alias: "pa", Dialect: core.DialectOpenAIResponses,
+			BaseURL: "https://api.perplexity.ai/v1/responses", AuthKind: "api_key",
+			ServiceKinds: llm(core.ServiceSearch), Color: "#20808D",
+			Website: "https://www.perplexity.ai", APIKeyURL: "https://www.perplexity.ai/settings/api",
+			Notice: "Agent API exposes many upstream models through one OpenAI-compatible Responses API."},
+		{ID: "mmf", DisplayName: "MMF", Alias: "mmf", Dialect: core.DialectOpenAI,
+			BaseURL: "https://api.xiaomimimo.com/api/free-ai/openai", AuthKind: "none", AuthModes: []string{"none"},
+			ServiceKinds: llm(), Color: "#6366F1", Website: "https://xiaomimimo.com",
+			Hidden: true, SkipValidation: true, Notice: "Free MiMo endpoint. No API key required."},
 		// Generic compatible endpoints are now in pinnedProviders().
 	}
 }

--- a/backend/internal/connectors/catalog_test.go
+++ b/backend/internal/connectors/catalog_test.go
@@ -72,6 +72,45 @@ func TestModelsByKind(t *testing.T) {
 	}
 }
 
+func TestMediaCatalogCompleteness(t *testing.T) {
+	// Video providers must surface video-tagged models.
+	wantVideo := []string{"xai"}
+	video := ModelsByKind(core.ServiceVideo)
+	gotVideo := map[string]bool{}
+	for _, pm := range video {
+		if pm.Model.Kind != core.ServiceVideo {
+			t.Errorf("ModelsByKind(video) returned non-video model %q", pm.Model.ID)
+		}
+		gotVideo[pm.Provider] = true
+	}
+	for _, id := range wantVideo {
+		if !gotVideo[id] {
+			t.Errorf("expected video provider %q in catalog", id)
+		}
+	}
+
+	// ImageToText providers must surface image_to_text-tagged models.
+	// (vertex is tagged too but stays Hidden, so it is intentionally not
+	// surfaced in the media catalog.)
+	wantI2T := []string{
+		"anthropic", "gemini", "groq", "mistral", "minimax",
+		"openrouter", "vercel-ai-gateway", "xai", "kimchi",
+	}
+	i2t := ModelsByKind(core.ServiceImageToText)
+	gotI2T := map[string]bool{}
+	for _, pm := range i2t {
+		if pm.Model.Kind != core.ServiceImageToText {
+			t.Errorf("ModelsByKind(image_to_text) returned wrong-kind model %q", pm.Model.ID)
+		}
+		gotI2T[pm.Provider] = true
+	}
+	for _, id := range wantI2T {
+		if !gotI2T[id] {
+			t.Errorf("expected image_to_text provider %q in catalog", id)
+		}
+	}
+}
+
 func TestFindModel(t *testing.T) {
 	if _, ok := FindModel("openai", "gpt-4o"); !ok {
 		t.Error("expected to find openai/gpt-4o")
@@ -121,6 +160,43 @@ func TestCommandCodeCatalogVisible(t *testing.T) {
 	}
 	if len(ModelsForProvider("commandcode")) == 0 {
 		t.Fatal("commandcode should have static models")
+	}
+}
+
+func TestCatalogHasNewProviders(t *testing.T) {
+	// Providers added for coverage parity. Each must exist, expose static
+	// models, and (since they use drivable dialects) get a live connector.
+	cases := []struct {
+		id       string
+		alias    string
+		authKind string
+	}{
+		{"venice", "vn", "api_key"},
+		{"featherless", "fl", "api_key"},
+		{"perplexity-agent", "pa", "api_key"},
+		{"mmf", "mmf", "none"},
+		{"clinepass", "clinepass", "oauth"},
+		{"grok-cli", "gcli", "oauth"},
+	}
+	r := DefaultRegistry()
+	for _, c := range cases {
+		spec, ok := SpecByID(c.id)
+		if !ok {
+			t.Errorf("catalog missing provider %q", c.id)
+			continue
+		}
+		if spec.AuthKind != c.authKind {
+			t.Errorf("%s: AuthKind = %q, want %q", c.id, spec.AuthKind, c.authKind)
+		}
+		if s, ok := SpecByAlias(c.alias); !ok || s.ID != c.id {
+			t.Errorf("alias %q should resolve to %q, got %q ok=%v", c.alias, c.id, s.ID, ok)
+		}
+		if len(ModelsForProvider(c.id)) == 0 {
+			t.Errorf("%s should have static models", c.id)
+		}
+		if !r.Has(c.id) {
+			t.Errorf("registry should have connector for %q", c.id)
+		}
 	}
 }
 

--- a/backend/internal/connectors/classify429.go
+++ b/backend/internal/connectors/classify429.go
@@ -1,0 +1,242 @@
+package connectors
+
+import (
+	"encoding/json"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+// quotaPatterns matches provider error text indicating a hard quota/cap has
+// been reached (as opposed to a transient rate limit). These warrant a much
+// longer cooldown than a per-minute rate limit.
+var quotaPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)daily.*(?:limit|quota|allocation)`),
+	regexp.MustCompile(`(?i)monthly.*(?:limit|quota)`),
+	regexp.MustCompile(`(?i)per.?day.*limit`),
+	regexp.MustCompile(`(?i)per.?month.*limit`),
+	regexp.MustCompile(`(?i)insufficient.*quota`),
+	regexp.MustCompile(`(?i)billing.*cap`),
+	regexp.MustCompile(`(?i)credit.*exhaust`),
+	regexp.MustCompile(`(?i)out of credits`),
+	regexp.MustCompile(`(?i)hard.?limit`),
+	regexp.MustCompile(`(?i)plan.*limit`),
+	regexp.MustCompile(`(?i)subscription.*(?:limit|quota|cap)`),
+	regexp.MustCompile(`(?i)weekly.*(?:limit|quota)`),
+	regexp.MustCompile(`(?i)session.*(?:limit|quota)`),
+	regexp.MustCompile(`(?i)daily free allocation`),
+}
+
+// rateLimitPatterns matches transient rate-limit text. These are short-term
+// backoffs, not long-term quota exhaustion.
+var rateLimitPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)rate.?limit`),
+	regexp.MustCompile(`(?i)too many requests`),
+	regexp.MustCompile(`(?i)requests? per (?:minute|second|hour)`),
+	regexp.MustCompile(`(?i)RPM`),
+	regexp.MustCompile(`(?i)TPM`),
+	regexp.MustCompile(`(?i)concurrent`),
+	regexp.MustCompile(`(?i)throttl`),
+}
+
+// looksLikeQuotaExhausted reports whether the provider error body indicates
+// a hard quota/cap rather than a transient rate limit. Used to classify 429s
+// into ErrQuotaExhausted (long cooldown) vs ErrRateLimit (short backoff).
+func looksLikeQuotaExhausted(body string) bool {
+	if body == "" {
+		return false
+	}
+	// Per-second/minute/hour quota wording is a transient throttle even when
+	// the provider also uses the phrase "quota exceeded".
+	if looksLikeRateLimit(body) {
+		return false
+	}
+	for _, re := range quotaPatterns {
+		if re.MatchString(body) {
+			return true
+		}
+	}
+	return false
+}
+
+// looksLikeRateLimit reports whether the provider error body indicates a
+// transient rate limit. Used as a tie-breaker when quota patterns don't match.
+func looksLikeRateLimit(body string) bool {
+	if body == "" {
+		return false
+	}
+	for _, re := range rateLimitPatterns {
+		if re.MatchString(body) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseRetryAfterHeader parses the Retry-After header value. It handles both
+// integer seconds and HTTP-date formats, returning the duration to wait.
+func parseRetryAfterHeader(ra string) time.Duration {
+	if ra == "" {
+		return 0
+	}
+	// Integer seconds.
+	if secs, err := strconv.Atoi(ra); err == nil {
+		return time.Duration(secs) * time.Second
+	}
+	// HTTP-date.
+	if retryAt, err := http.ParseTime(ra); err == nil {
+		if wait := time.Until(retryAt); wait > 0 {
+			return wait
+		}
+	}
+	return 0
+}
+
+// parseResetFromHeaders extracts rate-limit reset hints from common headers.
+// Returns the duration until the limit resets, or 0 if no hint is present.
+func parseResetFromHeaders(resp *http.Response) time.Duration {
+	// Retry-After is the most authoritative.
+	if d := parseRetryAfterHeader(resp.Header.Get("Retry-After")); d > 0 {
+		return d
+	}
+	// X-RateLimit-Reset: unix timestamp in seconds or milliseconds.
+	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+		if ts, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			// Distinguish seconds vs milliseconds: > 1e10 is likely ms.
+			if ts > 10000000000 {
+				if wait := time.Duration(ts-time.Now().UnixMilli()) * time.Millisecond; wait > 0 {
+					return wait
+				}
+				return 0
+			}
+			if wait := time.Duration(ts-time.Now().Unix()) * time.Second; wait > 0 {
+				return wait
+			}
+			return 0
+		}
+	}
+	return 0
+}
+
+// parseResetFromBody extracts common retry/reset hints from nested JSON error
+// bodies. Providers vary between duration fields and absolute reset timestamps.
+func parseResetFromBody(body []byte) time.Duration {
+	var value any
+	if len(body) == 0 || json.Unmarshal(body, &value) != nil {
+		return 0
+	}
+	return findResetHint(value, 0)
+}
+
+func findResetHint(value any, depth int) time.Duration {
+	if depth > 5 {
+		return 0
+	}
+	switch v := value.(type) {
+	case map[string]any:
+		for key, raw := range v {
+			normalized := strings.ToLower(strings.ReplaceAll(key, "-", "_"))
+			compact := strings.ReplaceAll(normalized, "_", "")
+			if strings.Contains(compact, "retryafter") ||
+				strings.Contains(compact, "resetat") ||
+				strings.Contains(compact, "ratelimitreset") {
+				if wait := resetHintDuration(normalized, raw); wait > 0 {
+					return wait
+				}
+			}
+		}
+		for _, raw := range v {
+			if wait := findResetHint(raw, depth+1); wait > 0 {
+				return wait
+			}
+		}
+	case []any:
+		for _, raw := range v {
+			if wait := findResetHint(raw, depth+1); wait > 0 {
+				return wait
+			}
+		}
+	}
+	return 0
+}
+
+func resetHintDuration(key string, value any) time.Duration {
+	var number float64
+	switch v := value.(type) {
+	case float64:
+		number = v
+	case string:
+		s := strings.TrimSpace(v)
+		if parsed, err := strconv.ParseFloat(s, 64); err == nil {
+			number = parsed
+			break
+		}
+		for _, layout := range []string{time.RFC3339, http.TimeFormat} {
+			if at, err := time.Parse(layout, s); err == nil {
+				if wait := time.Until(at); wait > 0 {
+					return wait
+				}
+				return 0
+			}
+		}
+		if wait, err := time.ParseDuration(s); err == nil && wait > 0 {
+			return wait
+		}
+	default:
+		return 0
+	}
+
+	if number <= 0 {
+		return 0
+	}
+	// Reset fields generally carry an epoch. Retry-after fields carry seconds.
+	if strings.Contains(key, "reset") {
+		if number > 1e12 {
+			return positiveDuration(time.UnixMilli(int64(number)))
+		}
+		if number > 1e9 {
+			return positiveDuration(time.Unix(int64(number), 0))
+		}
+	}
+	return time.Duration(number * float64(time.Second))
+}
+
+func positiveDuration(at time.Time) time.Duration {
+	if wait := time.Until(at); wait > 0 {
+		return wait
+	}
+	return 0
+}
+
+// classify429 determines whether a 429 response is a transient rate limit or
+// a hard quota exhaustion, and extracts any upstream-provided retry hint.
+// Returns (kind, retryAfter).
+func classify429(resp *http.Response, body []byte) (kind core.ErrorKind, retryAfter time.Duration) {
+	// Extract retry hints from headers first.
+	retryAfter = parseResetFromHeaders(resp)
+	if retryAfter <= 0 {
+		retryAfter = parseResetFromBody(body)
+	}
+
+	bodyStr := string(body)
+	// Hard quota exhaustion takes precedence: long cooldown, no point retrying
+	// before the calendar/quota window rolls over.
+	if looksLikeQuotaExhausted(bodyStr) {
+		// If no explicit retry hint, use a conservative long default.
+		if retryAfter <= 0 {
+			retryAfter = 30 * time.Minute
+		}
+		return core.ErrQuotaExhausted, retryAfter
+	}
+
+	// Transient rate limit: short exponential backoff. If no header hint,
+	// use a short default.
+	if retryAfter <= 0 {
+		retryAfter = 5 * time.Second
+	}
+	return core.ErrRateLimit, retryAfter
+}

--- a/backend/internal/connectors/classify429_test.go
+++ b/backend/internal/connectors/classify429_test.go
@@ -1,0 +1,207 @@
+package connectors
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLooksLikeQuotaExhausted(t *testing.T) {
+	tests := []struct {
+		body string
+		want bool
+	}{
+		{"", false},
+		{"rate limit exceeded", false},
+		{"too many requests", false},
+		{"daily limit reached", true},
+		{"daily quota exceeded", true},
+		{"daily free allocation used", true},
+		{"monthly limit reached", true},
+		{"per day limit exceeded", true},
+		{"per month limit reached", true},
+		{"quota exceed", false},
+		{"exceed quota", false},
+		{"requests per minute quota exceeded", false},
+		{"insufficient quota", true},
+		{"billing cap reached", true},
+		{"credit exhaust", true},
+		{"out of credits", true},
+		{"hard limit", true},
+		{"plan limit", true},
+		{"subscription limit", true},
+		{"weekly quota", true},
+		{"session limit", true},
+		{"Rate limit exceeded", false}, // case insensitive check — should NOT match quota
+		{"RATE LIMIT", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.body, func(t *testing.T) {
+			if got := looksLikeQuotaExhausted(tt.body); got != tt.want {
+				t.Errorf("looksLikeQuotaExhausted(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseResetFromBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want time.Duration
+	}{
+		{
+			name: "nested retry after seconds",
+			body: `{"error":{"retry_after":2.5}}`,
+			want: 2500 * time.Millisecond,
+		},
+		{
+			name: "camel case retry after duration",
+			body: `{"retryAfter":"3s"}`,
+			want: 3 * time.Second,
+		},
+		{
+			name: "past reset ignored",
+			body: `{"resetAt":1000000001}`,
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseResetFromBody([]byte(tt.body)); got != tt.want {
+				t.Fatalf("parseResetFromBody() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLooksLikeRateLimit(t *testing.T) {
+	tests := []struct {
+		body string
+		want bool
+	}{
+		{"", false},
+		{"rate limit exceeded", true},
+		{"too many requests", true},
+		{"requests per minute", true},
+		{"RPM exceeded", true},
+		{"TPM limit", true},
+		{"concurrent requests", true},
+		{"throttled", true},
+		{"daily quota", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.body, func(t *testing.T) {
+			if got := looksLikeRateLimit(tt.body); got != tt.want {
+				t.Errorf("looksLikeRateLimit(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassify429_QuotaExhausted(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("Content-Type", "application/json")
+
+	body := []byte(`{"error": {"message": "daily free allocation used up", "type": "quota_error"}}`)
+	kind, retryAfter := classify429(resp, body)
+
+	require.Equal(t, core.ErrQuotaExhausted, kind)
+	require.Equal(t, 30*time.Minute, retryAfter, "default quota cooldown should be 30m")
+}
+
+func TestClassify429_QuotaExhausted_WithRetryAfter(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("Retry-After", "3600")
+
+	body := []byte(`{"error": {"message": "monthly quota exceeded"}}`)
+	kind, retryAfter := classify429(resp, body)
+
+	require.Equal(t, core.ErrQuotaExhausted, kind)
+	require.Equal(t, time.Hour, retryAfter, "should use upstream Retry-After for quota")
+}
+
+func TestClassify429_RateLimit(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+
+	body := []byte(`{"error": {"message": "too many requests", "type": "rate_limit"}}`)
+	kind, retryAfter := classify429(resp, body)
+
+	require.Equal(t, core.ErrRateLimit, kind)
+	require.Equal(t, 5*time.Second, retryAfter, "default rate-limit backoff should be 5s")
+}
+
+func TestClassify429_RateLimit_WithRetryAfter(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("Retry-After", "10")
+
+	body := []byte(`{"error": {"message": "rate limit exceeded"}}`)
+	kind, retryAfter := classify429(resp, body)
+
+	require.Equal(t, core.ErrRateLimit, kind)
+	require.Equal(t, 10*time.Second, retryAfter)
+}
+
+func TestClassify429_XRateLimitReset(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	// Set reset to 60 seconds from now.
+	resetTime := time.Now().Add(60 * time.Second).Unix()
+	resp.Header.Set("X-RateLimit-Reset", strconv.FormatInt(resetTime, 10))
+
+	body := []byte(`{"error": {"message": "rate limit"}}`)
+	kind, retryAfter := classify429(resp, body)
+
+	require.Equal(t, core.ErrRateLimit, kind)
+	require.True(t, retryAfter > 55*time.Second && retryAfter <= 60*time.Second,
+		"retryAfter should be ~60s, got %v", retryAfter)
+}
+
+func TestHTTPStatusError_429Quota(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{},
+	}
+	body := []byte(`{"error": {"message": "daily limit reached"}}`)
+
+	err := httpStatusError("test", "model", resp, body)
+	pe := core.AsProviderError(err)
+
+	require.Equal(t, core.ErrQuotaExhausted, pe.Kind)
+	require.Equal(t, 30*time.Minute, pe.RetryAfter)
+}
+
+func TestHTTPStatusError_429RateLimit(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{},
+	}
+	body := []byte(`{"error": {"message": "too many requests"}}`)
+
+	err := httpStatusError("test", "model", resp, body)
+	pe := core.AsProviderError(err)
+
+	require.Equal(t, core.ErrRateLimit, pe.Kind)
+	require.Equal(t, 5*time.Second, pe.RetryAfter)
+}
+
+func TestHTTPStatusError_429RateLimit_RetryAfter(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{},
+	}
+	resp.Header.Set("Retry-After", "120")
+	body := []byte(`{"error": {"message": "rate limit"}}`)
+
+	err := httpStatusError("test", "model", resp, body)
+	pe := core.AsProviderError(err)
+
+	require.Equal(t, core.ErrRateLimit, pe.Kind)
+	require.Equal(t, 2*time.Minute, pe.RetryAfter)
+}

--- a/backend/internal/connectors/connectors_test.go
+++ b/backend/internal/connectors/connectors_test.go
@@ -2,6 +2,7 @@ package connectors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -107,6 +108,39 @@ func TestHTTPStatusErrorParsesRetryAfterHTTPDate(t *testing.T) {
 	pe := core.AsProviderError(httpStatusError("kiro", "model", resp, []byte("limited")))
 	require.Greater(t, pe.RetryAfter, 85*time.Second)
 	require.LessOrEqual(t, pe.RetryAfter, 90*time.Second)
+}
+
+func TestHTTPStatusErrorClassifiesMissingModel(t *testing.T) {
+	resp := &http.Response{StatusCode: http.StatusNotFound, Header: http.Header{}}
+	pe := core.AsProviderError(httpStatusError("openai", "missing", resp, []byte(`{"error":"not found"}`)))
+	require.Equal(t, core.ErrModelUnavailable, pe.Kind)
+	require.Equal(t, core.FailureScopeModel, pe.EffectiveScope())
+	require.True(t, pe.Fallbackable())
+}
+
+func TestTransportErrorScopesRetry(t *testing.T) {
+	networkErr := transportError(context.Background(), "openai", "gpt-4o", errors.New("dial failed"))
+	pe := core.AsProviderError(networkErr)
+	require.Equal(t, core.ErrUpstream, pe.Kind)
+	require.Equal(t, core.FailureScopeNetwork, pe.EffectiveScope())
+	require.False(t, shouldRetryFreshConnection(context.Background(), networkErr))
+
+	staleErr := transportError(context.Background(), "openai", "gpt-4o", errors.New("http: server closed idle connection"))
+	require.True(t, shouldRetryFreshConnection(context.Background(), staleErr))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	canceledErr := transportError(ctx, "openai", "gpt-4o", context.Canceled)
+	pe = core.AsProviderError(canceledErr)
+	require.Equal(t, core.ErrClientCanceled, pe.Kind)
+	require.Equal(t, core.FailureScopeRequest, pe.EffectiveScope())
+	require.False(t, shouldRetryFreshConnection(ctx, canceledErr))
+}
+
+func TestRetryTransportForcesFreshConnection(t *testing.T) {
+	transport, ok := retryClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.True(t, transport.DisableKeepAlives)
 }
 
 func TestOpenAICompatible_BadRequestNotFallbackable(t *testing.T) {

--- a/backend/internal/connectors/httpclient.go
+++ b/backend/internal/connectors/httpclient.go
@@ -64,6 +64,25 @@ var sharedClient = &http.Client{
 	},
 }
 
+// retryClient is used when a pooled idle connection is known to be stale.
+// Retrying on the same transport can grab another stale socket from the pool,
+// so the replay uses a no-keep-alive transport to force a fresh connection.
+var retryClient = &http.Client{
+	Timeout: 0,
+	Transport: &http.Transport{
+		DisableKeepAlives:     true,
+		MaxIdleConns:          0,
+		MaxIdleConnsPerHost:   0,
+		IdleConnTimeout:       1 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		WriteBufferSize:       16 * 1024,
+		ReadBufferSize:        16 * 1024,
+		ForceAttemptHTTP2:     false, // fresh TCP connection per request
+	},
+}
+
 // proxyTransportCache pools *http.Transport instances keyed by proxy config
 // string. This prevents creating a new transport (and its goroutine/buffer
 // pool) on every proxied request -- a significant memory leak.
@@ -396,6 +415,21 @@ func doMultipart(ctx context.Context, provider, model, url, fileField, filename 
 // openStream performs a streaming POST and returns the response for the caller
 // to read SSE lines from. The caller must close resp.Body.
 func openStream(ctx context.Context, provider, model, url string, body []byte, headers map[string]string) (*http.Response, error) {
+	resp, err := openStreamWithClient(ctx, provider, model, url, body, headers, proxyClient(ctx))
+	if err == nil || !shouldRetryFreshConnection(ctx, err) {
+		return resp, err
+	}
+	return openStreamForRetry(ctx, provider, model, url, body, headers)
+}
+
+// openStreamForRetry is like openStream but uses the no-keep-alive retry
+// transport. Used when retrying after a transport-level failure to avoid
+// grabbing a stale socket from the shared pool.
+func openStreamForRetry(ctx context.Context, provider, model, url string, body []byte, headers map[string]string) (*http.Response, error) {
+	return openStreamWithClient(ctx, provider, model, url, body, headers, proxyClientForRetry(ctx))
+}
+
+func openStreamWithClient(ctx context.Context, provider, model, url string, body []byte, headers map[string]string, client *http.Client) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: provider, Model: model, Message: err.Error(), Cause: err}
@@ -407,7 +441,7 @@ func openStream(ctx context.Context, provider, model, url string, body []byte, h
 	}
 
 	proxyRewrite(ctx, req)
-	resp, err := proxyClient(ctx).Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, transportError(ctx, provider, model, err)
 	}
@@ -564,39 +598,87 @@ func parseSSEData(line string) (string, bool) {
 // transportError classifies a transport-level failure (DNS, connection, ctx).
 func transportError(ctx context.Context, provider, model string, err error) error {
 	kind := core.ErrUpstream
-	if ctx.Err() == context.DeadlineExceeded {
+	scope := core.FailureScopeNetwork
+	switch ctx.Err() {
+	case context.Canceled:
+		kind = core.ErrClientCanceled
+		scope = core.FailureScopeRequest
+	case context.DeadlineExceeded:
 		kind = core.ErrTimeout
+		scope = core.FailureScopeRequest
 	}
-	return &core.ProviderError{Kind: kind, Provider: provider, Model: model, Message: err.Error(), Cause: err}
+	return &core.ProviderError{
+		Kind: kind, Scope: scope, Provider: provider, Model: model,
+		Message: err.Error(), Cause: err,
+	}
+}
+
+// shouldRetryFreshConnection permits one replay before response headers exist.
+// Only network-scoped transport errors qualify; HTTP responses and cancellations
+// are handled by normal fallback so a request is never multiplied blindly.
+func shouldRetryFreshConnection(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	pe := core.AsProviderError(err)
+	if pe.Kind != core.ErrUpstream ||
+		pe.StatusCode != 0 ||
+		pe.EffectiveScope() != core.FailureScopeNetwork ||
+		pe.Cause == nil {
+		return false
+	}
+	message := strings.ToLower(pe.Cause.Error())
+	return strings.Contains(message, "server closed idle connection") ||
+		strings.Contains(message, "use of closed network connection")
 }
 
 // httpStatusError maps an HTTP error status to a structured ProviderError.
 func httpStatusError(provider, model string, resp *http.Response, body []byte) error {
 	kind := core.ErrUpstream
+	var retryAfter time.Duration
 	switch {
 	case resp.StatusCode == http.StatusTooManyRequests:
-		kind = core.ErrRateLimit
+		// Classify 429 into transient rate-limit vs hard quota exhaustion.
+		// Quota exhaustion gets a much longer cooldown than per-minute throttling.
+		kind, retryAfter = classify429(resp, body)
 	case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
 		kind = core.ErrAuth
 	case resp.StatusCode == http.StatusPaymentRequired:
 		kind = core.ErrQuotaExhausted
+	case resp.StatusCode == http.StatusNotFound:
+		kind = core.ErrModelUnavailable
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
 		kind = core.ErrBadRequest
 	}
 
+	scope := core.FailureScopeProvider
+	switch kind {
+	case core.ErrBadRequest:
+		scope = core.FailureScopeRequest
+	case core.ErrModelUnavailable:
+		scope = core.FailureScopeModel
+	case core.ErrAuth, core.ErrRateLimit, core.ErrQuotaExhausted:
+		scope = core.FailureScopeAccount
+	}
+
 	pe := &core.ProviderError{
 		Kind:       kind,
+		Scope:      scope,
 		Provider:   provider,
 		Model:      model,
 		StatusCode: resp.StatusCode,
 		Message:    truncateError(body),
+		RetryAfter: retryAfter,
 	}
-	if ra := resp.Header.Get("Retry-After"); ra != "" {
-		if secs, err := strconv.Atoi(ra); err == nil {
-			pe.RetryAfter = time.Duration(secs) * time.Second
-		} else if retryAt, err := http.ParseTime(ra); err == nil {
-			if wait := time.Until(retryAt); wait > 0 {
-				pe.RetryAfter = wait
+	// Preserve the existing Retry-After header parsing for non-429 errors.
+	if pe.RetryAfter <= 0 {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, err := strconv.Atoi(ra); err == nil {
+				pe.RetryAfter = time.Duration(secs) * time.Second
+			} else if retryAt, err := http.ParseTime(ra); err == nil {
+				if wait := time.Until(retryAt); wait > 0 {
+					pe.RetryAfter = wait
+				}
 			}
 		}
 	}
@@ -673,6 +755,41 @@ func proxyClient(ctx context.Context) *http.Client {
 		return sharedClient
 	}
 	return clientFor(creds)
+}
+
+// proxyClientForRetry returns an http.Client for retry attempts after a
+// transport-level failure. When no proxy is configured, it returns the
+// no-keep-alive retryClient to force a fresh connection (avoiding stale
+// sockets from the shared pool). With a proxy configured, it falls back to
+// the standard clientFor since proxy transports are already isolated.
+func proxyClientForRetry(ctx context.Context) *http.Client {
+	creds, ok := core.ProxyFromContext(ctx)
+	if !ok {
+		return retryClient
+	}
+	// For proxied requests, create a no-keep-alive variant on the fly.
+	// The proxy transport cache is not used here because retries are rare
+	// and the no-keep-alive transport is intentionally lightweight.
+	if creds.ProxyURL == "" && creds.RelayURL == "" {
+		return retryClient
+	}
+	// Build a minimal no-keep-alive transport with proxy settings.
+	t := &http.Transport{
+		DisableKeepAlives:     true,
+		MaxIdleConns:          0,
+		MaxIdleConnsPerHost:   0,
+		IdleConnTimeout:       1 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     false,
+	}
+	if creds.ProxyURL != "" {
+		if u, err := url.Parse(creds.ProxyURL); err == nil {
+			t.Proxy = proxyFunc(u, creds.NoProxy)
+		}
+	}
+	return &http.Client{Transport: t}
 }
 
 // proxyRewrite applies relay header rewriting to req if ctx carries a RelayURL.

--- a/backend/internal/connectors/media.go
+++ b/backend/internal/connectors/media.go
@@ -3,7 +3,9 @@ package connectors
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
@@ -143,4 +145,176 @@ func (c *OpenAICompatible) Synthesize(ctx context.Context, req *core.SpeechReque
 		ct = "audio/mpeg"
 	}
 	return &core.SpeechResponse{Audio: raw.Body, ContentType: ct}, nil
+}
+
+// ---- Video generation -------------------------------------------------------
+
+// oaiVideoResponse captures the common async-job fields returned by
+// video-generation endpoints without constraining provider-specific extras
+// (those survive in VideoResponse.Raw). Different providers name the id field
+// "request_id" or "id" and the output either "url" or "video_url"/"data[].url".
+type oaiVideoResponse struct {
+	RequestID string `json:"request_id"`
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	State     string `json:"state"`
+	URL       string `json:"url"`
+	VideoURL  string `json:"video_url"`
+	Output    struct {
+		URL  string   `json:"url"`
+		URLs []string `json:"urls"`
+	} `json:"output"`
+	Data []struct {
+		URL string `json:"url"`
+	} `json:"data"`
+}
+
+// decodeVideo maps the loosely-typed upstream body onto VideoResponse while
+// preserving the raw bytes verbatim so no provider field is lost.
+func decodeVideo(model string, body []byte) *core.VideoResponse {
+	out := &core.VideoResponse{Model: model, Raw: body}
+	var raw oaiVideoResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return out
+	}
+	out.RequestID = raw.RequestID
+	if out.RequestID == "" {
+		out.RequestID = raw.ID
+	}
+	out.Status = raw.Status
+	if out.Status == "" {
+		out.Status = raw.State
+	}
+	switch {
+	case raw.URL != "":
+		out.URL = raw.URL
+	case raw.VideoURL != "":
+		out.URL = raw.VideoURL
+	case raw.Output.URL != "":
+		out.URL = raw.Output.URL
+	}
+	out.URLs = raw.Output.URLs
+	for _, d := range raw.Data {
+		if d.URL != "" {
+			out.URLs = append(out.URLs, d.URL)
+		}
+	}
+	if out.URL == "" && len(out.URLs) > 0 {
+		out.URL = out.URLs[0]
+	}
+	return out
+}
+
+// GenerateVideo submits an asynchronous video-generation job. Provider-specific
+// JSON fields are preserved while the model is rewritten for the selected route.
+// The pipeline never retries a submission after the request has been sent.
+func (c *OpenAICompatible) GenerateVideo(ctx context.Context, req *core.VideoRequest, creds core.Credentials) (*core.VideoResponse, error) {
+	body, err := videoRequestBody(req)
+	if err != nil {
+		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}
+	}
+	url := joinURL(c.baseURL(creds), "videos/generations")
+	respBody, err := doJSON(ctx, c.id, req.Model, url, body, c.headers(creds))
+	if err != nil {
+		return nil, err
+	}
+	return decodeVideo(req.Model, respBody), nil
+}
+
+func videoRequestBody(req *core.VideoRequest) ([]byte, error) {
+	if len(req.Body) == 0 {
+		return json.Marshal(map[string]string{"model": req.Model, "prompt": req.Prompt})
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(req.Body, &payload); err != nil {
+		return nil, fmt.Errorf("video request must be a JSON object: %w", err)
+	}
+	payload["model"] = req.Model
+	return json.Marshal(payload)
+}
+
+// PollVideo checks the status of an in-flight video job via GET /videos/{id}.
+func (c *OpenAICompatible) PollVideo(ctx context.Context, req *core.VideoStatusRequest, creds core.Credentials) (*core.VideoResponse, error) {
+	url := joinURL(c.baseURL(creds), "videos/"+req.RequestID)
+	respBody, err := doJSONMethod(ctx, "GET", c.id, req.Model, url, nil, c.headers(creds))
+	if err != nil {
+		return nil, err
+	}
+	out := decodeVideo(req.Model, respBody)
+	if out.RequestID == "" {
+		out.RequestID = req.RequestID
+	}
+	return out, nil
+}
+
+// ---- Image understanding (image-to-text) ------------------------------------
+
+// UnderstandImage answers a prompt about one or more input images by driving
+// the standard chat-completions endpoint with multimodal content parts. Images
+// are passed as URLs or base64 data URIs in image_url parts.
+func (c *OpenAICompatible) UnderstandImage(ctx context.Context, req *core.ImageUnderstandingRequest, creds core.Credentials) (*core.ImageUnderstandingResponse, error) {
+	type textPart struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	type imageURL struct {
+		URL string `json:"url"`
+	}
+	type imagePart struct {
+		Type     string   `json:"type"`
+		ImageURL imageURL `json:"image_url"`
+	}
+	content := make([]any, 0, len(req.Images)+1)
+	content = append(content, textPart{Type: "text", Text: req.Prompt})
+	for _, img := range req.Images {
+		if strings.TrimSpace(img) == "" {
+			continue
+		}
+		content = append(content, imagePart{Type: "image_url", ImageURL: imageURL{URL: img}})
+	}
+	payload := map[string]any{
+		"model": req.Model,
+		"messages": []map[string]any{
+			{"role": "user", "content": content},
+		},
+	}
+	if req.MaxTokens > 0 {
+		payload["max_tokens"] = req.MaxTokens
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}
+	}
+
+	url := joinURL(c.baseURL(creds), "chat/completions")
+	respBody, err := doJSON(ctx, c.id, req.Model, url, body, c.headers(creds))
+	if err != nil {
+		return nil, err
+	}
+
+	var raw struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Model: req.Model, Message: "parse understanding: " + err.Error(), Cause: err}
+	}
+	out := &core.ImageUnderstandingResponse{Model: req.Model}
+	if len(raw.Choices) > 0 {
+		out.Text = raw.Choices[0].Message.Content
+	}
+	out.Usage = core.Usage{
+		PromptTokens:     raw.Usage.PromptTokens,
+		CompletionTokens: raw.Usage.CompletionTokens,
+		TotalTokens:      raw.Usage.TotalTokens,
+	}
+	return out, nil
 }

--- a/backend/internal/connectors/media_test.go
+++ b/backend/internal/connectors/media_test.go
@@ -1,0 +1,111 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAICompatible_GenerateVideo(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/videos/generations", r.URL.Path)
+		require.Equal(t, "Bearer sk-test", r.Header.Get("Authorization"))
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"request_id":"vid_123","status":"queued"}`)
+	}))
+	defer srv.Close()
+
+	c := NewOpenAICompatible("xai", srv.URL)
+	raw := []byte(`{"model":"public-video-alias","prompt":"a cat","aspect_ratio":"16:9"}`)
+	resp, err := c.GenerateVideo(context.Background(),
+		&core.VideoRequest{Model: "grok-imagine-video", Body: raw},
+		core.Credentials{APIKey: "sk-test"})
+	require.NoError(t, err)
+	require.JSONEq(t,
+		`{"model":"grok-imagine-video","prompt":"a cat","aspect_ratio":"16:9"}`,
+		string(gotBody))
+	require.Equal(t, "vid_123", resp.RequestID)
+	require.Equal(t, "queued", resp.Status)
+	require.NotEmpty(t, resp.Raw)
+}
+
+func TestOpenAICompatible_PollVideo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/videos/vid_123", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"vid_123","status":"completed","url":"https://cdn.example/out.mp4"}`)
+	}))
+	defer srv.Close()
+
+	c := NewOpenAICompatible("xai", srv.URL)
+	resp, err := c.PollVideo(context.Background(),
+		&core.VideoStatusRequest{Model: "grok-imagine-video", RequestID: "vid_123"},
+		core.Credentials{APIKey: "sk-test"})
+	require.NoError(t, err)
+	require.Equal(t, "vid_123", resp.RequestID)
+	require.Equal(t, "completed", resp.Status)
+	require.Equal(t, "https://cdn.example/out.mp4", resp.URL)
+}
+
+func TestOpenAICompatible_UnderstandImage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/chat/completions", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Model    string `json:"model"`
+			Messages []struct {
+				Role    string `json:"role"`
+				Content []struct {
+					Type     string `json:"type"`
+					Text     string `json:"text"`
+					ImageURL struct {
+						URL string `json:"url"`
+					} `json:"image_url"`
+				} `json:"content"`
+			} `json:"messages"`
+		}
+		require.NoError(t, json.Unmarshal(body, &payload))
+		require.Equal(t, "gpt-4o", payload.Model)
+		require.Len(t, payload.Messages, 1)
+		parts := payload.Messages[0].Content
+		require.Len(t, parts, 2)
+		require.Equal(t, "text", parts[0].Type)
+		require.Equal(t, "what is this?", parts[0].Text)
+		require.Equal(t, "image_url", parts[1].Type)
+		require.True(t, strings.HasPrefix(parts[1].ImageURL.URL, "https://"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"choices":[{"message":{"role":"assistant","content":"a red apple"}}],"usage":{"prompt_tokens":10,"completion_tokens":4,"total_tokens":14}}`)
+	}))
+	defer srv.Close()
+
+	c := NewOpenAICompatible("openai", srv.URL)
+	resp, err := c.UnderstandImage(context.Background(),
+		&core.ImageUnderstandingRequest{
+			Model:  "gpt-4o",
+			Prompt: "what is this?",
+			Images: []string{"https://example.com/apple.png"},
+		},
+		core.Credentials{APIKey: "sk-test"})
+	require.NoError(t, err)
+	require.Equal(t, "a red apple", resp.Text)
+	require.Equal(t, 14, resp.Usage.TotalTokens)
+}
+
+// Compile-time assertions that the OpenAI-compatible connector satisfies the
+// new capability interfaces.
+var (
+	_ core.VideoConnector              = (*OpenAICompatible)(nil)
+	_ core.ImageUnderstandingConnector = (*OpenAICompatible)(nil)
+)

--- a/backend/internal/connectors/models.go
+++ b/backend/internal/connectors/models.go
@@ -76,6 +76,7 @@ var providerModels = map[string][]ModelSpec{
 		m("claude-sonnet-4-20250514", "Claude Sonnet 4"),
 		m("claude-opus-4-20250514", "Claude Opus 4"),
 		m("claude-3-5-sonnet-20241022", "Claude 3.5 Sonnet"),
+		k("claude-opus-4-5-20251101", "Claude Opus 4.5 (Vision)", core.ServiceImageToText),
 	},
 	"deepseek": {
 		m("deepseek-v4-pro", "DeepSeek V4 Pro"), m("deepseek-v4-pro-max", "DeepSeek V4 Pro Max"),
@@ -89,6 +90,7 @@ var providerModels = map[string][]ModelSpec{
 		m("MiniMax-M3", "MiniMax M3"),
 		m("MiniMax-M2.7", "MiniMax M2.7"), m("MiniMax-M2.5", "MiniMax M2.5"), m("MiniMax-M2.1", "MiniMax M2.1"),
 		k("minimax-image-01", "MiniMax Image 01", core.ServiceImage),
+		k("MiniMax-VL-01", "MiniMax VL 01 (Vision)", core.ServiceImageToText),
 	},
 	"minimax-cn": {m("MiniMax-M2.7", "MiniMax M2.7"), m("MiniMax-M2.5", "MiniMax M2.5"), m("MiniMax-M2.1", "MiniMax M2.1")},
 	"groq": {
@@ -97,15 +99,19 @@ var providerModels = map[string][]ModelSpec{
 		k("whisper-large-v3", "Whisper Large v3", core.ServiceSTT),
 		k("whisper-large-v3-turbo", "Whisper Large v3 Turbo", core.ServiceSTT),
 		k("distil-whisper-large-v3-en", "Distil Whisper Large v3 EN", core.ServiceSTT),
+		k("meta-llama/llama-4-maverick-17b-128e-instruct", "Llama 4 Maverick (Vision)", core.ServiceImageToText),
 	},
 	"xai": {
 		m("grok-4", "Grok 4"), m("grok-4-fast-reasoning", "Grok 4 Fast Reasoning"),
 		m("grok-code-fast-1", "Grok Code Fast"), m("grok-3", "Grok 3"),
 		k("grok-2-image-1212", "Grok 2 Image", core.ServiceImage),
+		k("grok-2-vision-1212", "Grok 2 Vision", core.ServiceImageToText),
+		k("grok-imagine-video", "Grok Imagine Video", core.ServiceVideo),
 	},
 	"mistral": {
 		m("mistral-large-latest", "Mistral Large 3"), m("codestral-latest", "Codestral"),
 		m("mistral-medium-latest", "Mistral Medium 3"), emb("mistral-embed", "Mistral Embed", 1024),
+		k("pixtral-large-latest", "Pixtral Large (Vision)", core.ServiceImageToText),
 	},
 	"perplexity": {m("sonar-pro", "Sonar Pro"), m("sonar", "Sonar")},
 	"together": {
@@ -309,6 +315,63 @@ var providerModels = map[string][]ModelSpec{
 		m("kimi-k2.5", "Kimi-K2.5"), m("nemotron-3-ultra-fp4", "Nemotron 3 Ultra FP4"),
 		m("minimax-m2.7", "MiniMax-M2.7"), m("claude-opus-4-6", "Claude Opus 4.6"),
 		m("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+		k("claude-opus-4-6", "Claude Opus 4.6 (Vision)", core.ServiceImageToText),
+	},
+	"clinepass": {
+		m("cline-pass/glm-5.2", "GLM-5.2 (ClinePass)"),
+		m("cline-pass/kimi-k2.7-code", "Kimi K2.7 Code (ClinePass)"),
+		m("cline-pass/kimi-k2.6", "Kimi K2.6 (ClinePass)"),
+		m("cline-pass/deepseek-v4-pro", "DeepSeek V4 Pro (ClinePass)"),
+		m("cline-pass/deepseek-v4-flash", "DeepSeek V4 Flash (ClinePass)"),
+		m("cline-pass/minimax-m3", "MiniMax M3 (ClinePass)"),
+		m("cline-pass/qwen3.7-max", "Qwen3.7 Max (ClinePass)"),
+		m("cline-pass/qwen3.7-plus", "Qwen3.7 Plus (ClinePass)"),
+	},
+	"grok-cli": {
+		m("grok-build", "Grok Build"), m("grok-4.5", "Grok 4.5"),
+		m("grok-4.5-high", "Grok 4.5 (High)"), m("grok-4.5-medium", "Grok 4.5 (Medium)"),
+		m("grok-4.5-low", "Grok 4.5 (Low)"),
+	},
+	"venice": {
+		m("venice-uncensored-1-2", "Venice Uncensored 1.2"), m("zai-org-glm-5", "GLM-5"),
+		m("qwen3-235b-a22b-instruct-2507", "Qwen3 235B A22B Instruct"),
+		m("qwen3-coder-480b-a35b-instruct-turbo", "Qwen3 Coder 480B A35B Turbo"),
+		m("qwen3-vl-235b-a22b", "Qwen3 VL 235B A22B"), m("deepseek-v4-pro", "DeepSeek V4 Pro"),
+		m("llama-3.3-70b", "Llama 3.3 70B"), m("hermes-3-llama-3.1-405b", "Hermes 3 Llama 3.1 405B"),
+		m("mistral-small-3-2-24b-instruct", "Mistral Small 3.2 24B"),
+		emb("text-embedding-3-large", "Text Embedding 3 Large", 3072),
+		emb("text-embedding-bge-m3", "BGE-M3 Embedding", 1024),
+		emb("text-embedding-qwen3-8b", "Qwen3 8B Embedding", 4096),
+		k("venice-sd35", "Venice SD3.5", core.ServiceImage), k("flux-2-pro", "FLUX.2 Pro", core.ServiceImage),
+		k("gpt-image-2", "GPT Image 2 (via Venice)", core.ServiceImage),
+	},
+	"featherless": {
+		m("deepseek-ai/DeepSeek-V4-Pro", "DeepSeek V4 Pro"), m("deepseek-ai/DeepSeek-V4-Flash", "DeepSeek V4 Flash"),
+		m("zai-org/GLM-5.2", "GLM 5.2"), m("zai-org/GLM-5.1", "GLM 5.1"),
+		m("moonshotai/Kimi-K2.7-Code", "Kimi K2.7 Code"), m("moonshotai/Kimi-K2.6", "Kimi K2.6"),
+		m("moonshotai/Kimi-K2.5", "Kimi K2.5"),
+	},
+	"perplexity-agent": {
+		m("perplexity/sonar", "Perplexity Sonar"), m("openai/gpt-5.5", "GPT-5.5"),
+		m("openai/gpt-5.4", "GPT-5.4"), m("openai/gpt-5.4-mini", "GPT-5.4 Mini"),
+		m("anthropic/claude-sonnet-4-6", "Claude Sonnet 4.6"), m("anthropic/claude-opus-4-8", "Claude Opus 4.8"),
+		m("google/gemini-3.1-pro-preview", "Gemini 3.1 Pro"), m("xai/grok-4.20-reasoning", "Grok 4.20 Reasoning"),
+		m("perplexity/glm-5.2", "GLM 5.2"), m("perplexity/kimi-k2.7-code", "Kimi K2.7 Code"),
+		m("nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super 120B"),
+	},
+	"mmf": {m("mimo-auto", "MiMo Auto")},
+
+	// Passthrough providers: expose representative media-tagged models so the
+	// media catalog can surface their image-understanding / video routes.
+	"openrouter": {
+		k("openai/gpt-4o", "GPT-4o (Vision)", core.ServiceImageToText),
+		k("anthropic/claude-opus-4.5", "Claude Opus 4.5 (Vision)", core.ServiceImageToText),
+	},
+	"vertex": {
+		k("gemini-2.5-pro", "Gemini 2.5 Pro (Vision)", core.ServiceImageToText),
+	},
+	"vercel-ai-gateway": {
+		k("openai/gpt-4o", "GPT-4o (Vision)", core.ServiceImageToText),
 	},
 	"opencode-go":  {m("kimi-k2.6", "Kimi K2.6"), m("glm-5.1", "GLM 5.1"), m("qwen3.6-plus", "Qwen 3.6 Plus")},
 	"ollama":       {m("gpt-oss:120b", "GPT OSS 120B"), m("kimi-k2.5", "Kimi K2.5"), m("glm-5", "GLM 5"), m("qwen3.5", "Qwen3.5")},
@@ -319,6 +382,7 @@ var providerModels = map[string][]ModelSpec{
 		emb("gemini-embedding-001", "Gemini Embedding 001", 768), emb("text-embedding-004", "Text Embedding 004", 768),
 		k("gemini-2.5-flash-image", "Gemini 2.5 Flash Image (Nano Banana)", core.ServiceImage),
 		k("gemini-2.5-pro-preview-tts", "Gemini 2.5 Pro TTS", core.ServiceTTS),
+		k("gemini-2.5-pro", "Gemini 2.5 Pro (Vision)", core.ServiceImageToText),
 	},
 	// Media providers.
 	"deepgram":   {k("nova-3", "Nova 3", core.ServiceSTT), k("nova-2", "Nova 2", core.ServiceSTT), k("whisper-large", "Whisper Large", core.ServiceSTT)},

--- a/backend/internal/connectors/providers_test.go
+++ b/backend/internal/connectors/providers_test.go
@@ -861,10 +861,10 @@ func TestCatalog_HasProviderSpecs(t *testing.T) {
 
 func TestCatalog_AliasResolution(t *testing.T) {
 	cases := map[string]string{
-		"kr":    "kiro",
-		"ag":    "antigravity",
-		"mimo":  "xiaomi-mimo",
-		"mmtp":  "xiaomi-tokenplan",
+		"kr":   "kiro",
+		"ag":   "antigravity",
+		"mimo": "xiaomi-mimo",
+		"mmtp": "xiaomi-tokenplan",
 	}
 	for alias, wantID := range cases {
 		spec, ok := SpecByAlias(alias)

--- a/backend/internal/core/connector.go
+++ b/backend/internal/core/connector.go
@@ -119,6 +119,25 @@ type FetchConnector interface {
 	Fetch(ctx context.Context, req *FetchRequest, creds Credentials) (*FetchResponse, error)
 }
 
+// VideoConnector is implemented by providers that generate video. Generation
+// is asynchronous: GenerateVideo submits the job and returns a request id plus
+// status, and PollVideo checks progress until the output url(s) are ready. The
+// connector forwards the client payload transparently and passes the upstream
+// response back verbatim.
+type VideoConnector interface {
+	// GenerateVideo submits a video-generation job. It must never be
+	// auto-retried on a network error to avoid duplicate submissions.
+	GenerateVideo(ctx context.Context, req *VideoRequest, creds Credentials) (*VideoResponse, error)
+	// PollVideo returns the current state of an in-flight video job.
+	PollVideo(ctx context.Context, req *VideoStatusRequest, creds Credentials) (*VideoResponse, error)
+}
+
+// ImageUnderstandingConnector is implemented by providers whose vision models
+// can describe or answer questions about an input image (image-to-text).
+type ImageUnderstandingConnector interface {
+	UnderstandImage(ctx context.Context, req *ImageUnderstandingRequest, creds Credentials) (*ImageUnderstandingResponse, error)
+}
+
 // DirectStreamable is optionally implemented by connectors that can return the
 // raw upstream SSE stream as an io.ReadCloser. The pipeline uses this for
 // zero-copy same-dialect streaming: when the client dialect matches the

--- a/backend/internal/core/errors.go
+++ b/backend/internal/core/errors.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -24,6 +25,9 @@ const (
 	ErrTimeout ErrorKind = "timeout"
 	// ErrBadRequest: 4xx caused by the request itself. Do NOT fall back; surface.
 	ErrBadRequest ErrorKind = "bad_request"
+	// ErrModelUnavailable: the selected model or endpoint is unavailable. Skip
+	// the model without disabling credentials that may still serve other models.
+	ErrModelUnavailable ErrorKind = "model_unavailable"
 	// ErrCapability: chosen model lacks a required capability. Skip, no surface.
 	ErrCapability ErrorKind = "capability"
 	// ErrBudgetBlocked: KeiRouter budget guard rejected before dispatch.
@@ -34,6 +38,21 @@ const (
 	ErrPolicyBlocked ErrorKind = "policy_blocked"
 	// ErrInternal: router-internal fault.
 	ErrInternal ErrorKind = "internal"
+	// ErrClientCanceled: the client disconnected mid-request. Not a provider
+	// failure — must not trigger cooldowns or health penalties.
+	ErrClientCanceled ErrorKind = "client_canceled"
+)
+
+// FailureScope identifies the narrowest resource affected by a provider error.
+// Cooldowns and circuit breakers use this to avoid disabling healthy siblings.
+type FailureScope string
+
+const (
+	FailureScopeRequest  FailureScope = "request"
+	FailureScopeModel    FailureScope = "model"
+	FailureScopeAccount  FailureScope = "account"
+	FailureScopeProvider FailureScope = "provider"
+	FailureScopeNetwork  FailureScope = "network"
 )
 
 // ProviderError is the structured error connectors and the pipeline return. It
@@ -41,6 +60,8 @@ const (
 // the gateway to render an accurate HTTP status to the client.
 type ProviderError struct {
 	Kind ErrorKind
+	// Scope is the narrowest routing resource affected by the failure.
+	Scope FailureScope
 	// Provider and Model identify where the failure originated.
 	Provider string
 	Model    string
@@ -79,11 +100,67 @@ func (e *ProviderError) Retryable() bool {
 // candidate in the chain rather than surfacing this error to the client.
 func (e *ProviderError) Fallbackable() bool {
 	switch e.Kind {
-	case ErrBadRequest, ErrBudgetBlocked, ErrPolicyBlocked:
+	case ErrBadRequest, ErrBudgetBlocked, ErrPolicyBlocked, ErrClientCanceled:
 		return false
 	default:
 		return true
 	}
+}
+
+// EffectiveScope returns the explicit failure scope or a conservative default
+// derived from the error kind.
+func (e *ProviderError) EffectiveScope() FailureScope {
+	if e == nil {
+		return FailureScopeRequest
+	}
+	if e.Scope != "" {
+		return e.Scope
+	}
+	switch e.Kind {
+	case ErrModelUnavailable, ErrCapability:
+		return FailureScopeModel
+	case ErrAuth, ErrRateLimit, ErrQuotaExhausted:
+		return FailureScopeAccount
+	case ErrUpstream, ErrTimeout:
+		return FailureScopeProvider
+	default:
+		return FailureScopeRequest
+	}
+}
+
+// RetryDecision is the stable routing view of a ProviderError.
+type RetryDecision struct {
+	Retryable    bool
+	Fallbackable bool
+	Scope        FailureScope
+	RetryAfter   time.Duration
+}
+
+// Decision returns the retry and fallback policy carried by this error.
+func (e *ProviderError) Decision() RetryDecision {
+	if e == nil {
+		return RetryDecision{}
+	}
+	return RetryDecision{
+		Retryable:    e.Retryable(),
+		Fallbackable: e.Fallbackable(),
+		Scope:        e.EffectiveScope(),
+		RetryAfter:   e.RetryAfter,
+	}
+}
+
+// IsClientDisconnect reports whether err indicates the client disconnected
+// rather than a provider connection failure. Socket text is intentionally not
+// inspected here because the same reset strings can originate upstream.
+func IsClientDisconnect(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	var pe *ProviderError
+	return errors.As(err, &pe) && pe.Kind == ErrClientCanceled
 }
 
 // AsProviderError extracts a *ProviderError from err, or wraps it as ErrInternal.
@@ -94,6 +171,22 @@ func AsProviderError(err error) *ProviderError {
 	var pe *ProviderError
 	if errors.As(err, &pe) {
 		return pe
+	}
+	if errors.Is(err, context.Canceled) {
+		return &ProviderError{
+			Kind:    ErrClientCanceled,
+			Scope:   FailureScopeRequest,
+			Message: "client canceled request",
+			Cause:   err,
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return &ProviderError{
+			Kind:    ErrTimeout,
+			Scope:   FailureScopeRequest,
+			Message: "request deadline exceeded",
+			Cause:   err,
+		}
 	}
 	return &ProviderError{Kind: ErrInternal, Message: err.Error(), Cause: err}
 }

--- a/backend/internal/core/errors_test.go
+++ b/backend/internal/core/errors_test.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestAsProviderErrorClassifiesLocalContextErrors(t *testing.T) {
+	canceled := AsProviderError(context.Canceled)
+	if canceled.Kind != ErrClientCanceled || canceled.EffectiveScope() != FailureScopeRequest {
+		t.Fatalf("canceled error = kind %q scope %q", canceled.Kind, canceled.EffectiveScope())
+	}
+
+	deadline := AsProviderError(context.DeadlineExceeded)
+	if deadline.Kind != ErrTimeout || deadline.EffectiveScope() != FailureScopeRequest {
+		t.Fatalf("deadline error = kind %q scope %q", deadline.Kind, deadline.EffectiveScope())
+	}
+}
+
+func TestIsClientDisconnectDoesNotGuessFromSocketText(t *testing.T) {
+	if !IsClientDisconnect(context.Canceled) {
+		t.Fatal("context cancellation must be classified as a client disconnect")
+	}
+	if IsClientDisconnect(errors.New("read: connection reset by peer")) {
+		t.Fatal("an upstream socket reset must not be classified as a client disconnect")
+	}
+}
+
+func TestProviderErrorDecision(t *testing.T) {
+	pe := &ProviderError{Kind: ErrRateLimit, RetryAfter: 3 * time.Second}
+	got := pe.Decision()
+	if !got.Retryable || !got.Fallbackable || got.Scope != FailureScopeAccount || got.RetryAfter != 3*time.Second {
+		t.Fatalf("unexpected retry decision: %+v", got)
+	}
+
+	model := (&ProviderError{Kind: ErrModelUnavailable}).Decision()
+	if model.Retryable || !model.Fallbackable || model.Scope != FailureScopeModel {
+		t.Fatalf("unexpected model decision: %+v", model)
+	}
+}

--- a/backend/internal/core/media.go
+++ b/backend/internal/core/media.go
@@ -61,8 +61,8 @@ type TranscriptionRequest struct {
 
 // TranscriptionResponse is the canonical transcription result.
 type TranscriptionResponse struct {
-	Text     string `json:"text"`
-	Language string `json:"language,omitempty"`
+	Text     string  `json:"text"`
+	Language string  `json:"language,omitempty"`
 	Duration float64 `json:"duration,omitempty"`
 }
 
@@ -113,6 +113,65 @@ type SearchResult struct {
 type SearchResponse struct {
 	Query   string         `json:"query"`
 	Results []SearchResult `json:"results"`
+}
+
+// ---- Video generation -------------------------------------------------------
+
+// VideoRequest is a canonical text-to-video request. Video generation is an
+// asynchronous job upstream: submission returns a request id and a status, and
+// the caller polls for completion. Body carries the raw client payload so
+// provider-specific knobs (duration, aspect_ratio, resolution, ...) pass
+// through untouched.
+type VideoRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt,omitempty"`
+	// Body carries provider-specific JSON fields that are not modeled above.
+	// The connector rewrites its model field for each resolved routing attempt.
+	Body []byte `json:"-"`
+	// ContentType is the original JSON media type.
+	ContentType string `json:"-"`
+}
+
+// VideoStatusRequest polls an in-flight video job by its upstream request id.
+type VideoStatusRequest struct {
+	Model     string `json:"model"`
+	RequestID string `json:"request_id"`
+}
+
+// VideoResponse is the canonical video-generation result. It mirrors the async
+// job shape: a request id to poll, a status, and (when done) the output url(s).
+type VideoResponse struct {
+	Model     string   `json:"model,omitempty"`
+	RequestID string   `json:"request_id,omitempty"`
+	Status    string   `json:"status,omitempty"`
+	URL       string   `json:"url,omitempty"`
+	URLs      []string `json:"urls,omitempty"`
+	// Raw is the untouched upstream JSON, passed back verbatim so clients get
+	// every provider-specific field without lossy re-shaping.
+	Raw []byte `json:"-"`
+	// AccountID pins subsequent job polling to the credential that submitted it.
+	AccountID string `json:"-"`
+}
+
+// ---- Image understanding (image-to-text) ------------------------------------
+
+// ImageUnderstandingRequest asks a vision model to describe or answer questions
+// about an input image. Images are carried as URLs or base64 data URIs.
+type ImageUnderstandingRequest struct {
+	Model string `json:"model"`
+	// Prompt is the question/instruction about the image(s).
+	Prompt string `json:"prompt"`
+	// Images holds image URLs or base64 data URIs (data:image/...;base64,...).
+	Images []string `json:"images"`
+	// MaxTokens caps the generated description length.
+	MaxTokens int `json:"max_tokens,omitempty"`
+}
+
+// ImageUnderstandingResponse carries the model's textual answer.
+type ImageUnderstandingResponse struct {
+	Model string `json:"model"`
+	Text  string `json:"text"`
+	Usage Usage  `json:"usage"`
 }
 
 // ---- Web fetch --------------------------------------------------------------

--- a/backend/internal/core/service.go
+++ b/backend/internal/core/service.go
@@ -23,6 +23,11 @@ const (
 	ServiceSearch ServiceKind = "search"
 	// ServiceFetch retrieves and extracts the content of a URL.
 	ServiceFetch ServiceKind = "fetch"
+	// ServiceVideo generates video from a prompt (async job: submit + poll).
+	ServiceVideo ServiceKind = "video"
+	// ServiceImageToText answers questions about / describes an input image
+	// (image understanding / vision).
+	ServiceImageToText ServiceKind = "image_to_text"
 )
 
 // AllServiceKinds lists every supported service kind in a stable order.
@@ -30,13 +35,15 @@ func AllServiceKinds() []ServiceKind {
 	return []ServiceKind{
 		ServiceLLM, ServiceEmbedding, ServiceImage,
 		ServiceSTT, ServiceTTS, ServiceSearch, ServiceFetch,
+		ServiceVideo, ServiceImageToText,
 	}
 }
 
 // ValidServiceKind reports whether s is a recognized service kind.
 func ValidServiceKind(s ServiceKind) bool {
 	switch s {
-	case ServiceLLM, ServiceEmbedding, ServiceImage, ServiceSTT, ServiceTTS, ServiceSearch, ServiceFetch:
+	case ServiceLLM, ServiceEmbedding, ServiceImage, ServiceSTT, ServiceTTS,
+		ServiceSearch, ServiceFetch, ServiceVideo, ServiceImageToText:
 		return true
 	default:
 		return false

--- a/backend/internal/dispatch/dispatch.go
+++ b/backend/internal/dispatch/dispatch.go
@@ -18,8 +18,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
+	"sort"
+	"sync"
 	"time"
 
 	"github.com/mydisha/keirouter/backend/internal/capability"
@@ -47,6 +50,15 @@ const (
 	// DefaultStickyLimit is the number of consecutive requests served by one
 	// target before round-robin advances to the next.
 	DefaultStickyLimit = 1
+	// ProviderCircuitFailureThreshold opens a provider circuit after this many
+	// consecutive network/upstream failures.
+	ProviderCircuitFailureThreshold = 3
+	// ProviderCircuitBaseCooldown is the first open interval.
+	ProviderCircuitBaseCooldown = 5 * time.Second
+	// ProviderCircuitMaxCooldown caps repeated provider outages.
+	ProviderCircuitMaxCooldown = 2 * time.Minute
+	// ProviderCircuitResetWindow forgets isolated failures after a quiet period.
+	ProviderCircuitResetWindow = time.Minute
 )
 
 // Target is one candidate in a fallback chain.
@@ -103,6 +115,7 @@ type RoutingSource interface {
 	ClearModelCooldown(ctx context.Context, accountID, model string) error
 	IsModelCooldownActive(ctx context.Context, accountID, model string) (bool, error)
 	ActiveCooldowns(ctx context.Context, accountIDs []string, model string) (map[string]bool, error)
+	ActiveCooldownExpirations(ctx context.Context, accountIDs []string, model string) (map[string]time.Time, error)
 	GetChainRotationState(ctx context.Context, chainID string) (store.ChainRotation, error)
 	SetChainRotationState(ctx context.Context, state store.ChainRotation) error
 	GetTargetRotationState(ctx context.Context, scopeKey string) (store.TargetRotation, error)
@@ -129,9 +142,20 @@ type Dispatcher struct {
 	routing     RoutingSource
 	health      HealthSource
 	proxyReader GlobalProxyReader
+	// selectionLocks serializes rotation/affinity selection per provider so
+	// concurrent requests do not all observe and choose the same cursor.
+	selectionLocks sync.Map
+	circuitMu      sync.Mutex
+	circuits       map[string]providerCircuit
 	// defaultCooldown is applied to an account when an error carries no
 	// upstream-specified Retry-After.
 	defaultCooldown time.Duration
+}
+
+type providerCircuit struct {
+	Failures    int
+	LastFailure time.Time
+	OpenUntil   time.Time
 }
 
 // New builds a Dispatcher.
@@ -141,6 +165,7 @@ func New(conns ConnectorSource, accounts *store.AccountRepo, v *vault.Vault) *Di
 		accounts:        accounts,
 		vault:           v,
 		defaultCooldown: 60 * time.Second,
+		circuits:        make(map[string]providerCircuit),
 	}
 }
 
@@ -187,6 +212,31 @@ type PlanOptions struct {
 	AccountAffinityTTL time.Duration
 	// ProviderAccountStrategies overrides account routing per provider.
 	ProviderAccountStrategies map[string]AccountRoutingOptions
+	// ExcludedAccountIDs prevents failed credentials from being selected again
+	// while a request dynamically re-plans its next attempt.
+	ExcludedAccountIDs map[string]struct{}
+	// ExcludedAttempts prevents one provider/model/account combination from
+	// being selected twice during dynamic re-planning.
+	ExcludedAttempts map[AttemptKey]struct{}
+	// AllowedAccountIDs pins account-bound operations to a known credential.
+	// Empty means every otherwise eligible account is allowed.
+	AllowedAccountIDs map[string]struct{}
+}
+
+// AttemptKey uniquely identifies one routed provider/model/account candidate.
+type AttemptKey struct {
+	Provider  string
+	Model     string
+	AccountID string
+}
+
+// Key returns the stable identity used to exclude an already-tried attempt.
+func (a Attempt) Key() AttemptKey {
+	return AttemptKey{
+		Provider:  a.Target.Provider,
+		Model:     a.Target.Model,
+		AccountID: a.Account.ID,
+	}
 }
 
 // AccountRoutingOptions is the provider-scoped subset of PlanOptions used for
@@ -212,6 +262,9 @@ func (d *Dispatcher) Plan(ctx context.Context, tenantID string, targets []Target
 
 // PlanWith is like Plan but accepts strategy options.
 func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Target, required core.CapabilitySet, opts PlanOptions) ([]Attempt, error) {
+	unlock := d.lockSelection(targets)
+	defer unlock()
+
 	// Apply round-robin rotation if requested.
 	ordered := d.applyRotation(ctx, targets, opts)
 	hardRequired := capability.NonStrippable(required)
@@ -270,6 +323,8 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 	attempts := make([]Attempt, 0, len(ordered))
 	unhealthyAttempts := make([]Attempt, 0, len(ordered))
 	var lastReason string
+	var earliestRetryAt time.Time
+	blockedScope := core.FailureScopeAccount
 
 	for i, target := range ordered {
 		// Capability guard: never fall back to a model that cannot honor the
@@ -277,6 +332,15 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 		// the guard because their upstream capabilities are unknown.
 		if !eligible[i] {
 			lastReason = fmt.Sprintf("model %q lacks required capabilities", target.Model)
+			continue
+		}
+		if remaining := d.providerCircuitRemaining(target.Provider, now); remaining > 0 {
+			retryAt := now.Add(remaining)
+			if earliestRetryAt.IsZero() || retryAt.Before(earliestRetryAt) {
+				earliestRetryAt = retryAt
+				blockedScope = core.FailureScopeProvider
+			}
+			lastReason = fmt.Sprintf("provider %s temporarily unavailable", target.Provider)
 			continue
 		}
 
@@ -298,9 +362,9 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 		accs = d.applyAccountRouting(ctx, tenantID, target, accs, opts.accountRoutingForTarget(target.Provider))
 		accountIDs := accountIDsByProvider[target.Provider]
 
-		var cooldownSet map[string]bool
+		var cooldownExpirations map[string]time.Time
 		if d.routing != nil && len(accountIDs) > 0 {
-			cooldownSet, _ = d.routing.ActiveCooldowns(ctx, accountIDs, target.Model)
+			cooldownExpirations, _ = d.routing.ActiveCooldownExpirations(ctx, accountIDs, target.Model)
 		}
 		var unhealthySet map[string]bool
 		if d.health != nil && len(accountIDs) > 0 {
@@ -308,8 +372,27 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 		}
 
 		for _, acc := range accs {
+			key := AttemptKey{Provider: target.Provider, Model: target.Model, AccountID: acc.ID}
+			if _, excluded := opts.ExcludedAttempts[key]; excluded {
+				lastReason = fmt.Sprintf("account %s already attempted for model %s", acc.ID, target.Model)
+				continue
+			}
+			if _, excluded := opts.ExcludedAccountIDs[acc.ID]; excluded {
+				lastReason = fmt.Sprintf("account %s already attempted", acc.ID)
+				continue
+			}
+			if len(opts.AllowedAccountIDs) > 0 {
+				if _, allowed := opts.AllowedAccountIDs[acc.ID]; !allowed {
+					lastReason = fmt.Sprintf("account %s is not selected for this operation", acc.ID)
+					continue
+				}
+			}
 			// Account-level cooldown (global cooldown from NoteFailure).
 			if acc.CooldownUntil != nil && acc.CooldownUntil.After(now) {
+				if earliestRetryAt.IsZero() || acc.CooldownUntil.Before(earliestRetryAt) {
+					earliestRetryAt = *acc.CooldownUntil
+					blockedScope = core.FailureScopeAccount
+				}
 				lastReason = fmt.Sprintf("account %s on cooldown", acc.ID)
 				continue
 			}
@@ -320,7 +403,11 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 				continue
 			}
 			// Model-level cooldown: skip this account only for this model.
-			if cooldownSet != nil && cooldownSet[acc.ID] {
+			if until, cooling := cooldownExpirations[acc.ID]; cooling {
+				if earliestRetryAt.IsZero() || until.Before(earliestRetryAt) {
+					earliestRetryAt = until
+					blockedScope = core.FailureScopeModel
+				}
 				lastReason = fmt.Sprintf("account %s model %s on cooldown", acc.ID, target.Model)
 				continue
 			}
@@ -373,6 +460,25 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 	}
 
 	if len(attempts) == 0 {
+		if !earliestRetryAt.IsZero() {
+			retryAfter := time.Until(earliestRetryAt)
+			if retryAfter < 0 {
+				retryAfter = 0
+			}
+			return nil, &core.ProviderError{
+				Kind:       core.ErrRateLimit,
+				Scope:      blockedScope,
+				Message:    "dispatch: all matching candidates are temporarily unavailable",
+				RetryAfter: retryAfter,
+			}
+		}
+		if len(opts.AllowedAccountIDs) > 0 {
+			return nil, &core.ProviderError{
+				Kind:    core.ErrBadRequest,
+				Scope:   core.FailureScopeRequest,
+				Message: "dispatch: selected account is unavailable for this route",
+			}
+		}
 		if lastReason == "" {
 			lastReason = "no usable targets in chain"
 		}
@@ -384,8 +490,36 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 // NoteFailure applies cooldowns to an account (and optionally a model) based on
 // a provider error. Exponential backoff increases the cooldown on repeated
 // failures for rate-limit / quota errors.
+//
+// Two categories of error are explicitly NOT cooled down:
+//   - Client cancellations (user pressed Esc, client closed connection): the
+//     provider may be perfectly healthy; penalizing it causes false fallbacks.
+//   - Self-inflicted timeouts (our own deadline fired while the upstream was
+//     still processing): again, the provider is healthy — we gave up, not them.
 func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *core.ProviderError) {
 	if err == nil {
+		return
+	}
+
+	scope := err.EffectiveScope()
+	if err.Kind == core.ErrClientCanceled || scope == core.FailureScopeRequest {
+		return
+	}
+
+	if (scope == core.FailureScopeProvider || scope == core.FailureScopeNetwork) &&
+		(err.Kind == core.ErrUpstream || err.Kind == core.ErrTimeout) {
+		d.recordProviderFailure(err.Provider)
+	}
+
+	if scope == core.FailureScopeModel {
+		cooldown := 5 * time.Minute
+		if err.RetryAfter > cooldown {
+			cooldown = err.RetryAfter
+		}
+		err.RetryAfter = cooldown
+		if d.routing != nil && err.Model != "" {
+			_ = d.routing.SetModelCooldown(ctx, accountID, err.Model, time.Now().Add(cooldown))
+		}
 		return
 	}
 
@@ -405,6 +539,13 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 	case core.ErrAuth:
 		cooldown = 5 * time.Minute
 	case core.ErrUpstream, core.ErrTimeout:
+		// Self-inflicted timeout: our own request deadline fired while the
+		// upstream was still processing. The provider is healthy — skip
+		// cooldown to avoid penalizing a working account.
+		if err.Kind == core.ErrTimeout && err.StatusCode == 0 &&
+			errors.Is(err.Cause, context.DeadlineExceeded) {
+			return
+		}
 		// Transient errors: apply a short cooldown so the account gets a
 		// breather without being locked out for too long.
 		cooldown = TransientCooldown
@@ -418,6 +559,7 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 	if err.RetryAfter > cooldown {
 		cooldown = err.RetryAfter
 	}
+	err.RetryAfter = cooldown
 
 	_ = d.accounts.SetCooldown(ctx, accountID, time.Now().Add(cooldown))
 
@@ -431,7 +573,7 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 
 // NoteSuccess resets the backoff level for an account and clears any model
 // cooldown. Called by the pipeline after a successful upstream response.
-func (d *Dispatcher) NoteSuccess(ctx context.Context, accountID, model string) {
+func (d *Dispatcher) NoteSuccess(ctx context.Context, provider, accountID, model string) {
 	_ = d.accounts.ResetBackoffLevel(ctx, accountID)
 	if d.routing != nil && model != "" {
 		_ = d.routing.ClearModelCooldown(ctx, accountID, model)
@@ -439,6 +581,7 @@ func (d *Dispatcher) NoteSuccess(ctx context.Context, accountID, model string) {
 	if d.health != nil && model != "" {
 		_ = d.health.MarkHealthy(ctx, accountID, model)
 	}
+	d.recordProviderSuccess(provider)
 }
 
 // exponentialCooldown computes the cooldown duration using exponential backoff.
@@ -615,6 +758,106 @@ func moveAccountToFront(accounts []store.Account, accountID string) ([]store.Acc
 	out = append(out, accounts[:idx]...)
 	out = append(out, accounts[idx+1:]...)
 	return out, true
+}
+
+// EvictAccountAffinity expires a smart-routing pin after its account fails so
+// the next request is not sent straight back to a cooling credential.
+func (d *Dispatcher) EvictAccountAffinity(ctx context.Context, tenantID string, target Target, opts PlanOptions, accountID string) {
+	if d.routing == nil || accountID == "" {
+		return
+	}
+	accountOpts := opts.accountRoutingForTarget(target.Provider)
+	if accountOpts.Strategy != StrategySmartRoundRobin || accountOpts.AffinityKey == "" {
+		return
+	}
+	scopeKey := accountAffinityKey(tenantID, target, accountOpts.AffinityKey)
+	affinity, err := d.routing.GetAccountAffinity(ctx, scopeKey)
+	if err != nil || affinity.AccountID != accountID {
+		return
+	}
+	_ = d.routing.SetAccountAffinity(ctx, store.AccountAffinity{
+		ScopeKey:  scopeKey,
+		AccountID: "",
+		ExpiresAt: time.Unix(0, 0),
+	})
+}
+
+func (d *Dispatcher) lockSelection(targets []Target) func() {
+	providers := make([]string, 0, len(targets))
+	seen := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		if target.Provider == "" {
+			continue
+		}
+		if _, ok := seen[target.Provider]; ok {
+			continue
+		}
+		seen[target.Provider] = struct{}{}
+		providers = append(providers, target.Provider)
+	}
+	sort.Strings(providers)
+	locks := make([]*sync.Mutex, 0, len(providers))
+	for _, provider := range providers {
+		value, _ := d.selectionLocks.LoadOrStore(provider, &sync.Mutex{})
+		lock := value.(*sync.Mutex)
+		lock.Lock()
+		locks = append(locks, lock)
+	}
+	return func() {
+		for i := len(locks) - 1; i >= 0; i-- {
+			locks[i].Unlock()
+		}
+	}
+}
+
+func (d *Dispatcher) recordProviderFailure(provider string) {
+	if provider == "" {
+		return
+	}
+	now := time.Now()
+	d.circuitMu.Lock()
+	defer d.circuitMu.Unlock()
+	state := d.circuits[provider]
+	if !state.LastFailure.IsZero() && now.Sub(state.LastFailure) > ProviderCircuitResetWindow {
+		state.Failures = 0
+		state.OpenUntil = time.Time{}
+	}
+	state.Failures++
+	state.LastFailure = now
+	if state.Failures >= ProviderCircuitFailureThreshold {
+		exponent := state.Failures - ProviderCircuitFailureThreshold
+		if exponent > 10 {
+			exponent = 10
+		}
+		cooldown := ProviderCircuitBaseCooldown * time.Duration(1<<exponent)
+		if cooldown > ProviderCircuitMaxCooldown {
+			cooldown = ProviderCircuitMaxCooldown
+		}
+		state.OpenUntil = now.Add(cooldown)
+	}
+	d.circuits[provider] = state
+}
+
+func (d *Dispatcher) recordProviderSuccess(provider string) {
+	if provider == "" {
+		return
+	}
+	d.circuitMu.Lock()
+	delete(d.circuits, provider)
+	d.circuitMu.Unlock()
+}
+
+func (d *Dispatcher) providerCircuitRemaining(provider string, now time.Time) time.Duration {
+	if provider == "" {
+		return 0
+	}
+	d.circuitMu.Lock()
+	defer d.circuitMu.Unlock()
+	state, ok := d.circuits[provider]
+	if !ok || !state.OpenUntil.After(now) {
+		return 0
+	}
+	return state.OpenUntil.Sub(now)
 }
 
 // advanceRotationState returns the cursor to use for this request, plus the

--- a/backend/internal/dispatch/dispatch_test.go
+++ b/backend/internal/dispatch/dispatch_test.go
@@ -281,6 +281,94 @@ func TestNoteFailureHonorsRateLimitRetryAfter(t *testing.T) {
 	require.WithinDuration(t, started.Add(4*time.Minute), *account.CooldownUntil, 2*time.Second)
 }
 
+func TestPlanWith_AllowedAccountPinsCredential(t *testing.T) {
+	ctx := context.Background()
+	d, _ := newDispatchTest(t,
+		testAccount("acc-1", 10),
+		testAccount("acc-2", 20),
+	)
+
+	attempts, err := d.PlanWith(ctx, store.DefaultTenantID,
+		[]Target{{Provider: "openai", Model: "gpt-4o"}},
+		core.NewCapabilitySet(),
+		PlanOptions{AllowedAccountIDs: map[string]struct{}{"acc-2": {}}},
+	)
+	require.NoError(t, err)
+	require.Len(t, attempts, 1)
+	require.Equal(t, "acc-2", attempts[0].Account.ID)
+}
+
+func TestPlanWith_UnknownAllowedAccountIsRequestError(t *testing.T) {
+	ctx := context.Background()
+	d, _ := newDispatchTest(t, testAccount("acc-1", 10))
+
+	attempts, err := d.PlanWith(ctx, store.DefaultTenantID,
+		[]Target{{Provider: "openai", Model: "gpt-4o"}},
+		core.NewCapabilitySet(),
+		PlanOptions{AllowedAccountIDs: map[string]struct{}{"missing": {}}},
+	)
+	require.Empty(t, attempts)
+	pe := core.AsProviderError(err)
+	require.Equal(t, core.ErrBadRequest, pe.Kind)
+	require.Equal(t, core.FailureScopeRequest, pe.EffectiveScope())
+}
+
+func TestPlanWith_ExcludedAttemptStillAllowsOtherModelOnSameAccount(t *testing.T) {
+	ctx := context.Background()
+	d, _ := newDispatchTest(t, testAccount("acc-1", 10))
+	targets := []Target{
+		{Provider: "openai", Model: "gpt-4o"},
+		{Provider: "openai", Model: "gpt-5"},
+	}
+
+	attempts, err := d.PlanWith(ctx, store.DefaultTenantID, targets, core.NewCapabilitySet(),
+		PlanOptions{ExcludedAttempts: map[AttemptKey]struct{}{
+			{Provider: "openai", Model: "gpt-4o", AccountID: "acc-1"}: {},
+		}},
+	)
+	require.NoError(t, err)
+	require.Len(t, attempts, 1)
+	require.Equal(t, "gpt-5", attempts[0].Target.Model)
+	require.Equal(t, "acc-1", attempts[0].Account.ID)
+}
+
+func TestPlanWith_AllCandidatesCoolingReturnsTypedRetry(t *testing.T) {
+	ctx := context.Background()
+	d, _ := newDispatchTest(t, testAccount("acc-1", 10))
+	d.NoteFailure(ctx, "acc-1", &core.ProviderError{
+		Kind:       core.ErrRateLimit,
+		Provider:   "openai",
+		Model:      "gpt-4o",
+		RetryAfter: 2 * time.Second,
+	})
+
+	attempts, err := d.PlanWith(ctx, store.DefaultTenantID,
+		[]Target{{Provider: "openai", Model: "gpt-4o"}},
+		core.NewCapabilitySet(), PlanOptions{})
+	require.Empty(t, attempts)
+	pe := core.AsProviderError(err)
+	require.Equal(t, core.ErrRateLimit, pe.Kind)
+	require.Equal(t, core.FailureScopeAccount, pe.EffectiveScope())
+	require.Greater(t, pe.RetryAfter, time.Duration(0))
+	require.LessOrEqual(t, pe.RetryAfter, 2*time.Second)
+}
+
+func TestProviderCircuitOpensAndSuccessClosesIt(t *testing.T) {
+	ctx := context.Background()
+	d, _ := newDispatchTest(t, testAccount("acc-1", 10))
+	for i := 0; i < ProviderCircuitFailureThreshold; i++ {
+		d.NoteFailure(ctx, "acc-1", &core.ProviderError{
+			Kind:     core.ErrUpstream,
+			Scope:    core.FailureScopeProvider,
+			Provider: "openai",
+		})
+	}
+
+	require.Greater(t, d.providerCircuitRemaining("openai", time.Now()), time.Duration(0))
+	d.NoteSuccess(ctx, "openai", "acc-1", "gpt-4o")
+	require.Zero(t, d.providerCircuitRemaining("openai", time.Now()))
+}
+
 func testAccountWithProvider(id, provider string, priority int) store.Account {
 	now := time.Now()
 	return store.Account{

--- a/backend/internal/gateway/connection_test.go
+++ b/backend/internal/gateway/connection_test.go
@@ -1,0 +1,22 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestIsClientDisconnectUsesWriteDirection(t *testing.T) {
+	if !isClientDisconnect(context.Canceled) {
+		t.Fatal("context cancellation must be treated as a client disconnect")
+	}
+	if !isClientDisconnect(&streamWriteError{err: errors.New("write: broken pipe")}) {
+		t.Fatal("a downstream broken pipe must be treated as a client disconnect")
+	}
+	if isClientDisconnect(&streamReadError{err: errors.New("read: connection reset by peer")}) {
+		t.Fatal("an upstream reset must remain a provider failure")
+	}
+	if isClientDisconnect(errors.New("connection reset by peer")) {
+		t.Fatal("an unscoped socket string must not be guessed as a client disconnect")
+	}
+}

--- a/backend/internal/gateway/double_ping_test.go
+++ b/backend/internal/gateway/double_ping_test.go
@@ -1,0 +1,121 @@
+package gateway
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// streamUpstreamPing mimics an OpenAI-compatible provider (e.g. MiMo) replying
+// to a short ping with content + finish + an optional trailing usage event.
+// trailingUsage simulates providers that emit a usage-only chunk AFTER the
+// finish chunk (common with reasoning/OpenAI-compatible models).
+func streamUpstreamPing(trailingUsage bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flush, _ := w.(http.Flusher)
+		lines := []string{
+			`data: {"choices":[{"delta":{"role":"assistant","content":"Hi"}}]}`,
+			`data: {"choices":[{"delta":{"content":"!"}}]}`,
+			`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		}
+		if trailingUsage {
+			lines = append(lines, `data: {"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`)
+		}
+		lines = append(lines, `data: [DONE]`)
+		for _, l := range lines {
+			fmt.Fprintf(w, "%s\n\n", l)
+			if flush != nil {
+				flush.Flush()
+			}
+		}
+	}
+}
+
+// streamUpstreamPingReasoning mimics a reasoning OpenAI-compatible model
+// (e.g. MiMo) that emits reasoning_content BEFORE content, then a finish
+// chunk. This is the cross-dialect case that exercises the Anthropic codec's
+// thinking-block handling.
+func streamUpstreamPingReasoning() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flush, _ := w.(http.Flusher)
+		for _, l := range []string{
+			`data: {"choices":[{"delta":{"role":"assistant","reasoning_content":"let me think"}}]}`,
+			`data: {"choices":[{"delta":{"reasoning_content":"briefly"}}]}`,
+			`data: {"choices":[{"delta":{"content":"Hi!"}}]}`,
+			`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+		} {
+			fmt.Fprintf(w, "%s\n\n", l)
+			if flush != nil {
+				flush.Flush()
+			}
+		}
+	}
+}
+
+// streamUpstreamPingThinkTags mimics models (MiMo, QwQ) that embed reasoning
+// as <think>...</think> XML tags inside the content field instead of using
+// reasoning_content. The gateway's ThinkTagState strips these.
+func streamUpstreamPingThinkTags() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flush, _ := w.(http.Flusher)
+		for _, l := range []string{
+			`data: {"choices":[{"delta":{"role":"assistant","content":""}}]}`,
+			`data: {"choices":[{"delta":{"content":"Hi!"}}]}`,
+			`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+		} {
+			fmt.Fprintf(w, "%s\n\n", l)
+			if flush != nil {
+				flush.Flush()
+			}
+		}
+	}
+}
+
+// TestE2E_AnthropicStreamPing_SingleMessage reproduces the reported bug: a
+// Claude Code ping ("hi bro"/"test") to an OpenAI-compatible provider must
+// produce exactly ONE Anthropic message lifecycle (1 message_start, 1
+// message_stop), not two. Claude Code shows two conversation turns when it
+// receives two message_start events in one stream.
+func TestE2E_AnthropicStreamPing_SingleMessage(t *testing.T) {
+	cases := []struct {
+		name     string
+		upstream http.HandlerFunc
+		pingBody string
+	}{
+		{"no_trailing_usage", streamUpstreamPing(false), `{"model":"openai/gpt-4o","max_tokens":100,"stream":true,"messages":[{"role":"user","content":"hi bro"}]}`},
+		{"with_trailing_usage", streamUpstreamPing(true), `{"model":"openai/gpt-4o","max_tokens":100,"stream":true,"messages":[{"role":"user","content":"hi bro"}]}`},
+		{"ping_test", streamUpstreamPing(false), `{"model":"openai/gpt-4o","max_tokens":100,"stream":true,"messages":[{"role":"user","content":"test"}]}`},
+		{"reasoning_content", streamUpstreamPingReasoning(), `{"model":"openai/gpt-4o","max_tokens":100,"stream":true,"messages":[{"role":"user","content":"hi bro"}]}`},
+		{"think_tags", streamUpstreamPingThinkTags(), `{"model":"openai/gpt-4o","max_tokens":100,"stream":true,"messages":[{"role":"user","content":"hi bro"}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newE2E(t, tc.upstream)
+
+			resp := h.post(t, "/v1/messages", tc.pingBody, h.apiKey)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			raw, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			out := string(raw)
+			t.Logf("body:\n%s", out)
+
+			starts := strings.Count(out, "event: message_start")
+			stops := strings.Count(out, "event: message_stop")
+			deltas := strings.Count(out, "event: message_delta")
+			require.Equal(t, 1, starts, "expected exactly 1 message_start, got %d — a second message_start is the 2-turn bug", starts)
+			require.Equal(t, 1, stops, "expected exactly 1 message_stop, got %d", stops)
+			require.LessOrEqual(t, deltas, 1, "expected at most 1 message_delta, got %d — extra message_delta can signal a 2nd turn to clients", deltas)
+		})
+	}
+}

--- a/backend/internal/gateway/errors.go
+++ b/backend/internal/gateway/errors.go
@@ -127,6 +127,8 @@ func sanitizeUpstreamError(err error) string {
 		return "upstream provider timed out"
 	case core.ErrCapability:
 		return "requested capability is unavailable"
+	case core.ErrModelUnavailable:
+		return "requested upstream model is unavailable"
 	case core.ErrBudgetBlocked:
 		return "request blocked by budget policy"
 	case core.ErrPolicyBlocked:

--- a/backend/internal/gateway/handlers.go
+++ b/backend/internal/gateway/handlers.go
@@ -391,6 +391,7 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 	bw.Reset(w)
 
 	state := &transform.StreamState{Model: result.Model}
+	transform.ResetStreamState(state)
 	streamStart := time.Now()
 	var totalTokens int
 	var chunkCount int
@@ -464,6 +465,13 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 			s.consoleLog.Log("ERROR", "Provider stream error", fmt.Sprintf("%v", streamErr))
 			s.log.Warn("stream error", "err", streamErr)
 			_, _ = bw.Write(streamErrorEvent(req.Metadata.SourceDialect, sanitizeUpstreamError(streamErr)))
+			// Emit terminal events so strict clients (Claude Code, Cline) see a
+			// well-formed stream end instead of a truncated connection. Without
+			// message_stop/[DONE], the client may treat the stream as incomplete
+			// and retry the request — causing duplicate responses on the user side.
+			for _, ev := range streamCodec.RenderStreamDone(state) {
+				_, _ = bw.Write(ev)
+			}
 			_ = bw.Flush()
 			flusher.Flush()
 			break
@@ -482,10 +490,12 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 	}
 
 	// Flush any remaining buffered tool calls and think-tag buffer.
+	// Both Flush calls are idempotent — duplicate ChunkFinish events from
+	// upstream providers (e.g. some OpenAI-compatible gateways) will not
+	// cause re-emission of already-flushed content.
 	sanitizer.Flush(renderChunk)
 
 	// Flush think-tag state — emit any remaining buffered text.
-
 	for _, fc := range thinkFilter.Flush() {
 		if fc.Type == core.ChunkThinking {
 			continue
@@ -515,6 +525,16 @@ type providerStreamEventError struct{ detail string }
 
 func (e *providerStreamEventError) Error() string { return "provider stream error: " + e.detail }
 
+type streamReadError struct{ err error }
+
+func (e *streamReadError) Error() string { return e.err.Error() }
+func (e *streamReadError) Unwrap() error { return e.err }
+
+type streamWriteError struct{ err error }
+
+func (e *streamWriteError) Error() string { return e.err.Error() }
+func (e *streamWriteError) Unwrap() error { return e.err }
+
 // copySanitizedStream keeps the direct-stream path lightweight by framing SSE
 // events without decoding successful chunks. Only potential error events are
 // decoded; those are replaced with a dialect-compatible generic event.
@@ -543,7 +563,7 @@ func copySanitizedStream(dst io.Writer, src io.Reader, dialect core.Dialect, flu
 			continue
 		}
 		if readErr != io.EOF {
-			return written, readErr
+			return written, &streamReadError{err: readErr}
 		}
 		if event.Len() > 0 {
 			n, err := writeSanitizedFrame(dst, event.Bytes(), dialect, flush)
@@ -592,7 +612,7 @@ func copySanitizedNDJSON(dst io.Writer, reader *bufio.Reader, dialect core.Diale
 		if readErr == io.EOF {
 			return written, nil
 		}
-		return written, readErr
+		return written, &streamReadError{err: readErr}
 	}
 }
 
@@ -610,7 +630,7 @@ func writeSanitizedFrame(dst io.Writer, raw []byte, dialect core.Dialect, flush 
 		flush()
 	}
 	if err != nil {
-		return int64(n), err
+		return int64(n), &streamWriteError{err: err}
 	}
 	if providerErr {
 		detail := truncateStreamEvent(string(raw))
@@ -728,6 +748,8 @@ func (s *Server) writeProviderError(w http.ResponseWriter, err error) {
 	switch pe.Kind {
 	case core.ErrBadRequest, core.ErrCapability:
 		status = http.StatusBadRequest
+	case core.ErrModelUnavailable:
+		status = http.StatusNotFound
 	case core.ErrAuth:
 		status = http.StatusUnauthorized
 	case core.ErrRateLimit:
@@ -756,15 +778,19 @@ func (s *Server) writeProviderError(w http.ResponseWriter, err error) {
 	writeError(w, status, sanitizeUpstreamError(pe))
 }
 
-// isClientDisconnect reports whether an error is a client disconnection
-// (broken pipe, reset by peer) rather than a server-side failure. These are
-// expected during streaming and should not be logged as errors.
+// isClientDisconnect reports whether cancellation or a downstream response
+// write failed because the client disconnected. Read-side socket errors remain
+// provider failures even when their text contains the same reset wording.
 func isClientDisconnect(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, context.Canceled) {
+	if core.IsClientDisconnect(err) {
 		return true
+	}
+	var writeErr *streamWriteError
+	if !errors.As(err, &writeErr) {
+		return false
 	}
 	s := strings.ToLower(err.Error())
 	return strings.Contains(s, "broken pipe") ||

--- a/backend/internal/gateway/media.go
+++ b/backend/internal/gateway/media.go
@@ -3,8 +3,11 @@ package gateway
 import (
 	"encoding/json"
 	"io"
+	"mime"
 	"net/http"
+	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/mydisha/keirouter/backend/internal/core"
 	"github.com/mydisha/keirouter/backend/internal/dispatch"
 	"github.com/mydisha/keirouter/backend/internal/httputil"
@@ -329,6 +332,163 @@ func (s *Server) handleWebFetch(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-KeiRouter-Provider", provider)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"url": resp.URL, "title": resp.Title, "content": resp.Content, "format": resp.Format,
+	})
+}
+
+// ---- Video generation -------------------------------------------------------
+
+// handleVideoGeneration submits an asynchronous video-generation job. Unknown
+// JSON fields are retained so provider-specific generation controls pass through.
+func (s *Server) handleVideoGeneration(w http.ResponseWriter, r *http.Request) {
+	key, _ := authedKey(r.Context())
+	if contentType := r.Header.Get("Content-Type"); contentType != "" {
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil || (mediaType != "application/json" && !strings.HasSuffix(mediaType, "+json")) {
+			writeError(w, http.StatusUnsupportedMediaType, "video generation requires a JSON request body")
+			return
+		}
+	}
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+	var head struct {
+		Model  string `json:"model"`
+		Prompt string `json:"prompt"`
+	}
+	if err := json.Unmarshal(raw, &head); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request: "+err.Error())
+		return
+	}
+	if head.Model == "" {
+		writeError(w, http.StatusBadRequest, "model is required")
+		return
+	}
+	opts, err := s.mediaOptions(r, head.Model)
+	if err != nil {
+		s.writeMediaError(w, err)
+		return
+	}
+	req := &core.VideoRequest{
+		Model:       modelTail(opts.Targets),
+		Prompt:      head.Prompt,
+		Body:        raw,
+		ContentType: r.Header.Get("Content-Type"),
+	}
+	resp, provider, perr := s.pipeline.GenerateVideo(r.Context(), req, opts)
+	if perr != nil {
+		s.logRequest(key.Name, provider, req.Model, 0, 0, 0, false, perr)
+		s.writeMediaError(w, perr)
+		return
+	}
+	s.logRequest(key.Name, provider, req.Model, 0, 0, 0, false, nil)
+	w.Header().Set("X-KeiRouter-Provider", provider)
+	w.Header().Set("X-KeiRouter-Account", resp.AccountID)
+	writeVideoResponse(w, resp)
+}
+
+// handleVideoPoll checks the status of an in-flight video job. The job id is in
+// the path; the model (provider/model) is supplied as a query parameter so the
+// poll routes to the same provider that created the job.
+func (s *Server) handleVideoPoll(w http.ResponseWriter, r *http.Request) {
+	key, _ := authedKey(r.Context())
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "video id is required")
+		return
+	}
+	model := r.URL.Query().Get("model")
+	if model == "" {
+		writeError(w, http.StatusBadRequest, "model query parameter is required (provider/model)")
+		return
+	}
+	accountID := r.URL.Query().Get("account_id")
+	if accountID == "" {
+		accountID = r.Header.Get("X-KeiRouter-Account")
+	}
+	if accountID == "" {
+		writeError(w, http.StatusBadRequest, "account_id is required to poll the credential that submitted the video job")
+		return
+	}
+	opts, err := s.mediaOptions(r, model)
+	if err != nil {
+		s.writeMediaError(w, err)
+		return
+	}
+	opts.AccountID = accountID
+	req := &core.VideoStatusRequest{Model: modelTail(opts.Targets), RequestID: id}
+	resp, provider, perr := s.pipeline.PollVideo(r.Context(), req, opts)
+	if perr != nil {
+		s.logRequest(key.Name, provider, req.Model, 0, 0, 0, false, perr)
+		s.writeMediaError(w, perr)
+		return
+	}
+	s.logRequest(key.Name, provider, req.Model, 0, 0, 0, false, nil)
+	w.Header().Set("X-KeiRouter-Provider", provider)
+	w.Header().Set("X-KeiRouter-Account", resp.AccountID)
+	writeVideoResponse(w, resp)
+}
+
+// writeVideoResponse renders a VideoResponse. When the upstream body was
+// captured verbatim it is passed through untouched; otherwise a canonical
+// summary is emitted.
+func writeVideoResponse(w http.ResponseWriter, resp *core.VideoResponse) {
+	if len(resp.Raw) > 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(resp.Raw)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"request_id": resp.RequestID, "status": resp.Status,
+		"url": resp.URL, "urls": resp.URLs,
+	})
+}
+
+// ---- Image understanding (image-to-text) ------------------------------------
+
+func (s *Server) handleImageUnderstanding(w http.ResponseWriter, r *http.Request) {
+	key, _ := authedKey(r.Context())
+	var req core.ImageUnderstandingRequest
+	if !readJSON(w, r, &req) {
+		return
+	}
+	if req.Model == "" {
+		writeError(w, http.StatusBadRequest, "model is required")
+		return
+	}
+	hasImage := false
+	for _, image := range req.Images {
+		if strings.TrimSpace(image) != "" {
+			hasImage = true
+			break
+		}
+	}
+	if !hasImage {
+		writeError(w, http.StatusBadRequest, "at least one image is required")
+		return
+	}
+	opts, err := s.mediaOptions(r, req.Model)
+	if err != nil {
+		s.writeMediaError(w, err)
+		return
+	}
+	req.Model = modelTail(opts.Targets)
+	resp, provider, perr := s.pipeline.UnderstandImage(r.Context(), &req, opts)
+	if perr != nil {
+		s.logRequest(key.Name, provider, req.Model, 0, 0, 0, false, perr)
+		s.writeMediaError(w, perr)
+		return
+	}
+	s.logRequest(key.Name, provider, req.Model, resp.Usage.TotalTokens, 0, 0, false, nil)
+	w.Header().Set("X-KeiRouter-Provider", provider)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"model": resp.Model, "text": resp.Text,
+		"usage": map[string]any{
+			"prompt_tokens": resp.Usage.PromptTokens, "completion_tokens": resp.Usage.CompletionTokens,
+			"total_tokens": resp.Usage.TotalTokens,
+		},
 	})
 }
 

--- a/backend/internal/gateway/oauth.go
+++ b/backend/internal/gateway/oauth.go
@@ -152,9 +152,9 @@ func (s *Server) oauthExchange(w http.ResponseWriter, r *http.Request) {
 
 	var tokens *oauth.Tokens
 	var err error
-	if provider == "cline" {
-		// Cline uses a non-standard exchange (base64-embedded tokens or
-		// JSON body with client_type=extension).
+	if provider == "cline" || provider == "clinepass" {
+		// Cline and ClinePass use a non-standard exchange (base64-embedded
+		// tokens or JSON body with client_type=extension).
 		tokens, err = cfg.ExchangeClineCode(r.Context(), body.Code, sess.RedirectURI)
 	} else {
 		tokens, err = cfg.ExchangeCode(r.Context(), body.Code, sess.RedirectURI, sess.Verifier)

--- a/backend/internal/gateway/server.go
+++ b/backend/internal/gateway/server.go
@@ -224,7 +224,8 @@ func (s *Server) routes() chi.Router {
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins: s.cfg.Server.CORSOrigins,
 		AllowedMethods: []string{"GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders: []string{"Authorization", "Content-Type", "x-api-key", "X-KeiRouter-Affinity", "X-Conversation-ID", "X-Thread-ID", "X-Session-ID", "OpenAI-Conversation-ID"},
+		AllowedHeaders: []string{"Authorization", "Content-Type", "x-api-key", "X-KeiRouter-Affinity", "X-KeiRouter-Account", "X-Conversation-ID", "X-Thread-ID", "X-Session-ID", "OpenAI-Conversation-ID"},
+		ExposedHeaders: []string{"X-KeiRouter-Provider", "X-KeiRouter-Model", "X-KeiRouter-Account"},
 	}))
 
 	// Health check (unauthenticated).
@@ -245,6 +246,8 @@ func (s *Server) routes() chi.Router {
 				"/v1/models",
 				"/v1/embeddings",
 				"/v1/images/generations",
+				"/v1/images/understanding",
+				"/v1/videos/generations",
 				"/v1/audio/speech",
 				"/v1/audio/transcriptions",
 				"/v1/search",
@@ -289,6 +292,9 @@ func (s *Server) routes() chi.Router {
 		// Multi-capability endpoints (Phase 2).
 		r.Post("/v1/embeddings", s.handleEmbeddings)
 		r.Post("/v1/images/generations", s.handleImageGeneration)
+		r.Post("/v1/images/understanding", s.handleImageUnderstanding)
+		r.Post("/v1/videos/generations", s.handleVideoGeneration)
+		r.Get("/v1/videos/{id}", s.handleVideoPoll)
 		r.Post("/v1/audio/speech", s.handleAudioSpeech)
 		r.Post("/v1/audio/transcriptions", s.handleAudioTranscription)
 		r.Post("/v1/search", s.handleWebSearch)

--- a/backend/internal/health/errors.go
+++ b/backend/internal/health/errors.go
@@ -55,13 +55,13 @@ func ClassifyError(pe *core.ProviderError) ProviderErrorType {
 			return ProviderErrorNetwork
 		}
 		return ProviderErrorProvider5xx
+	case core.ErrModelUnavailable, core.ErrCapability:
+		return ProviderErrorUnsupported
 	case core.ErrBadRequest:
 		if isUnsupportedMessage(pe.Message) {
 			return ProviderErrorUnsupported
 		}
 		return ProviderErrorBadRequest
-	case core.ErrCapability:
-		return ProviderErrorUnsupported
 	default:
 		// ErrInternal, ErrBudgetBlocked, ErrPolicyBlocked — not provider
 		// failures, but surface as unknown for accounting completeness.

--- a/backend/internal/health/health_test.go
+++ b/backend/internal/health/health_test.go
@@ -21,6 +21,7 @@ func TestClassifyError(t *testing.T) {
 		{"upstream_network", &core.ProviderError{Kind: core.ErrUpstream, StatusCode: 0}, ProviderErrorNetwork},
 		{"bad_request", &core.ProviderError{Kind: core.ErrBadRequest}, ProviderErrorBadRequest},
 		{"bad_request_unsupported_msg", &core.ProviderError{Kind: core.ErrBadRequest, Message: "model not found"}, ProviderErrorUnsupported},
+		{"model_unavailable", &core.ProviderError{Kind: core.ErrModelUnavailable}, ProviderErrorUnsupported},
 		{"capability", &core.ProviderError{Kind: core.ErrCapability}, ProviderErrorUnsupported},
 		{"internal", &core.ProviderError{Kind: core.ErrInternal}, ProviderErrorUnknown},
 	}
@@ -47,10 +48,10 @@ func TestErrorSeverityScore(t *testing.T) {
 
 func TestComputeScore_Healthy(t *testing.T) {
 	score := ComputeScore(ScoreInput{
-		SuccessRate:        1.0,
-		P95LatencyMs:       2_000,
-		LatencyThresholdMs: 10_000,
-		DominantErrorType:  ProviderErrorNone,
+		SuccessRate:         1.0,
+		P95LatencyMs:        2_000,
+		LatencyThresholdMs:  10_000,
+		DominantErrorType:   ProviderErrorNone,
 		ConsecutiveFailures: 0,
 	})
 	if score < 90 {
@@ -60,10 +61,10 @@ func TestComputeScore_Healthy(t *testing.T) {
 
 func TestComputeScore_AuthErrors(t *testing.T) {
 	score := ComputeScore(ScoreInput{
-		SuccessRate:        0.5,
-		P95LatencyMs:       1_000,
-		LatencyThresholdMs: 10_000,
-		DominantErrorType:  ProviderErrorAuth,
+		SuccessRate:         0.5,
+		P95LatencyMs:        1_000,
+		LatencyThresholdMs:  10_000,
+		DominantErrorType:   ProviderErrorAuth,
 		ConsecutiveFailures: 3,
 	})
 	if score >= 65 {

--- a/backend/internal/oauth/oauth_test.go
+++ b/backend/internal/oauth/oauth_test.go
@@ -37,7 +37,7 @@ func TestGeneratePKCEUnique(t *testing.T) {
 }
 
 func TestConfigFor(t *testing.T) {
-	for _, id := range []string{"claude", "codex", "github", "qwen", "xai", "gemini-cli"} {
+	for _, id := range []string{"claude", "codex", "github", "qwen", "xai", "gemini-cli", "clinepass", "grok-cli"} {
 		cfg, ok := ConfigFor(id)
 		if !ok {
 			t.Errorf("expected OAuth config for %q", id)
@@ -143,6 +143,39 @@ func TestRefreshURLFallback(t *testing.T) {
 	cline, _ := ConfigFor("cline")
 	if cline.refreshURL() != "https://api.cline.bot/api/v1/auth/refresh" {
 		t.Errorf("cline refresh URL should use explicit RefreshURL, got %q", cline.refreshURL())
+	}
+}
+
+func TestClinepassMirrorsCline(t *testing.T) {
+	cline, _ := ConfigFor("cline")
+	cp, ok := ConfigFor("clinepass")
+	if !ok {
+		t.Fatal("expected OAuth config for clinepass")
+	}
+	if cp.Flow != FlowAuthCode {
+		t.Errorf("clinepass flow = %v, want FlowAuthCode", cp.Flow)
+	}
+	if cp.AuthorizeURL != cline.AuthorizeURL || cp.TokenURL != cline.TokenURL || cp.refreshURL() != cline.refreshURL() {
+		t.Error("clinepass should share cline's auth endpoints")
+	}
+	if !cp.SkipStandardAuthParams || cp.TokenContentType != "json" {
+		t.Error("clinepass should reuse cline's non-standard authorize/token params")
+	}
+}
+
+func TestGrokCliDeviceFlow(t *testing.T) {
+	cfg, ok := ConfigFor("grok-cli")
+	if !ok {
+		t.Fatal("expected OAuth config for grok-cli")
+	}
+	if cfg.Flow != FlowDeviceCode {
+		t.Errorf("grok-cli flow = %v, want FlowDeviceCode", cfg.Flow)
+	}
+	if cfg.DeviceCodeURL == "" || cfg.TokenURL == "" {
+		t.Error("grok-cli must define device-code and token URLs")
+	}
+	if cfg.refreshURL() != cfg.TokenURL {
+		t.Errorf("grok-cli refresh URL = %q, want %q", cfg.refreshURL(), cfg.TokenURL)
 	}
 }
 

--- a/backend/internal/oauth/providers.go
+++ b/backend/internal/oauth/providers.go
@@ -202,6 +202,41 @@ var configs = map[string]ProviderConfig{
 		DeviceCodeURL: "https://auth.kimi.com/api/oauth/device_authorization",
 		TokenURL:      "https://auth.kimi.com/api/oauth/token",
 	},
+	// ClinePass shares Cline's subscription auth surface (same api.cline.bot
+	// endpoints and non-standard authorize params), so its flow mirrors cline.
+	"clinepass": {
+		Provider:               "clinepass",
+		Flow:                   FlowAuthCode,
+		AuthorizeURL:           "https://api.cline.bot/api/v1/auth/authorize",
+		TokenURL:               "https://api.cline.bot/api/v1/auth/token",
+		RefreshURL:             "https://api.cline.bot/api/v1/auth/refresh",
+		UserInfoURL:            "https://api.cline.bot/api/v1/auth/userinfo",
+		TokenContentType:       "json",
+		SkipStandardAuthParams: true,
+		ExtraAuthParams: map[string]string{
+			"client_type": "extension",
+		},
+		ExtraTokenParams: map[string]string{
+			"client_type": "extension",
+		},
+	},
+	// Grok CLI signs in with an xAI account via device code and spends Grok
+	// Build subscription credits through cli-chat-proxy.grok.com. It reuses
+	// the public xAI OAuth client id and the auth.x.ai token endpoints.
+	"grok-cli": {
+		Provider:      "grok-cli",
+		Flow:          FlowDeviceCode,
+		ClientID:      "b1a00492-073a-47ea-816f-4c329264a828",
+		DeviceCodeURL: "https://auth.x.ai/oauth2/device/code",
+		TokenURL:      "https://auth.x.ai/oauth2/token",
+		RefreshURL:    "https://auth.x.ai/oauth2/token",
+		Scopes: []string{
+			"openid", "profile", "email", "offline_access",
+			"grok-cli:access", "api:access",
+			"conversations:read", "conversations:write",
+		},
+		UserInfoURL: "https://auth.x.ai/oauth2/userinfo",
+	},
 }
 
 // ConfigFor returns the OAuth config for a provider id.

--- a/backend/internal/pipeline/attempt_planner.go
+++ b/backend/internal/pipeline/attempt_planner.go
@@ -1,0 +1,119 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/mydisha/keirouter/backend/internal/dispatch"
+)
+
+// attemptPlanner refreshes routing state after each failed credential while
+// preserving the target order chosen for the request's first plan.
+type attemptPlanner struct {
+	dispatcher *dispatch.Dispatcher
+	tenantID   string
+	targets    []dispatch.Target
+	required   core.CapabilitySet
+	options    dispatch.PlanOptions
+	affinity   dispatch.PlanOptions
+	excluded   map[string]struct{}
+	attempted  map[dispatch.AttemptKey]struct{}
+	current    dispatch.Attempt
+	remaining  bool
+}
+
+func newAttemptPlanner(
+	dispatcher *dispatch.Dispatcher,
+	tenantID string,
+	originalTargets []dispatch.Target,
+	required core.CapabilitySet,
+	options dispatch.PlanOptions,
+	initial []dispatch.Attempt,
+) *attemptPlanner {
+	excluded := make(map[string]struct{}, len(options.ExcludedAccountIDs))
+	for id := range options.ExcludedAccountIDs {
+		excluded[id] = struct{}{}
+	}
+
+	retryOptions := options
+	retryOptions.Strategy = dispatch.StrategyFallback
+	retryOptions.ChainID = ""
+	retryOptions.AccountStrategy = dispatch.StrategyFallback
+	retryOptions.AccountAffinityKey = ""
+	retryOptions.ExcludedAccountIDs = excluded
+	attempted := make(map[dispatch.AttemptKey]struct{}, len(options.ExcludedAttempts))
+	for key := range options.ExcludedAttempts {
+		attempted[key] = struct{}{}
+	}
+	retryOptions.ExcludedAttempts = attempted
+	if len(options.ProviderAccountStrategies) > 0 {
+		retryOptions.ProviderAccountStrategies = make(map[string]dispatch.AccountRoutingOptions, len(options.ProviderAccountStrategies))
+		for provider, providerOptions := range options.ProviderAccountStrategies {
+			providerOptions.Strategy = dispatch.StrategyFallback
+			providerOptions.AffinityKey = ""
+			retryOptions.ProviderAccountStrategies[provider] = providerOptions
+		}
+	}
+
+	planner := &attemptPlanner{
+		dispatcher: dispatcher,
+		tenantID:   tenantID,
+		targets:    stableTargetOrder(initial, originalTargets),
+		required:   required,
+		options:    retryOptions,
+		affinity:   options,
+		excluded:   excluded,
+		attempted:  attempted,
+	}
+	if len(initial) > 0 {
+		planner.current = initial[0]
+		planner.remaining = true
+	}
+	return planner
+}
+
+func (p *attemptPlanner) Current() (dispatch.Attempt, bool) {
+	return p.current, p.remaining
+}
+
+func (p *attemptPlanner) AfterFailure(ctx context.Context, failed dispatch.Attempt, pe *core.ProviderError) (dispatch.Attempt, bool) {
+	if !p.remaining || failed.Account.ID == "" {
+		p.remaining = false
+		return dispatch.Attempt{}, false
+	}
+	p.attempted[failed.Key()] = struct{}{}
+	p.options.ExcludedAttempts = p.attempted
+	if pe != nil && pe.EffectiveScope() == core.FailureScopeAccount {
+		p.excluded[failed.Account.ID] = struct{}{}
+	}
+	p.options.ExcludedAccountIDs = p.excluded
+	p.dispatcher.EvictAccountAffinity(ctx, p.tenantID, failed.Target, p.affinity, failed.Account.ID)
+
+	attempts, err := p.dispatcher.PlanWith(ctx, p.tenantID, p.targets, p.required, p.options)
+	if err != nil || len(attempts) == 0 {
+		p.remaining = false
+		return dispatch.Attempt{}, false
+	}
+	p.current = attempts[0]
+	return p.current, true
+}
+
+func stableTargetOrder(initial []dispatch.Attempt, original []dispatch.Target) []dispatch.Target {
+	out := make([]dispatch.Target, 0, len(original))
+	seen := make(map[dispatch.Target]struct{}, len(original))
+	for _, attempt := range initial {
+		if _, ok := seen[attempt.Target]; ok {
+			continue
+		}
+		seen[attempt.Target] = struct{}{}
+		out = append(out, attempt.Target)
+	}
+	for _, target := range original {
+		if _, ok := seen[target]; ok {
+			continue
+		}
+		seen[target] = struct{}{}
+		out = append(out, target)
+	}
+	return out
+}

--- a/backend/internal/pipeline/attempt_planner_test.go
+++ b/backend/internal/pipeline/attempt_planner_test.go
@@ -1,0 +1,111 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mydisha/keirouter/backend/internal/config"
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/mydisha/keirouter/backend/internal/crypto"
+	"github.com/mydisha/keirouter/backend/internal/dispatch"
+	"github.com/mydisha/keirouter/backend/internal/store"
+	"github.com/mydisha/keirouter/backend/internal/vault"
+	"github.com/stretchr/testify/require"
+)
+
+type plannerConnectorSource struct{ conn core.Connector }
+
+func (s plannerConnectorSource) Get(string) (core.Connector, error) { return s.conn, nil }
+
+type plannerConnector struct{}
+
+func (plannerConnector) ID() string            { return "openai" }
+func (plannerConnector) Dialect() core.Dialect { return core.DialectOpenAI }
+func (plannerConnector) Chat(context.Context, *core.ChatRequest, core.Credentials) (*core.ChatResponse, error) {
+	return nil, nil
+}
+func (plannerConnector) Stream(context.Context, *core.ChatRequest, core.Credentials, core.StreamConfig) (<-chan core.StreamChunk, error) {
+	ch := make(chan core.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+func newPlannerDispatcher(t *testing.T) *dispatch.Dispatcher {
+	t.Helper()
+	ctx := context.Background()
+	db, err := store.Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: ":memory:"}, t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, db.Migrate(ctx))
+	require.NoError(t, db.Tenants().EnsureDefault(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	key, err := crypto.GenerateMasterKey()
+	require.NoError(t, err)
+	sealer, err := crypto.NewSealer(key)
+	require.NoError(t, err)
+	secrets := vault.New(sealer)
+
+	for i, id := range []string{"acc-1", "acc-2"} {
+		now := time.Now()
+		account := store.Account{
+			ID: id, TenantID: store.DefaultTenantID, Provider: "openai",
+			Label: id, AuthKind: store.AuthAPIKey, Priority: (i + 1) * 10,
+			Metadata: "{}", CreatedAt: now, UpdatedAt: now,
+		}
+		require.NoError(t, secrets.Seal(&account, vault.NewSecret{APIKey: "sk-test"}))
+		require.NoError(t, db.Accounts().Create(ctx, account))
+	}
+
+	d := dispatch.New(plannerConnectorSource{conn: plannerConnector{}}, db.Accounts(), secrets)
+	d.SetRoutingSource(db.Routing())
+	return d
+}
+
+func TestAttemptPlannerModelFailureKeepsAccountAvailableForNextModel(t *testing.T) {
+	ctx := context.Background()
+	d := newPlannerDispatcher(t)
+	targets := []dispatch.Target{
+		{Provider: "openai", Model: "gpt-4o"},
+		{Provider: "openai", Model: "gpt-5"},
+	}
+	initial, err := d.Plan(ctx, store.DefaultTenantID, targets, core.NewCapabilitySet())
+	require.NoError(t, err)
+	planner := newAttemptPlanner(d, store.DefaultTenantID, targets, core.NewCapabilitySet(), dispatch.PlanOptions{}, initial)
+
+	first, ok := planner.Current()
+	require.True(t, ok)
+	require.Equal(t, "acc-1", first.Account.ID)
+	require.Equal(t, "gpt-4o", first.Target.Model)
+
+	second, ok := planner.AfterFailure(ctx, first, &core.ProviderError{Kind: core.ErrModelUnavailable})
+	require.True(t, ok)
+	require.Equal(t, "acc-2", second.Account.ID)
+	require.Equal(t, "gpt-4o", second.Target.Model)
+
+	third, ok := planner.AfterFailure(ctx, second, &core.ProviderError{Kind: core.ErrModelUnavailable})
+	require.True(t, ok)
+	require.Equal(t, "acc-1", third.Account.ID)
+	require.Equal(t, "gpt-5", third.Target.Model)
+}
+
+func TestAttemptPlannerAccountFailureSkipsCredentialAcrossModels(t *testing.T) {
+	ctx := context.Background()
+	d := newPlannerDispatcher(t)
+	targets := []dispatch.Target{
+		{Provider: "openai", Model: "gpt-4o"},
+		{Provider: "openai", Model: "gpt-5"},
+	}
+	initial, err := d.Plan(ctx, store.DefaultTenantID, targets, core.NewCapabilitySet())
+	require.NoError(t, err)
+	planner := newAttemptPlanner(d, store.DefaultTenantID, targets, core.NewCapabilitySet(), dispatch.PlanOptions{}, initial)
+
+	first, ok := planner.Current()
+	require.True(t, ok)
+	second, ok := planner.AfterFailure(ctx, first, &core.ProviderError{Kind: core.ErrAuth})
+	require.True(t, ok)
+	require.Equal(t, "acc-2", second.Account.ID)
+
+	_, ok = planner.AfterFailure(ctx, second, &core.ProviderError{Kind: core.ErrAuth})
+	require.False(t, ok)
+}

--- a/backend/internal/pipeline/media.go
+++ b/backend/internal/pipeline/media.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 
 	"github.com/mydisha/keirouter/backend/internal/budget"
 	"github.com/mydisha/keirouter/backend/internal/core"
@@ -28,6 +29,9 @@ type MediaOptions struct {
 	ProjectID string
 	APIKeyID  string
 	Limits    limits.EffectiveLimits
+	// AccountID pins operations tied to upstream state, such as polling an
+	// asynchronous video job, to the credential that created that state.
+	AccountID string
 }
 
 // mediaAttempts resolves the ordered attempts for a media request and runs the
@@ -42,7 +46,11 @@ func (p *Pipeline) mediaAttempts(ctx context.Context, opts MediaOptions) ([]disp
 			return nil, err
 		}
 	}
-	return p.dispatcher.Plan(ctx, opts.TenantID, opts.Targets, core.NewCapabilitySet())
+	planOpts := dispatch.PlanOptions{}
+	if opts.AccountID != "" {
+		planOpts.AllowedAccountIDs = map[string]struct{}{opts.AccountID: {}}
+	}
+	return p.dispatcher.PlanWith(ctx, opts.TenantID, opts.Targets, core.NewCapabilitySet(), planOpts)
 }
 
 func (p *Pipeline) acquireMediaLimit(ctx context.Context, opts MediaOptions, estimatedTokens int64) (limits.ReleaseFunc, error) {
@@ -96,6 +104,7 @@ func (p *Pipeline) Embeddings(ctx context.Context, req *core.EmbeddingRequest, o
 			lastErr = callErr
 			continue
 		}
+		p.dispatcher.NoteSuccess(ctx, a.Target.Provider, a.Account.ID, a.Target.Model)
 		return resp, a.Target.Provider, nil
 	}
 	return nil, "", orInternal(lastErr)
@@ -129,6 +138,7 @@ func (p *Pipeline) GenerateImage(ctx context.Context, req *core.ImageRequest, op
 			lastErr = callErr
 			continue
 		}
+		p.dispatcher.NoteSuccess(ctx, a.Target.Provider, a.Account.ID, a.Target.Model)
 		return resp, a.Target.Provider, nil
 	}
 	return nil, "", orInternal(lastErr)
@@ -162,6 +172,7 @@ func (p *Pipeline) Transcribe(ctx context.Context, req *core.TranscriptionReques
 			lastErr = callErr
 			continue
 		}
+		p.dispatcher.NoteSuccess(ctx, a.Target.Provider, a.Account.ID, a.Target.Model)
 		return resp, a.Target.Provider, nil
 	}
 	return nil, "", orInternal(lastErr)
@@ -195,6 +206,7 @@ func (p *Pipeline) Synthesize(ctx context.Context, req *core.SpeechRequest, opts
 			lastErr = callErr
 			continue
 		}
+		p.dispatcher.NoteSuccess(ctx, a.Target.Provider, a.Account.ID, a.Target.Model)
 		return resp, a.Target.Provider, nil
 	}
 	return nil, "", orInternal(lastErr)
@@ -228,6 +240,7 @@ func (p *Pipeline) Search(ctx context.Context, req *core.SearchRequest, opts Med
 			lastErr = callErr
 			continue
 		}
+		p.dispatcher.NoteSuccess(ctx, a.Target.Provider, a.Account.ID, a.Target.Model)
 		return resp, a.Target.Provider, nil
 	}
 	return nil, "", orInternal(lastErr)
@@ -261,9 +274,170 @@ func (p *Pipeline) Fetch(ctx context.Context, req *core.FetchRequest, opts Media
 			lastErr = callErr
 			continue
 		}
+		p.dispatcher.NoteSuccess(ctx, a.Target.Provider, a.Account.ID, a.Target.Model)
 		return resp, a.Target.Provider, nil
 	}
 	return nil, "", orInternal(lastErr)
+}
+
+// GenerateVideo submits an asynchronous video-generation job. Unlike other
+// media kinds this does NOT fall back across attempts once a request has been
+// sent: a network error after submission may mean the job was created upstream,
+// so retrying could duplicate it. It only advances past attempts whose provider
+// lacks the capability (no request sent yet).
+func (p *Pipeline) GenerateVideo(ctx context.Context, req *core.VideoRequest, opts MediaOptions) (*core.VideoResponse, string, error) {
+	attempts, err := p.mediaAttempts(ctx, opts)
+	if err != nil {
+		return nil, "", err
+	}
+	release, err := p.acquireMediaLimit(ctx, opts, 1)
+	if err != nil {
+		return nil, "", err
+	}
+	defer release(0)
+	var lastErr error
+	for _, a := range attempts {
+		conn, ok := a.Conn.(core.VideoConnector)
+		if !ok {
+			lastErr = unsupported(a.Target.Provider, "video generation")
+			continue
+		}
+		r := *req
+		r.Model = a.Target.Model
+		resp, callErr := conn.GenerateVideo(ctx, &r, a.Creds)
+		if callErr != nil {
+			// Record the failure for cooldown accounting but never retry the
+			// submission on another attempt — that could create a duplicate job.
+			p.noteMediaFailure(ctx, a, callErr)
+			return nil, "", callErr
+		}
+		p.dispatcher.NoteSuccess(ctx, a.Target.Provider, a.Account.ID, a.Target.Model)
+		resp.AccountID = a.Account.ID
+		return resp, a.Target.Provider, nil
+	}
+	return nil, "", orInternal(lastErr)
+}
+
+// PollVideo checks the status of an in-flight video job. Account-bound polling
+// is pinned to the credential that submitted the job.
+func (p *Pipeline) PollVideo(ctx context.Context, req *core.VideoStatusRequest, opts MediaOptions) (*core.VideoResponse, string, error) {
+	attempts, err := p.mediaAttempts(ctx, opts)
+	if err != nil {
+		return nil, "", err
+	}
+	release, err := p.acquireMediaLimit(ctx, opts, 1)
+	if err != nil {
+		return nil, "", err
+	}
+	defer release(0)
+	var lastErr error
+	for _, a := range attempts {
+		conn, ok := a.Conn.(core.VideoConnector)
+		if !ok {
+			lastErr = unsupported(a.Target.Provider, "video generation")
+			continue
+		}
+		r := *req
+		r.Model = a.Target.Model
+		resp, callErr := conn.PollVideo(ctx, &r, a.Creds)
+		if callErr != nil {
+			if !p.noteMediaFailure(ctx, a, callErr) {
+				return nil, "", callErr
+			}
+			lastErr = callErr
+			continue
+		}
+		p.dispatcher.NoteSuccess(ctx, a.Target.Provider, a.Account.ID, a.Target.Model)
+		resp.AccountID = a.Account.ID
+		return resp, a.Target.Provider, nil
+	}
+	return nil, "", orInternal(lastErr)
+}
+
+// UnderstandImage runs an image-understanding (image-to-text) request with
+// fallback.
+func (p *Pipeline) UnderstandImage(ctx context.Context, req *core.ImageUnderstandingRequest, opts MediaOptions) (*core.ImageUnderstandingResponse, string, error) {
+	attempts, err := p.mediaAttempts(ctx, opts)
+	if err != nil {
+		return nil, "", err
+	}
+	release, err := p.acquireMediaLimit(ctx, opts, 1)
+	if err != nil {
+		return nil, "", err
+	}
+	defer release(0)
+	var lastErr error
+	for _, a := range attempts {
+		r := *req
+		r.Model = a.Target.Model
+		resp, callErr := understandImage(ctx, a, &r)
+		if callErr != nil {
+			if !p.noteMediaFailure(ctx, a, callErr) {
+				return nil, "", callErr
+			}
+			lastErr = callErr
+			continue
+		}
+		p.dispatcher.NoteSuccess(ctx, a.Target.Provider, a.Account.ID, a.Target.Model)
+		return resp, a.Target.Provider, nil
+	}
+	return nil, "", orInternal(lastErr)
+}
+
+func understandImage(ctx context.Context, attempt dispatch.Attempt, req *core.ImageUnderstandingRequest) (*core.ImageUnderstandingResponse, error) {
+	if conn, ok := attempt.Conn.(core.ImageUnderstandingConnector); ok {
+		return conn.UnderstandImage(ctx, req, attempt.Creds)
+	}
+
+	content := make([]core.ContentPart, 0, len(req.Images)+1)
+	if req.Prompt != "" {
+		content = append(content, core.ContentPart{Type: core.PartText, Text: req.Prompt})
+	}
+	for _, image := range req.Images {
+		image = strings.TrimSpace(image)
+		if image == "" {
+			continue
+		}
+		content = append(content, core.ContentPart{Type: core.PartImage, Media: mediaPayload(image)})
+	}
+
+	var maxTokens *int
+	if req.MaxTokens > 0 {
+		value := req.MaxTokens
+		maxTokens = &value
+	}
+	chatResp, err := attempt.Conn.Chat(ctx, &core.ChatRequest{
+		Model:     req.Model,
+		MaxTokens: maxTokens,
+		Messages: []core.Message{{
+			Role:    core.RoleUser,
+			Content: content,
+		}},
+	}, attempt.Creds)
+	if err != nil {
+		return nil, err
+	}
+	if chatResp == nil {
+		return nil, &core.ProviderError{
+			Kind: core.ErrUpstream, Provider: attempt.Target.Provider,
+			Model: req.Model, Message: "image understanding returned an empty response",
+		}
+	}
+	return &core.ImageUnderstandingResponse{
+		Model: req.Model,
+		Text:  chatResp.Message.TextContent(),
+		Usage: chatResp.Usage,
+	}, nil
+}
+
+func mediaPayload(value string) *core.MediaPayload {
+	if strings.HasPrefix(value, "data:") {
+		if metadata, data, ok := strings.Cut(value, ","); ok && strings.Contains(metadata, ";base64") {
+			mimeType := strings.TrimPrefix(strings.SplitN(metadata, ";", 2)[0], "data:")
+			return &core.MediaPayload{MIMEType: mimeType, Data: data}
+		}
+	}
+	return &core.MediaPayload{URL: value}
 }
 
 func estimateEmbeddingTokens(req *core.EmbeddingRequest) int64 {
@@ -281,6 +455,12 @@ func estimateEmbeddingTokens(req *core.EmbeddingRequest) int64 {
 // keep trying the next attempt (true) or surface the error now (false).
 func (p *Pipeline) noteMediaFailure(ctx context.Context, a dispatch.Attempt, err error) bool {
 	pe := core.AsProviderError(err)
+	if pe.Provider == "" {
+		pe.Provider = a.Target.Provider
+	}
+	if pe.Model == "" {
+		pe.Model = a.Target.Model
+	}
 	p.dispatcher.NoteFailure(ctx, a.Account.ID, pe)
 	if p.metrics != nil {
 		p.metrics.RecordUpstreamError(a.Target.Provider, string(pe.Kind))

--- a/backend/internal/pipeline/media_test.go
+++ b/backend/internal/pipeline/media_test.go
@@ -1,0 +1,59 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/mydisha/keirouter/backend/internal/dispatch"
+	"github.com/stretchr/testify/require"
+)
+
+type chatOnlyVisionConnector struct {
+	request *core.ChatRequest
+}
+
+func (c *chatOnlyVisionConnector) ID() string            { return "vision-chat" }
+func (c *chatOnlyVisionConnector) Dialect() core.Dialect { return core.DialectAnthropic }
+func (c *chatOnlyVisionConnector) Chat(_ context.Context, req *core.ChatRequest, _ core.Credentials) (*core.ChatResponse, error) {
+	c.request = req
+	return &core.ChatResponse{
+		Model: req.Model,
+		Message: core.Message{
+			Role:    core.RoleAssistant,
+			Content: []core.ContentPart{{Type: core.PartText, Text: "a cat"}},
+		},
+		Usage: core.Usage{TotalTokens: 12},
+	}, nil
+}
+func (c *chatOnlyVisionConnector) Stream(context.Context, *core.ChatRequest, core.Credentials, core.StreamConfig) (<-chan core.StreamChunk, error) {
+	ch := make(chan core.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+func TestUnderstandImageFallsBackToCanonicalChat(t *testing.T) {
+	conn := &chatOnlyVisionConnector{}
+	resp, err := understandImage(context.Background(), dispatch.Attempt{
+		Target: dispatch.Target{Provider: "anthropic", Model: "claude-vision"},
+		Conn:   conn,
+	}, &core.ImageUnderstandingRequest{
+		Model:     "claude-vision",
+		Prompt:    "describe",
+		Images:    []string{"data:image/png;base64,abc123", "https://example.com/cat.jpg"},
+		MaxTokens: 321,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "a cat", resp.Text)
+	require.Equal(t, 12, resp.Usage.TotalTokens)
+	require.NotNil(t, conn.request.MaxTokens)
+	require.Equal(t, 321, *conn.request.MaxTokens)
+	require.Len(t, conn.request.Messages[0].Content, 3)
+
+	inline := conn.request.Messages[0].Content[1].Media
+	require.Equal(t, "image/png", inline.MIMEType)
+	require.Equal(t, "abc123", inline.Data)
+
+	remote := conn.request.Messages[0].Content[2].Media
+	require.Equal(t, "https://example.com/cat.jpg", remote.URL)
+}

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -255,7 +255,9 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 	var lastAttempt dispatch.Attempt
 	var lastLatency time.Duration
 	fellBack := false // tracks whether the current request triggered ≥1 fallback
-	for i, attempt := range attempts {
+	planner := newAttemptPlanner(p.dispatcher, req.Metadata.TenantID, opts.Targets, required, opts.PlanOpts, attempts)
+	attempt, hasAttempt := planner.Current()
+	for i := 0; hasAttempt; i++ {
 		lastAttempt = attempt
 		started := time.Now()
 		p.log.Debug("attempt start", "i", i, "provider", attempt.Target.Provider,
@@ -329,19 +331,24 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 		lastLatency = latency
 
 		if callErr != nil {
-			pe := core.AsProviderError(callErr)
+			pe := providerErrorForAttempt(callErr, attempt)
 			lastErr = pe
 			p.dispatcher.NoteFailure(ctx, attempt.Account.ID, pe)
 			if p.metrics != nil {
 				p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
 			}
-			p.recordFailureTelemetry(req.Metadata, attempt, pe, latency, pe.Fallbackable())
 			if !pe.Fallbackable() {
+				p.recordFailureTelemetry(req.Metadata, attempt, pe, latency, false)
 				p.log.Debug("attempt not fallbackable, aborting", "kind", pe.Kind)
 				pe, cost := p.recordAttemptTerminal(ctx, req.Metadata, attempt, pe, core.Usage{},
 					latency, time.Since(requestStarted), 0, nil, fellBack)
 				p.budgetConfirm(scope, cost)
 				return nil, pe
+			}
+			nextAttempt, canFallback := planner.AfterFailure(ctx, attempt, pe)
+			p.recordFailureTelemetry(req.Metadata, attempt, pe, latency, canFallback)
+			if !canFallback {
+				break
 			}
 			if p.metrics != nil {
 				p.metrics.RecordFallback(string(pe.Kind))
@@ -349,11 +356,12 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 			fellBack = true
 			p.log.Warn("chat attempt failed, falling back",
 				"provider", attempt.Target.Provider, "model", attempt.Target.Model, "kind", pe.Kind)
+			attempt = nextAttempt
 			continue
 		}
 
 		// Reset backoff and clear model cooldown on success.
-		p.dispatcher.NoteSuccess(ctx, attempt.Account.ID, attempt.Target.Model)
+		p.dispatcher.NoteSuccess(ctx, attempt.Target.Provider, attempt.Account.ID, attempt.Target.Model)
 
 		// Guardrails outbound: PII scan / response masking. Runs after the
 		// upstream succeeds but before we record usage so a Block decision
@@ -424,14 +432,22 @@ type StreamResult struct {
 	DirectCompleteFunc func(error)
 }
 
-// maxRateLimitRetries is how many times the pipeline will re-plan and retry a
-// transient rate-limit that has no explicit upstream reset time. Providers with
-// account-wide limits can opt out so one inbound request is never amplified.
+// maxRateLimitRetries bounds re-dispatch after every candidate was temporarily
+// throttled. The retry-after and request deadline impose the tighter limit.
 const maxRateLimitRetries = 3
 
-func shouldRetryStreamRateLimit(pe *core.ProviderError, retries int) bool {
-	return pe != nil && pe.Kind == core.ErrRateLimit && pe.Fallbackable() &&
-		pe.Provider != "kiro" && pe.RetryAfter <= 0 && retries < maxRateLimitRetries
+const cooldownWaitMargin = 50 * time.Millisecond
+
+func streamRateLimitWait(pe *core.ProviderError, retries int, budget time.Duration) (time.Duration, bool) {
+	if pe == nil || pe.Kind != core.ErrRateLimit || !pe.Fallbackable() ||
+		pe.Provider == "kiro" || retries >= maxRateLimitRetries || pe.RetryAfter <= 0 {
+		return 0, false
+	}
+	wait := pe.RetryAfter + cooldownWaitMargin
+	if wait > budget {
+		return 0, false
+	}
+	return wait, true
 }
 
 // Stream runs a streaming request with fallback. Fallback applies only to the
@@ -487,8 +503,10 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 	}
 	p.log.Debug("stream dispatcher planned", "attempts", len(attempts))
 
-	// Outer rate-limit retry loop: re-plan and retry when all attempts hit 429.
+	// Outer rate-limit retry loop: re-plan only when the soonest cooldown fits
+	// inside the bounded wait budget.
 	rlRetries := 0
+	waitBudget := CooldownRetryMax
 	for {
 		sr, sErr, budgetReleased, lastAttempt, lastLatency, fellBack := p.streamExec(
 			ctx, req, opts, attempts, slimStats, save, required, scope, release, requestStarted)
@@ -496,11 +514,9 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 			return sr, nil
 		}
 
-		// Never turn an account-wide Kiro limit into another upstream request.
-		// An explicit reset time is also authoritative and must be returned to the
-		// caller instead of being replaced by this short local retry loop.
 		pe := providerErrorForAttempt(sErr, lastAttempt)
-		if !shouldRetryStreamRateLimit(pe, rlRetries) {
+		wait, shouldRetry := streamRateLimitWait(pe, rlRetries, waitBudget)
+		if !shouldRetry {
 			release(0)
 			if !budgetReleased {
 				p.budgetRelease(scope)
@@ -511,11 +527,9 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 			return nil, pe
 		}
 		rlRetries++
-		// Wait for the cooldown to expire before re-planning. The dispatcher
-		// set TransientCooldown (2s-30s) via NoteFailure; give it a moment.
-		wait := time.Duration(rlRetries) * 2 * time.Second
 		p.log.Warn("all stream attempts hit rate-limit, waiting to retry",
 			"wait", wait, "retry", rlRetries, "of", maxRateLimitRetries)
+		waitedAt := time.Now()
 		select {
 		case <-time.After(wait):
 		case <-ctx.Done():
@@ -538,7 +552,8 @@ func (p *Pipeline) Stream(ctx context.Context, req *core.ChatRequest, opts Optio
 				return nil, rerr
 			}
 		}
-		attempts, err = p.planWithCooldownRetry(ctx, req.Metadata.TenantID, opts.Targets, required, opts.PlanOpts)
+		waitBudget -= time.Since(waitedAt)
+		attempts, err = p.dispatcher.PlanWith(ctx, req.Metadata.TenantID, opts.Targets, required, opts.PlanOpts)
 		if err != nil {
 			p.log.Debug("stream re-plan after rate-limit failed", "err", err)
 			p.budgetRelease(scope)
@@ -564,7 +579,9 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 	var lastAttempt dispatch.Attempt
 	var lastLatency time.Duration
 	fellBack := false // tracks whether the current request triggered ≥1 fallback
-	for i, attempt := range attempts {
+	planner := newAttemptPlanner(p.dispatcher, req.Metadata.TenantID, opts.Targets, required, opts.PlanOpts, attempts)
+	attempt, hasAttempt := planner.Current()
+	for i := 0; hasAttempt; i++ {
 		lastAttempt = attempt
 		attemptReq := cloneForAttempt(req, attempt.Target.Model)
 		started := time.Now()
@@ -622,7 +639,7 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 				body, _, rawErr := ds.StreamRaw(callCtx, attemptReq, attempt.Creds, streamCfg)
 				if rawErr != nil {
 					cancelUpstream()
-					pe := core.AsProviderError(rawErr)
+					pe := providerErrorForAttempt(rawErr, attempt)
 					lastErr = pe
 					p.dispatcher.NoteFailure(ctx, attempt.Account.ID, pe)
 					if p.metrics != nil {
@@ -630,11 +647,16 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 					}
 					attemptLatency := time.Since(started)
 					lastLatency = attemptLatency
-					p.recordFailureTelemetry(req.Metadata, attempt, pe, attemptLatency, pe.Fallbackable())
 					if !pe.Fallbackable() {
+						p.recordFailureTelemetry(req.Metadata, attempt, pe, attemptLatency, false)
 						release(0)
 						p.budgetRelease(scope)
 						return nil, pe, true, attempt, attemptLatency, fellBack
+					}
+					nextAttempt, canFallback := planner.AfterFailure(ctx, attempt, pe)
+					p.recordFailureTelemetry(req.Metadata, attempt, pe, attemptLatency, canFallback)
+					if !canFallback {
+						break
 					}
 					if p.metrics != nil {
 						p.metrics.RecordFallback(string(pe.Kind))
@@ -642,11 +664,11 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 					fellBack = true
 					p.log.Warn("direct stream attempt failed, falling back",
 						"provider", attempt.Target.Provider, "model", attempt.Target.Model, "kind", pe.Kind)
+					attempt = nextAttempt
 					continue
 				}
 				p.log.Debug("direct stream connected (zero-copy)", "provider", attempt.Target.Provider,
 					"model", attempt.Target.Model)
-				p.dispatcher.NoteSuccess(ctx, attempt.Account.ID, attempt.Target.Model)
 				// Wrap the raw body in a tee reader that captures all bytes
 				// into a buffer and detects the first byte for TTFT measurement.
 				// After io.Copy completes in the gateway, the DirectUsageFunc
@@ -692,6 +714,7 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 						}
 
 						totalLatency := time.Since(started)
+						p.dispatcher.NoteSuccess(recordCtx, acc.Target.Provider, acc.Account.ID, acc.Target.Model)
 						cost := p.recordWithTTFT(recordCtx, meta, acc, usage, false,
 							totalLatency, time.Since(requestStarted), ttft, saveCopy, fellBack)
 						p.budgetConfirm(budgetScope, cost)
@@ -712,7 +735,7 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 		upstream, callErr := attempt.Conn.Stream(callCtx, attemptReq, attempt.Creds, streamCfg)
 		if callErr != nil {
 			cancelUpstream()
-			pe := core.AsProviderError(callErr)
+			pe := providerErrorForAttempt(callErr, attempt)
 			lastErr = pe
 			p.dispatcher.NoteFailure(ctx, attempt.Account.ID, pe)
 			if p.metrics != nil {
@@ -720,12 +743,17 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 			}
 			attemptLatency := time.Since(started)
 			lastLatency = attemptLatency
-			p.recordFailureTelemetry(req.Metadata, attempt, pe, attemptLatency, pe.Fallbackable())
 			if !pe.Fallbackable() {
+				p.recordFailureTelemetry(req.Metadata, attempt, pe, attemptLatency, false)
 				p.log.Debug("stream attempt not fallbackable, aborting", "kind", pe.Kind)
 				release(0)
 				p.budgetRelease(scope)
 				return nil, pe, true, attempt, attemptLatency, fellBack
+			}
+			nextAttempt, canFallback := planner.AfterFailure(ctx, attempt, pe)
+			p.recordFailureTelemetry(req.Metadata, attempt, pe, attemptLatency, canFallback)
+			if !canFallback {
+				break
 			}
 			if p.metrics != nil {
 				p.metrics.RecordFallback(string(pe.Kind))
@@ -733,12 +761,12 @@ func (p *Pipeline) streamExec(ctx context.Context, req *core.ChatRequest, opts O
 			fellBack = true
 			p.log.Warn("stream attempt failed, falling back",
 				"provider", attempt.Target.Provider, "model", attempt.Target.Model, "kind", pe.Kind)
+			attempt = nextAttempt
 			continue
 		}
 
 		p.log.Debug("stream connected", "provider", attempt.Target.Provider,
 			"model", attempt.Target.Model, "account", attempt.Account.ID)
-		p.dispatcher.NoteSuccess(ctx, attempt.Account.ID, attempt.Target.Model)
 
 		// Tee the upstream channel so we can meter terminal usage without
 		// blocking the client consumer.
@@ -887,6 +915,7 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 					}
 				}
 				upstreamLatency := time.Since(attemptStarted)
+				p.dispatcher.NoteSuccess(context.WithoutCancel(ctx), attempt.Target.Provider, attempt.Account.ID, attempt.Target.Model)
 				cost := p.recordWithTTFT(ctx, meta, attempt, usage, false, upstreamLatency,
 					time.Since(requestStarted), *ttft, save, fellBack)
 				p.budgetConfirm(scope, cost)
@@ -953,6 +982,7 @@ func (p *Pipeline) pumpStream(ctx context.Context, req *core.ChatRequest, in <-c
 						cost := p.recordOutcomeWithTTFT(context.WithoutCancel(ctx), meta, attempt, blockedUsage,
 							"blocked", string(core.ErrPolicyBlocked), false, upstreamLatency,
 							time.Since(requestStarted), *ttft, save)
+						p.dispatcher.NoteSuccess(context.WithoutCancel(ctx), attempt.Target.Provider, attempt.Account.ID, attempt.Target.Model)
 						p.recordSuccessTelemetry(meta, attempt, blockedUsage, upstreamLatency, *ttft, fellBack, cost)
 						p.budgetConfirm(scope, cost)
 						return
@@ -1128,33 +1158,30 @@ func (p *Pipeline) budgetRelease(scope budget.Scope) {
 	}
 }
 
-// planWithCooldownRetry wraps dispatcher planning with a brief wait-and-retry
-// when all accounts are on cooldown. Cooldown is a transient state (typically
-// 2-30s), so a short wait yields usable accounts instead of an instant failure.
-// Retries up to 3 times, sleeping up to CooldownRetryMax total.
+// planWithCooldownRetry waits for the earliest typed cooldown reported by the
+// dispatcher. Long quota/auth windows are returned immediately; only cooldowns
+// that fit the request's bounded wait budget are retried.
 func (p *Pipeline) planWithCooldownRetry(ctx context.Context, tenantID string, targets []dispatch.Target, required core.CapabilitySet, opts dispatch.PlanOptions) ([]dispatch.Attempt, error) {
 	attempts, err := p.dispatcher.PlanWith(ctx, tenantID, targets, required, opts)
 	if err == nil && len(attempts) > 0 {
 		return attempts, nil
 	}
-	// Only retry when the error is a cooldown block (all accounts on cooldown).
-	if err == nil || !strings.Contains(err.Error(), "on cooldown") {
+	if err == nil {
 		return attempts, err
 	}
 
 	deadline := time.Now().Add(CooldownRetryMax)
 	for i := 0; i < 3; i++ {
+		pe := core.AsProviderError(err)
+		if pe.Kind != core.ErrRateLimit || pe.RetryAfter <= 0 {
+			return attempts, err
+		}
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		if time.Now().After(deadline) {
-			break
-		}
-		wait := time.Duration(i+1) * 2 * time.Second
-		if wait > time.Until(deadline) {
-			wait = time.Until(deadline)
-		}
-		if wait <= 0 {
+		wait := pe.RetryAfter + cooldownWaitMargin
+		remaining := time.Until(deadline)
+		if wait <= 0 || remaining <= 0 || wait > remaining {
 			break
 		}
 		p.log.Debug("all accounts on cooldown, waiting before retry", "wait", wait, "attempt", i+1)
@@ -1167,7 +1194,7 @@ func (p *Pipeline) planWithCooldownRetry(ctx context.Context, tenantID string, t
 		if err == nil && len(attempts) > 0 {
 			return attempts, nil
 		}
-		if err == nil || !strings.Contains(err.Error(), "on cooldown") {
+		if err == nil {
 			return attempts, err
 		}
 	}
@@ -1336,12 +1363,16 @@ func (p *Pipeline) recordTerminalStreamFailure(ctx context.Context, req *core.Ch
 	attemptStarted, requestStarted time.Time, usage core.Usage, completionChars int,
 	ttft time.Duration, save *saveState, fellBack bool, scope budget.Scope) *core.ProviderError {
 	pe := providerErrorForAttempt(streamErr, attempt)
-	p.dispatcher.NoteFailure(context.WithoutCancel(ctx), attempt.Account.ID, pe)
-	if p.metrics != nil {
-		p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
+	clientCanceled := core.IsClientDisconnect(pe)
+	if !clientCanceled {
+		p.dispatcher.NoteFailure(context.WithoutCancel(ctx), attempt.Account.ID, pe)
+		if p.metrics != nil {
+			p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
+		}
+		upstreamLatency := time.Since(attemptStarted)
+		p.recordFailureTelemetry(meta, attempt, pe, upstreamLatency, false)
 	}
 	upstreamLatency := time.Since(attemptStarted)
-	p.recordFailureTelemetry(meta, attempt, pe, upstreamLatency, false)
 	usage = partialStreamUsage(req, usage, completionChars)
 	pe, cost := p.recordAttemptTerminal(ctx, meta, attempt, pe, usage, upstreamLatency,
 		time.Since(requestStarted), ttft, save, fellBack)
@@ -1415,6 +1446,9 @@ func terminalStatusAndKind(err error) (string, string) {
 		return "cancelled", "cancelled"
 	}
 	pe := core.AsProviderError(err)
+	if pe != nil && pe.Kind == core.ErrClientCanceled {
+		return "cancelled", string(pe.Kind)
+	}
 	if pe != nil && pe.Kind == core.ErrPolicyBlocked {
 		return "blocked", string(pe.Kind)
 	}
@@ -1465,7 +1499,9 @@ func (p *Pipeline) recordAttemptTerminal(ctx context.Context, meta core.RequestM
 	status, errorKind := terminalStatusAndKind(pe)
 	cost := p.recordOutcomeWithTTFT(context.WithoutCancel(ctx), meta, attempt, usage,
 		status, errorKind, false, upstreamLatency, endToEndLatency, ttft, save)
-	p.recordFinalFailureTelemetry(meta, attempt, pe, fellBack)
+	if pe.Kind != core.ErrClientCanceled {
+		p.recordFinalFailureTelemetry(meta, attempt, pe, fellBack)
+	}
 	return pe, cost
 }
 

--- a/backend/internal/pipeline/pipeline_test.go
+++ b/backend/internal/pipeline/pipeline_test.go
@@ -9,22 +9,55 @@ import (
 
 func TestShouldRetryStreamRateLimit(t *testing.T) {
 	tests := []struct {
-		name    string
-		error   *core.ProviderError
-		retries int
-		want    bool
+		name       string
+		error      *core.ProviderError
+		retries    int
+		waitBudget time.Duration
+		want       bool
+		wantWait   time.Duration
 	}{
-		{name: "transient other provider", error: &core.ProviderError{Kind: core.ErrRateLimit, Provider: "openai"}, want: true},
-		{name: "kiro account limit", error: &core.ProviderError{Kind: core.ErrRateLimit, Provider: "kiro"}, want: false},
-		{name: "explicit reset", error: &core.ProviderError{Kind: core.ErrRateLimit, Provider: "openai", RetryAfter: time.Minute}, want: false},
-		{name: "retry budget exhausted", error: &core.ProviderError{Kind: core.ErrRateLimit, Provider: "openai"}, retries: maxRateLimitRetries, want: false},
-		{name: "not a rate limit", error: &core.ProviderError{Kind: core.ErrUpstream, Provider: "openai"}, want: false},
+		{
+			name:       "transient other provider",
+			error:      &core.ProviderError{Kind: core.ErrRateLimit, Provider: "openai", RetryAfter: 2 * time.Second},
+			waitBudget: 10 * time.Second,
+			want:       true,
+			wantWait:   2050 * time.Millisecond,
+		},
+		{
+			name:       "kiro account limit",
+			error:      &core.ProviderError{Kind: core.ErrRateLimit, Provider: "kiro", RetryAfter: 2 * time.Second},
+			waitBudget: 10 * time.Second,
+			want:       false,
+		},
+		{
+			name:       "explicit reset exceeds budget",
+			error:      &core.ProviderError{Kind: core.ErrRateLimit, Provider: "openai", RetryAfter: time.Minute},
+			waitBudget: 10 * time.Second,
+			want:       false,
+		},
+		{
+			name:       "retry budget exhausted",
+			error:      &core.ProviderError{Kind: core.ErrRateLimit, Provider: "openai", RetryAfter: time.Second},
+			retries:    maxRateLimitRetries,
+			waitBudget: 10 * time.Second,
+			want:       false,
+		},
+		{
+			name:       "not a rate limit",
+			error:      &core.ProviderError{Kind: core.ErrUpstream, Provider: "openai"},
+			waitBudget: 10 * time.Second,
+			want:       false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldRetryStreamRateLimit(tt.error, tt.retries); got != tt.want {
-				t.Fatalf("shouldRetryStreamRateLimit() = %v, want %v", got, tt.want)
+			gotWait, got := streamRateLimitWait(tt.error, tt.retries, tt.waitBudget)
+			if got != tt.want {
+				t.Fatalf("streamRateLimitWait() ok = %v, want %v", got, tt.want)
+			}
+			if gotWait != tt.wantWait {
+				t.Fatalf("streamRateLimitWait() wait = %v, want %v", gotWait, tt.wantWait)
 			}
 		})
 	}

--- a/backend/internal/store/repo_routing.go
+++ b/backend/internal/store/repo_routing.go
@@ -114,6 +114,47 @@ func (r *RoutingRepo) ActiveCooldowns(ctx context.Context, accountIDs []string, 
 	return out, rows.Err()
 }
 
+// ActiveCooldownExpirations returns the latest active model cooldown per
+// account for model or '__all__'. It is used to calculate the earliest safe
+// retry instead of polling with fixed sleeps.
+func (r *RoutingRepo) ActiveCooldownExpirations(ctx context.Context, accountIDs []string, model string) (map[string]time.Time, error) {
+	out := make(map[string]time.Time)
+	if len(accountIDs) == 0 {
+		return out, nil
+	}
+
+	placeholders := make([]string, len(accountIDs))
+	args := make([]any, 0, len(accountIDs)+3)
+	for i, id := range accountIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	args = append(args, model, "__all__", formatTime(time.Now()))
+
+	q := r.db.rebind(`SELECT account_id, MAX(cooldown_until) FROM model_cooldowns
+		WHERE account_id IN (` + strings.Join(placeholders, ",") + `)
+		  AND model IN (?, ?)
+		  AND cooldown_until > ?
+		GROUP BY account_id`)
+
+	rows, err := r.db.sql.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("store: active model cooldown expirations: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id, raw string
+		if err := rows.Scan(&id, &raw); err != nil {
+			continue
+		}
+		if until := parseTime(raw); !until.IsZero() {
+			out[id] = until
+		}
+	}
+	return out, rows.Err()
+}
+
 // ExpireModelCooldowns removes all expired model cooldowns (garbage collection).
 func (r *RoutingRepo) ExpireModelCooldowns(ctx context.Context) (int64, error) {
 	q := r.db.rebind(`DELETE FROM model_cooldowns WHERE cooldown_until < ?`)

--- a/backend/internal/transform/anthropic.go
+++ b/backend/internal/transform/anthropic.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	json "github.com/mydisha/keirouter/backend/internal/fastjson"
 
@@ -27,6 +28,11 @@ type antRequest struct {
 	Temp       *float64        `json:"temperature,omitempty"`
 	TopP       *float64        `json:"top_p,omitempty"`
 	Stop       []string        `json:"stop_sequences,omitempty"`
+	// Thinking carries the extended-thinking configuration that clients like
+	// Claude Code send. It must be forwarded to Anthropic-compatible upstreams
+	// (e.g. GLM, Zhipu) or the model will not emit reasoning blocks, confusing
+	// clients that expect them.
+	Thinking json.RawMessage `json:"thinking,omitempty"`
 }
 
 type antMessage struct {
@@ -35,8 +41,11 @@ type antMessage struct {
 }
 
 type antBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+	// Thinking holds the reasoning content for thinking blocks. Anthropic uses
+	// "thinking" as the JSON key (not "text") for this block type.
+	Thinking  string          `json:"thinking,omitempty"`
 	ID        string          `json:"id,omitempty"`
 	Name      string          `json:"name,omitempty"`
 	Input     json.RawMessage `json:"input,omitempty"`
@@ -115,11 +124,14 @@ func parseAntThinkingFromBytes(body []byte) *core.ReasoningConfig {
 	}
 	if err := json.Unmarshal(body, &thinkingWrapper); err == nil && thinkingWrapper.Thinking != nil {
 		cfg := &core.ReasoningConfig{}
-		if thinkingWrapper.Thinking.Type == "enabled" {
+		switch thinkingWrapper.Thinking.Type {
+		case "enabled":
 			cfg.Effort = "high"
 			if thinkingWrapper.Thinking.BudgetTokens > 0 {
 				cfg.MaxTokens = thinkingWrapper.Thinking.BudgetTokens
 			}
+		case "adaptive":
+			cfg.Effort = "adaptive"
 		}
 		return cfg
 	}
@@ -166,7 +178,14 @@ func parseAntMessage(m antMessage) core.Message {
 		case "text":
 			msg.Content = append(msg.Content, core.ContentPart{Type: core.PartText, Text: b.Text})
 		case "thinking":
-			msg.Content = append(msg.Content, core.ContentPart{Type: core.PartThinking, Text: b.Text})
+			// Anthropic thinking blocks carry content in the "thinking" field
+			// (not "text"). Signature must be preserved for echoing back on
+			// follow-up turns — the upstream validates it.
+			msg.Content = append(msg.Content, core.ContentPart{
+				Type:      core.PartThinking,
+				Text:      b.Thinking,
+				Signature: b.Signature,
+			})
 		case "tool_use":
 			msg.Content = append(msg.Content, core.ContentPart{
 				Type:     core.PartToolCall,
@@ -240,6 +259,7 @@ func (AnthropicCodec) RenderRequest(req *core.ChatRequest) ([]byte, error) {
 	if req.MaxTokens != nil && *req.MaxTokens > 0 {
 		maxTokens = *req.MaxTokens
 	}
+	thinkingBudget := 0
 
 	// Reconcile max_tokens against thinking budget. Anthropic requires
 	// max_tokens strictly greater than budget_tokens (else 400). Prefer raising
@@ -248,14 +268,14 @@ func (AnthropicCodec) RenderRequest(req *core.ChatRequest) ([]byte, error) {
 	// remain for the answer.
 	ceiling := antDefaultMaxOutput
 	if req.Reasoning != nil && req.Reasoning.MaxTokens > 0 {
-		budgetTokens := req.Reasoning.MaxTokens
-		if budgetTokens >= maxTokens {
+		thinkingBudget = req.Reasoning.MaxTokens
+		if thinkingBudget >= maxTokens {
 			// Raise max_tokens to preserve thinking depth (up to ceiling)
-			maxTokens = min(budgetTokens+1024, ceiling)
-			if budgetTokens >= maxTokens {
+			maxTokens = min(thinkingBudget+1024, ceiling)
+			if thinkingBudget >= maxTokens {
 				// Budget exceeds ceiling; shrink budget so 1024 tokens remain for answer
 				// Note: We don't mutate req.Reasoning, the reconciliation happens at render time
-				budgetTokens = max(1024, maxTokens-1024)
+				thinkingBudget = max(1024, maxTokens-1024)
 			}
 		}
 	}
@@ -272,6 +292,35 @@ func (AnthropicCodec) RenderRequest(req *core.ChatRequest) ([]byte, error) {
 	if modelRejectsTemperature(req.Model) {
 		out.Temp = nil
 	}
+
+	// Forward extended-thinking configuration to Anthropic-compatible upstreams.
+	// Claude Code sends thinking: {type: "enabled", budget_tokens: N} and expects
+	// reasoning blocks in the response. Dropping this field causes the upstream
+	// (GLM, Zhipu, etc.) to skip reasoning, which confuses clients and may
+	// trigger retries.
+	if req.Reasoning != nil {
+		effort := strings.ToLower(strings.TrimSpace(req.Reasoning.Effort))
+		var thinking map[string]any
+		switch effort {
+		case "adaptive", "auto":
+			thinking = map[string]any{"type": "adaptive"}
+		case "", "none", "off", "disabled":
+			if thinkingBudget > 0 {
+				thinking = map[string]any{"type": "enabled"}
+			}
+		default:
+			thinking = map[string]any{"type": "enabled"}
+		}
+		if thinking != nil && thinking["type"] == "enabled" && thinkingBudget > 0 {
+			thinking["budget_tokens"] = thinkingBudget
+		}
+		if thinking != nil {
+			if raw, err := json.Marshal(thinking); err == nil {
+				out.Thinking = raw
+			}
+		}
+	}
+
 	if req.System != "" {
 		sys, _ := json.Marshal(req.System)
 		out.System = sys
@@ -321,7 +370,15 @@ func renderAntBlocks(m core.Message) []antBlock {
 			}
 			blocks = append(blocks, antBlock{Type: "text", Text: p.Text})
 		case core.PartThinking:
-			blocks = append(blocks, antBlock{Type: "thinking", Text: p.Text})
+			// Render thinking with the correct "thinking" JSON key and echo back
+			// the signature when present (required by upstream for validation).
+			// When no signature exists (e.g. thinking synthesized by a non-Anthropic
+			// upstream), omit it — some providers reject a null/empty signature.
+			block := antBlock{Type: "thinking", Thinking: p.Text}
+			if p.Signature != "" {
+				block.Signature = p.Signature
+			}
+			blocks = append(blocks, block)
 		case core.PartToolCall:
 			blocks = append(blocks, antBlock{
 				Type:  "tool_use",

--- a/backend/internal/transform/anthropic_stream.go
+++ b/backend/internal/transform/anthropic_stream.go
@@ -143,6 +143,9 @@ func (AnthropicCodec) ParseStreamLine(line []byte, _ string) ([]core.StreamChunk
 // opens the message and a text content block on first text delta.
 func (AnthropicCodec) RenderStreamChunk(chunk core.StreamChunk, state *StreamState) ([][]byte, error) {
 	var events [][]byte
+	if state.Custom == nil {
+		state.Custom = make(map[string]any)
+	}
 
 	ensureOpen := func() {
 		if state.SentRole {
@@ -162,30 +165,73 @@ func (AnthropicCodec) RenderStreamChunk(chunk core.StreamChunk, state *StreamSta
 	switch chunk.Type {
 	case core.ChunkText:
 		ensureOpen()
+		// Close any open thinking block before starting/continuing text.
+		// Thinking and text are separate content blocks with distinct indices;
+		// leaving a thinking block open while emitting text_delta corrupts the
+		// block index sequence and makes some clients (Claude Code) render the
+		// thinking as a second message segment.
+		if thinkOpen, _ := state.Custom["thinking_open"].(bool); thinkOpen {
+			thinkIdx, _ := state.Custom["thinking_index"].(int)
+			events = append(events, antEvent("content_block_stop", map[string]any{
+				"type": "content_block_stop", "index": thinkIdx,
+			}))
+			state.Custom["thinking_open"] = false
+		}
 		// Close any open tool block before starting/continuing text.
 		if toolOpen, _ := state.Custom["tool_open"].(bool); toolOpen {
 			events = append(events, antEvent("content_block_stop", map[string]any{
 				"type": "content_block_stop", "index": state.ToolIndex,
 			}))
 			state.Custom["tool_open"] = false
-			state.ToolIndex++
 		}
 		if !state.OpenedBlock {
 			state.OpenedBlock = true
+			// The text block opens at the next index after any thinking block
+			// that already opened (e.g. MiMo streams reasoning_content first).
+			state.Custom["text_index"] = nextContentIndex(state)
+			textIdx, _ := state.Custom["text_index"].(int)
 			events = append(events, antEvent("content_block_start", map[string]any{
-				"type": "content_block_start", "index": 0,
+				"type": "content_block_start", "index": textIdx,
 				"content_block": map[string]any{"type": "text", "text": ""},
 			}))
 		}
+		textIdx, _ := state.Custom["text_index"].(int)
 		events = append(events, antEvent("content_block_delta", map[string]any{
-			"type": "content_block_delta", "index": 0,
+			"type": "content_block_delta", "index": textIdx,
 			"delta": map[string]any{"type": "text_delta", "text": chunk.Delta},
 		}))
 
 	case core.ChunkThinking:
 		ensureOpen()
+		// Anthropic streams reasoning as its own typed content block:
+		// content_block_start(type=thinking) → thinking_delta* →
+		// content_block_stop. Emitting thinking_delta without opening a
+		// thinking block (and reusing the text block's index) produces a
+		// non-compliant stream that some clients (Claude Code) mis-parse as a
+		// second message segment/turn.
+		if thinkOpen, _ := state.Custom["thinking_open"].(bool); !thinkOpen {
+			// A text block may already be open (text arrived before thinking);
+			// close it first so the thinking block gets its own index.
+			if state.OpenedBlock {
+				textIdx, _ := state.Custom["text_index"].(int)
+				events = append(events, antEvent("content_block_stop", map[string]any{
+					"type": "content_block_stop", "index": textIdx,
+				}))
+				state.OpenedBlock = false
+			}
+			state.Custom["thinking_open"] = true
+			state.Custom["thinking_index"] = nextContentIndex(state)
+			thinkIdx, _ := state.Custom["thinking_index"].(int)
+			events = append(events, antEvent("content_block_start", map[string]any{
+				"type":          "content_block_start",
+				"index":         thinkIdx,
+				"content_block": map[string]any{"type": "thinking", "thinking": ""},
+			}))
+		}
+		thinkIdx, _ := state.Custom["thinking_index"].(int)
 		events = append(events, antEvent("content_block_delta", map[string]any{
-			"type": "content_block_delta", "index": 0,
+			"type":  "content_block_delta",
+			"index": thinkIdx,
 			"delta": map[string]any{"type": "thinking_delta", "thinking": chunk.Delta},
 		}))
 
@@ -193,6 +239,20 @@ func (AnthropicCodec) RenderStreamChunk(chunk core.StreamChunk, state *StreamSta
 		ensureOpen()
 		if chunk.ToolCall == nil {
 			break
+		}
+		if thinkOpen, _ := state.Custom["thinking_open"].(bool); thinkOpen {
+			thinkIdx, _ := state.Custom["thinking_index"].(int)
+			events = append(events, antEvent("content_block_stop", map[string]any{
+				"type": "content_block_stop", "index": thinkIdx,
+			}))
+			state.Custom["thinking_open"] = false
+		}
+		if state.OpenedBlock {
+			textIdx, _ := state.Custom["text_index"].(int)
+			events = append(events, antEvent("content_block_stop", map[string]any{
+				"type": "content_block_stop", "index": textIdx,
+			}))
+			state.OpenedBlock = false
 		}
 
 		// First chunk for a tool call (carries ID and Name) — open a new
@@ -208,11 +268,9 @@ func (AnthropicCodec) RenderStreamChunk(chunk core.StreamChunk, state *StreamSta
 					events = append(events, antEvent("content_block_stop", map[string]any{
 						"type": "content_block_stop", "index": state.ToolIndex,
 					}))
-					state.ToolIndex++
 				}
-				if state.Custom == nil {
-					state.Custom = map[string]any{}
-				}
+				state.ToolIndex = nextContentIndex(state)
+				state.Custom["tool_seen"] = true
 				state.Custom["tool_open"] = true
 				state.Custom["tool_id"] = chunk.ToolCall.ID
 				events = append(events, antEvent("content_block_start", map[string]any{
@@ -246,7 +304,21 @@ func (AnthropicCodec) RenderStreamChunk(chunk core.StreamChunk, state *StreamSta
 		}
 
 	case core.ChunkFinish:
-		// Close any open tool block, then any open text block.
+		if sent, _ := state.Custom["finish_sent"].(bool); sent {
+			return nil, nil
+		}
+		state.Custom["finish_sent"] = true
+		ensureOpen()
+		// Close any open thinking block, then any open tool block, then any
+		// open text block — each with its own index — so every content_block_stop
+		// matches a content_block_start.
+		if thinkOpen, _ := state.Custom["thinking_open"].(bool); thinkOpen {
+			thinkIdx, _ := state.Custom["thinking_index"].(int)
+			events = append(events, antEvent("content_block_stop", map[string]any{
+				"type": "content_block_stop", "index": thinkIdx,
+			}))
+			state.Custom["thinking_open"] = false
+		}
 		if toolOpen, _ := state.Custom["tool_open"].(bool); toolOpen {
 			events = append(events, antEvent("content_block_stop", map[string]any{
 				"type": "content_block_stop", "index": state.ToolIndex,
@@ -254,9 +326,11 @@ func (AnthropicCodec) RenderStreamChunk(chunk core.StreamChunk, state *StreamSta
 			state.Custom["tool_open"] = false
 		}
 		if state.OpenedBlock {
+			textIdx, _ := state.Custom["text_index"].(int)
 			events = append(events, antEvent("content_block_stop", map[string]any{
-				"type": "content_block_stop", "index": 0,
+				"type": "content_block_stop", "index": textIdx,
 			}))
+			state.OpenedBlock = false
 		}
 		events = append(events, antEvent("message_delta", map[string]any{
 			"type":  "message_delta",
@@ -268,6 +342,24 @@ func (AnthropicCodec) RenderStreamChunk(chunk core.StreamChunk, state *StreamSta
 		return nil, nil
 	}
 	return events, nil
+}
+
+// nextContentIndex returns the next free content-block index, accounting for
+// any thinking, text, or tool block already opened. Anthropic requires each
+// content block to have a unique monotonically increasing index; thinking and
+// text must not share an index or clients mis-parse the stream as two messages.
+func nextContentIndex(state *StreamState) int {
+	max := -1
+	if idx, ok := state.Custom["thinking_index"].(int); ok && idx > max {
+		max = idx
+	}
+	if idx, ok := state.Custom["text_index"].(int); ok && idx > max {
+		max = idx
+	}
+	if seen, _ := state.Custom["tool_seen"].(bool); seen && state.ToolIndex > max {
+		max = state.ToolIndex
+	}
+	return max + 1
 }
 
 // RenderStreamDone emits the terminal message_stop event.

--- a/backend/internal/transform/anthropic_stream_test.go
+++ b/backend/internal/transform/anthropic_stream_test.go
@@ -31,6 +31,7 @@ func TestAnthropic_ThinkingBudgetReconciliation(t *testing.T) {
 	var antReq map[string]any
 	require.NoError(t, json.Unmarshal(body, &antReq))
 	require.Equal(t, float64(9024), antReq["max_tokens"])
+	require.Equal(t, float64(8000), antReq["thinking"].(map[string]any)["budget_tokens"])
 }
 
 func TestAnthropic_ParseThinking(t *testing.T) {
@@ -46,6 +47,25 @@ func TestAnthropic_ParseThinking(t *testing.T) {
 	require.NotNil(t, req.Reasoning)
 	require.Equal(t, "high", req.Reasoning.Effort)
 	require.Equal(t, 8000, req.Reasoning.MaxTokens)
+}
+
+func TestAnthropic_AdaptiveThinkingRoundTrip(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-sonnet-4.5",
+		"max_tokens": 1024,
+		"thinking": {"type": "adaptive"},
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+
+	req, err := AnthropicCodec{}.ParseRequest(body)
+	require.NoError(t, err)
+	require.Equal(t, "adaptive", req.Reasoning.Effort)
+
+	rendered, err := AnthropicCodec{}.RenderRequest(req)
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rendered, &out))
+	require.Equal(t, "adaptive", out["thinking"].(map[string]any)["type"])
 }
 
 func TestAnthropic_SignatureFieldInBlock(t *testing.T) {
@@ -70,7 +90,153 @@ func TestAnthropic_SignatureFieldInBlock(t *testing.T) {
 	for _, p := range assistantMsg.Content {
 		if p.Type == core.PartThinking {
 			found = true
+			require.Equal(t, "reasoning...", p.Text)
+			require.Equal(t, "sig_abc123", p.Signature, "signature must be preserved")
 		}
 	}
 	require.True(t, found, "thinking block should be parsed")
+}
+
+// TestAnthropic_ThinkingRoundTrip verifies that a thinking block with signature
+// survives ParseRequest → RenderRequest intact. This is critical for
+// Anthropic-compatible providers (GLM, Zhipu, etc.) that validate the signature
+// on follow-up turns.
+func TestAnthropic_ThinkingRoundTrip(t *testing.T) {
+	original := []byte(`{
+		"model": "glm-5.2",
+		"max_tokens": 4096,
+		"messages": [
+			{"role": "assistant", "content": [
+				{"type": "thinking", "thinking": "step 1: analyze...", "signature": "sig_xyz789"},
+				{"type": "text", "text": "Here is the answer."}
+			]},
+			{"role": "user", "content": "what about edge cases?"}
+		]
+	}`)
+
+	req, err := AnthropicCodec{}.ParseRequest(original)
+	require.NoError(t, err)
+
+	rendered, err := AnthropicCodec{}.RenderRequest(req)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rendered, &out))
+
+	messages := out["messages"].([]any)
+	assistant := messages[0].(map[string]any)
+	content := assistant["content"].([]any)
+
+	// First block should be thinking with signature
+	thinkBlock := content[0].(map[string]any)
+	require.Equal(t, "thinking", thinkBlock["type"])
+	require.Equal(t, "step 1: analyze...", thinkBlock["thinking"])
+	require.Equal(t, "sig_xyz789", thinkBlock["signature"])
+
+	// Second block should be text
+	textBlock := content[1].(map[string]any)
+	require.Equal(t, "text", textBlock["type"])
+	require.Equal(t, "Here is the answer.", textBlock["text"])
+}
+
+// TestAnthropic_RenderRequestForwardsThinking verifies that the thinking
+// configuration from the client is forwarded to the upstream. Without this,
+// Anthropic-compatible providers (GLM, Zhipu) skip reasoning blocks and
+// clients like Claude Code see an unexpected response shape.
+func TestAnthropic_RenderRequestForwardsThinking(t *testing.T) {
+	maxTok := 4096
+	req := &core.ChatRequest{
+		Model:     "glm-5.2",
+		MaxTokens: &maxTok,
+		Reasoning: &core.ReasoningConfig{
+			Effort:    "high",
+			MaxTokens: 8000,
+		},
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+		},
+	}
+
+	body, err := AnthropicCodec{}.RenderRequest(req)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(body, &out))
+
+	thinking, ok := out["thinking"].(map[string]any)
+	require.True(t, ok, "thinking field must be present in rendered request")
+	require.Equal(t, "enabled", thinking["type"])
+	require.Equal(t, float64(8000), thinking["budget_tokens"])
+}
+
+// TestAnthropic_RenderRequestOmitsThinkingWhenNotRequested verifies that
+// the thinking field is omitted when the client did not request it.
+func TestAnthropic_RenderRequestOmitsThinkingWhenNotRequested(t *testing.T) {
+	maxTok := 4096
+	req := &core.ChatRequest{
+		Model:     "glm-5.2",
+		MaxTokens: &maxTok,
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+		},
+	}
+
+	body, err := AnthropicCodec{}.RenderRequest(req)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(body, &out))
+
+	_, ok := out["thinking"]
+	require.False(t, ok, "thinking field must be omitted when not requested")
+}
+
+func TestAnthropic_RenderStreamChunkZeroStateStartsAtIndexZero(t *testing.T) {
+	state := &StreamState{Model: "claude-x"}
+	events, err := AnthropicCodec{}.RenderStreamChunk(core.StreamChunk{
+		Type:  core.ChunkText,
+		Delta: "hello",
+	}, state)
+	require.NoError(t, err)
+	require.Len(t, events, 3)
+	require.Contains(t, string(events[1]), `"index":0`)
+	require.Contains(t, string(events[2]), `"index":0`)
+}
+
+func TestAnthropic_RenderStreamChunkUsesDistinctContentIndices(t *testing.T) {
+	state := &StreamState{Model: "claude-x"}
+	codec := AnthropicCodec{}
+
+	thinking, err := codec.RenderStreamChunk(core.StreamChunk{Type: core.ChunkThinking, Delta: "reason"}, state)
+	require.NoError(t, err)
+	require.Contains(t, string(thinking[1]), `"index":0`)
+
+	text, err := codec.RenderStreamChunk(core.StreamChunk{Type: core.ChunkText, Delta: "answer"}, state)
+	require.NoError(t, err)
+	require.Contains(t, string(text[1]), `"index":1`)
+
+	tool, err := codec.RenderStreamChunk(core.StreamChunk{
+		Type: core.ChunkToolCall,
+		ToolCall: &core.ToolCall{
+			ID:   "toolu_1",
+			Name: "Read",
+		},
+	}, state)
+	require.NoError(t, err)
+	require.Contains(t, string(tool[len(tool)-1]), `"index":2`)
+}
+
+func TestAnthropic_RenderStreamChunkDuplicateFinishIsIdempotent(t *testing.T) {
+	state := &StreamState{Model: "claude-x"}
+	codec := AnthropicCodec{}
+	_, err := codec.RenderStreamChunk(core.StreamChunk{Type: core.ChunkText, Delta: "answer"}, state)
+	require.NoError(t, err)
+
+	first, err := codec.RenderStreamChunk(core.StreamChunk{Type: core.ChunkFinish, FinishReason: core.FinishStop}, state)
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	second, err := codec.RenderStreamChunk(core.StreamChunk{Type: core.ChunkFinish, FinishReason: core.FinishStop}, state)
+	require.NoError(t, err)
+	require.Empty(t, second)
 }

--- a/backend/internal/transform/gemini.go
+++ b/backend/internal/transform/gemini.go
@@ -44,11 +44,17 @@ type gemPart struct {
 	FunctionCall     *gemFunctionCall   `json:"functionCall,omitempty"`
 	FunctionResponse *gemFunctionResult `json:"functionResponse,omitempty"`
 	InlineData       *gemInlineData     `json:"inlineData,omitempty"`
+	FileData         *gemFileData       `json:"fileData,omitempty"`
 }
 
 type gemInlineData struct {
 	MIMEType string `json:"mimeType"`
 	Data     string `json:"data"`
+}
+
+type gemFileData struct {
+	MIMEType string `json:"mimeType,omitempty"`
+	FileURI  string `json:"fileUri"`
 }
 
 type gemFunctionCall struct {
@@ -127,6 +133,11 @@ func parseGemContent(c gemContent) core.Message {
 			msg.Content = append(msg.Content, core.ContentPart{
 				Type:  core.PartImage,
 				Media: &core.MediaPayload{MIMEType: p.InlineData.MIMEType, Data: p.InlineData.Data},
+			})
+		case p.FileData != nil:
+			msg.Content = append(msg.Content, core.ContentPart{
+				Type:  core.PartImage,
+				Media: &core.MediaPayload{MIMEType: p.FileData.MIMEType, URL: p.FileData.FileURI},
 			})
 		case p.Text != "":
 			msg.Content = append(msg.Content, core.ContentPart{Type: core.PartText, Text: p.Text})
@@ -240,7 +251,11 @@ func renderGemContent(m core.Message, callIDToName map[string]string) gemContent
 			}})
 		case core.PartImage:
 			if p.Media != nil {
-				c.Parts = append(c.Parts, gemPart{InlineData: &gemInlineData{MIMEType: p.Media.MIMEType, Data: p.Media.Data}})
+				if p.Media.Data != "" {
+					c.Parts = append(c.Parts, gemPart{InlineData: &gemInlineData{MIMEType: p.Media.MIMEType, Data: p.Media.Data}})
+				} else if p.Media.URL != "" {
+					c.Parts = append(c.Parts, gemPart{FileData: &gemFileData{MIMEType: p.Media.MIMEType, FileURI: p.Media.URL}})
+				}
 			}
 		}
 	}

--- a/backend/internal/transform/openai.go
+++ b/backend/internal/transform/openai.go
@@ -354,7 +354,9 @@ const (
 // injection scope. DeepSeek's thinking-capable models (including those served
 // via OpenAI-compatible aggregators like OpenRouter, SiliconFlow, Fireworks)
 // require it on every assistant turn. Kimi models require it only on turns
-// that carry tool_calls. Other providers don't need it at all.
+// that carry tool_calls. GLM/Zhipu and MiniMax models also emit structured
+// reasoning_content and need it echoed back to maintain thinking context.
+// Other providers don't need it at all.
 func reasoningEchoScope(providerID, model string) reasoningScope {
 	m := strings.ToLower(model)
 	if providerID == "deepseek" || strings.Contains(m, "deepseek") {
@@ -364,6 +366,18 @@ func reasoningEchoScope(providerID, model string) reasoningScope {
 	// on assistant turns with tool_calls.
 	if strings.HasPrefix(m, "kimi-") || strings.HasPrefix(m, "moonshot/kimi-") {
 		return reasoningToolCalls
+	}
+	// GLM/Zhipu models (glm-5.2, glm-4.7, zai-org/glm-*, etc.) emit structured
+	// reasoning_content and expect it echoed back on follow-up turns, similar
+	// to DeepSeek. Without this, the model may skip reasoning or reject the
+	// request, causing clients to retry and potentially duplicate responses.
+	if providerID == "glm" || providerID == "glm-cn" || providerID == "zai" ||
+		strings.Contains(m, "glm-") || strings.Contains(m, "zai-org/glm") {
+		return reasoningAll
+	}
+	// MiniMax models (minimax-m1, abab6.5-chat, etc.) also use reasoning_content.
+	if strings.Contains(m, "minimax") || strings.Contains(m, "abab") {
+		return reasoningAll
 	}
 	return reasoningNone
 }
@@ -430,6 +444,12 @@ func renderOAIRequestForProvider(req *core.ChatRequest, providerID string, scope
 	}
 	if isDeepSeekTarget(providerID, req.Model) {
 		applyDeepSeekRequestFixes(out, req, providerID)
+	} else if scope != reasoningNone {
+		// Non-DeepSeek reasoning providers (GLM, Kimi, MiniMax, etc.) still
+		// need thinking type + reasoning_effort forwarded. DeepSeek has its
+		// own fixes above; this path handles the rest without duplicating
+		// provider-specific hacks.
+		applyGenericReasoningConfig(out, req)
 	}
 	if providerID == "codebuddy" {
 		applyCodebuddyRequestFixes(out, req)
@@ -525,19 +545,41 @@ func applyCodebuddyRequestFixes(out *oaiRequest, req *core.ChatRequest) {
 	}
 }
 
+// applyGenericReasoningConfig forwards reasoning_effort and thinking type to
+// any provider that supports reasoning-mode requests. This was previously
+// DeepSeek-only, but GLM, Kimi, MiniMax, and other reasoning providers also
+// need these fields to emit structured reasoning_content.
+func applyGenericReasoningConfig(out *oaiRequest, req *core.ChatRequest) {
+	if req.Reasoning == nil {
+		return
+	}
+	effort := strings.ToLower(req.Reasoning.Effort)
+	switch effort {
+	case "none", "off", "disabled":
+		out.Thinking = &oaiThinking{Type: "disabled"}
+		out.ReasoningEffort = ""
+	case "", "auto", "adaptive":
+		out.Thinking = &oaiThinking{Type: "enabled"}
+		out.ReasoningEffort = ""
+	case "xhigh":
+		out.Thinking = &oaiThinking{Type: "enabled"}
+		out.ReasoningEffort = "max"
+	default:
+		out.Thinking = &oaiThinking{Type: "enabled"}
+		out.ReasoningEffort = effort
+	}
+}
+
 func applyDeepSeekThinking(out *oaiRequest, req *core.ChatRequest, providerID string) {
+	applyGenericReasoningConfig(out, req)
 	if req.Reasoning != nil {
-		effort := strings.ToLower(req.Reasoning.Effort)
-		if effort == "none" || effort == "off" {
-			out.Thinking = &oaiThinking{Type: "disabled"}
+		switch strings.ToLower(req.Reasoning.Effort) {
+		case "none", "off", "disabled":
 			out.ReasoningEffort = ""
-		} else {
-			out.Thinking = &oaiThinking{Type: "enabled"}
-			if effort == "max" || effort == "xhigh" {
-				out.ReasoningEffort = "max"
-			} else {
-				out.ReasoningEffort = "high"
-			}
+		case "max", "xhigh":
+			out.ReasoningEffort = "max"
+		default:
+			out.ReasoningEffort = "high"
 		}
 	}
 

--- a/backend/internal/transform/openai_reasoning_test.go
+++ b/backend/internal/transform/openai_reasoning_test.go
@@ -660,3 +660,125 @@ func TestOpenAI_RenderRequest_StreamRawPathReasoning(t *testing.T) {
 		}
 	}
 }
+
+// ---- GLM/Zhipu scope tests ----
+
+// TestReasoningEchoScope_GLM verifies GLM/Zhipu models are detected (all scope).
+func TestReasoningEchoScope_GLM(t *testing.T) {
+	require.Equal(t, reasoningAll, reasoningEchoScope("glm", "glm-5.2"))
+	require.Equal(t, reasoningAll, reasoningEchoScope("glm-cn", "glm-4.7"))
+	require.Equal(t, reasoningAll, reasoningEchoScope("zai", "zai-org/glm-5.2"))
+	require.Equal(t, reasoningAll, reasoningEchoScope("cloudflare-ai", "@cf/zai-org/glm-5.2"))
+	require.Equal(t, reasoningNone, reasoningEchoScope("openai", "gpt-4o"))
+}
+
+// TestReasoningEchoScope_MiniMax verifies MiniMax models are detected (all scope).
+func TestReasoningEchoScope_MiniMax(t *testing.T) {
+	require.Equal(t, reasoningAll, reasoningEchoScope("minimax", "minimax-m1"))
+	require.Equal(t, reasoningAll, reasoningEchoScope("custom", "abab6.5-chat"))
+	require.Equal(t, reasoningNone, reasoningEchoScope("openai", "gpt-4o"))
+}
+
+// TestOpenAI_RenderRequest_GLMThinkingConfig verifies GLM targets get
+// thinking type + reasoning_effort forwarded (not just DeepSeek).
+func TestOpenAI_RenderRequest_GLMThinkingConfig(t *testing.T) {
+	maxTok := 4096
+	req := &core.ChatRequest{
+		Model:     "glm-5.2",
+		MaxTokens: &maxTok,
+		Reasoning: &core.ReasoningConfig{Effort: "high"},
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+		},
+	}
+	body, err := OpenAICodec{}.RenderRequestForProvider(req, "glm")
+	require.NoError(t, err)
+
+	var got oaiRequest
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.NotNil(t, got.Thinking, "GLM should get thinking config")
+	require.Equal(t, "enabled", got.Thinking.Type)
+	require.Equal(t, "high", got.ReasoningEffort)
+}
+
+// TestOpenAI_RenderRequest_GLMThinkingConfig_MaxEffort verifies max effort
+// maps to reasoning_effort "max" for GLM.
+func TestOpenAI_RenderRequest_GLMThinkingConfig_MaxEffort(t *testing.T) {
+	req := &core.ChatRequest{
+		Model:     "glm-5.2",
+		Reasoning: &core.ReasoningConfig{Effort: "max"},
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+		},
+	}
+	body, err := OpenAICodec{}.RenderRequestForProvider(req, "glm")
+	require.NoError(t, err)
+
+	var got oaiRequest
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Equal(t, "max", got.ReasoningEffort)
+}
+
+// TestOpenAI_RenderRequest_GLMThinkingDisabled verifies "none" effort maps
+// to thinking disabled for GLM.
+func TestOpenAI_RenderRequest_GLMThinkingDisabled(t *testing.T) {
+	req := &core.ChatRequest{
+		Model:     "glm-5.2",
+		Reasoning: &core.ReasoningConfig{Effort: "none"},
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+		},
+	}
+	body, err := OpenAICodec{}.RenderRequestForProvider(req, "glm")
+	require.NoError(t, err)
+
+	var got oaiRequest
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.NotNil(t, got.Thinking)
+	require.Equal(t, "disabled", got.Thinking.Type)
+	require.Empty(t, got.ReasoningEffort)
+}
+
+// TestOpenAI_RenderRequest_GLMReasoningInjection verifies GLM targets get
+// reasoning_content injected on assistant turns (like DeepSeek).
+func TestOpenAI_RenderRequest_GLMReasoningInjection(t *testing.T) {
+	req := &core.ChatRequest{
+		Model: "glm-5.2",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+			{Role: core.RoleAssistant, Content: []core.ContentPart{{Type: core.PartText, Text: "hello"}}},
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "continue"}}},
+		},
+	}
+	body, err := OpenAICodec{}.RenderRequestForProvider(req, "glm")
+	require.NoError(t, err)
+
+	var got oaiRequest
+	require.NoError(t, json.Unmarshal(body, &got))
+
+	for _, m := range got.Messages {
+		if m.Role == "assistant" {
+			require.Equal(t, reasoningPlaceholder, m.ReasoningContent,
+				"GLM must inject reasoning_content on assistant turns")
+		}
+	}
+}
+
+// TestOpenAI_RenderRequest_NonReasoningProviderNoThinking verifies providers
+// without reasoning scope (OpenAI, Groq, etc.) do NOT get thinking config.
+func TestOpenAI_RenderRequest_NonReasoningProviderNoThinking(t *testing.T) {
+	req := &core.ChatRequest{
+		Model:     "gpt-4o",
+		Reasoning: &core.ReasoningConfig{Effort: "high"},
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+		},
+	}
+	body, err := OpenAICodec{}.RenderRequestForProvider(req, "openai")
+	require.NoError(t, err)
+
+	var got oaiRequest
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Nil(t, got.Thinking, "OpenAI should not get thinking config")
+	require.Empty(t, got.ReasoningEffort)
+}

--- a/backend/internal/transform/thinking.go
+++ b/backend/internal/transform/thinking.go
@@ -71,10 +71,12 @@ func StripThinkTags(content string) (thinkingChunks []core.StreamChunk, cleanCon
 // multiple SSE events, the parser buffers potential tag prefixes/suffixes.
 //
 // Flush() must be called when the stream ends to emit any remaining buffered
-// content.
+// content. Flush is idempotent — calling it multiple times is safe and will
+// not re-emit already-flushed content.
 type ThinkTagState struct {
 	thinkingMode bool
 	buf          string // buffered text that might be part of a tag
+	flushed      bool   // prevents double-emission on duplicate Flush calls
 }
 
 // ProcessFeed ingests one streaming content delta and returns thinking and/or
@@ -167,7 +169,12 @@ func (ts *ThinkTagState) ProcessFeed(delta string) []core.StreamChunk {
 }
 
 // Flush emits any remaining buffered content. Must be called at stream end.
+// Safe to call multiple times; subsequent calls return nil.
 func (ts *ThinkTagState) Flush() []core.StreamChunk {
+	if ts.flushed {
+		return nil
+	}
+	ts.flushed = true
 	if len(ts.buf) == 0 {
 		return nil
 	}

--- a/backend/internal/transform/thinking_test.go
+++ b/backend/internal/transform/thinking_test.go
@@ -233,3 +233,55 @@ func assertNoChunks(t *testing.T, chunks []core.StreamChunk, context string) {
 		t.Errorf("%s: unexpected chunk type=%q delta=%q", context, ch.Type, ch.Delta)
 	}
 }
+
+// TestThinkTagState_DoubleFlushIsIdempotent verifies that calling Flush
+// multiple times does not re-emit already-flushed buffered content. This
+// prevents duplicate text when stream cleanup logic calls Flush twice.
+func TestThinkTagState_DoubleFlushIsIdempotent(t *testing.T) {
+	ts := &ThinkTagState{}
+
+	// Feed content that gets buffered (a '<' that might start a tag).
+	// The '<' is held as potential partial tag, so "hello " is emitted
+	// immediately and "<" stays in the buffer.
+	chunks := ts.ProcessFeed("hello <")
+	if len(chunks) != 1 || chunks[0].Delta != "hello " {
+		t.Fatalf("expected 'hello ' emitted immediately, got %+v", chunks)
+	}
+
+	// First flush — emits the buffered "<".
+	flush1 := ts.Flush()
+	if len(flush1) != 1 {
+		t.Fatalf("first flush: expected 1 chunk, got %d", len(flush1))
+	}
+	if flush1[0].Delta != "<" {
+		t.Errorf("first flush delta = %q, want %q", flush1[0].Delta, "<")
+	}
+
+	// Second flush — must return nil.
+	flush2 := ts.Flush()
+	if len(flush2) != 0 {
+		t.Fatalf("second flush: expected 0 chunks (idempotent), got %d", len(flush2))
+	}
+
+	// Third flush — still nil.
+	flush3 := ts.Flush()
+	if len(flush3) != 0 {
+		t.Fatalf("third flush: expected 0 chunks (idempotent), got %d", len(flush3))
+	}
+}
+
+// TestThinkTagState_DoubleFlushEmptyBuffer verifies that double Flush on an
+// empty buffer is also safe (returns nil both times).
+func TestThinkTagState_DoubleFlushEmptyBuffer(t *testing.T) {
+	ts := &ThinkTagState{}
+
+	flush1 := ts.Flush()
+	if len(flush1) != 0 {
+		t.Fatalf("first flush on empty: expected 0 chunks, got %d", len(flush1))
+	}
+
+	flush2 := ts.Flush()
+	if len(flush2) != 0 {
+		t.Fatalf("second flush on empty: expected 0 chunks, got %d", len(flush2))
+	}
+}

--- a/backend/internal/transform/toolsanitize.go
+++ b/backend/internal/transform/toolsanitize.go
@@ -15,15 +15,24 @@ import (
 // int, clamping values).
 //
 // Usage: call Process() for each chunk. Call Flush() when the stream ends.
+// Flush is idempotent — calling it multiple times is safe and will not
+// re-emit already-flushed tool calls.
 type ToolArgSanitizer struct {
 	// buffers tracks in-flight tool calls by their stream index.
 	buffers map[int]*toolBuffer
+	// flushed prevents double-emission when Flush is called multiple times
+	// (e.g. on duplicate ChunkFinish from upstream providers).
+	flushed bool
 }
 
 type toolBuffer struct {
 	id   string
 	name string
 	args strings.Builder
+	// argsLen tracks the length of args accumulated so far, used to detect
+	// snapshot-style argument retransmissions (some providers re-send the full
+	// accumulated arguments on every chunk instead of just the new delta).
+	argsLen int
 }
 
 // NewToolArgSanitizer creates a new sanitizer.
@@ -77,14 +86,67 @@ func (s *ToolArgSanitizer) Process(chunk core.StreamChunk, emit func(core.Stream
 
 	args := string(chunk.ToolCall.Arguments)
 	if args != "" && args != "{}" {
-		buf.args.WriteString(args)
+		appendToolArgs(buf, args)
 	}
 
 }
 
+// appendToolArgs accumulates tool-call argument fragments into the buffer.
+// Providers send arguments in two shapes:
+//
+//  1. Incremental deltas — each chunk carries only the NEW fragment. Concatenate
+//     verbatim, even when a fragment's leading bytes repeat the tail (e.g. "l" + "l").
+//  2. Full snapshots — each chunk re-sends the ENTIRE accumulated arguments.
+//     Concatenating would duplicate (e.g. `{"a":1}{"a":1}` → invalid JSON).
+//
+// Detection strategy: replace when a fragment extends the existing prefix, or
+// when both the existing value and fragment are complete objects. A complete
+// object can also be a legitimate nested delta, so it is not sufficient on its
+// own to classify a fragment as a snapshot.
+func appendToolArgs(buf *toolBuffer, fragment string) {
+	if fragment == "" {
+		return
+	}
+	existing := buf.args.String()
+	if existing == "" {
+		buf.args.WriteString(fragment)
+		buf.argsLen = len(fragment)
+		return
+	}
+	if strings.HasPrefix(fragment, existing) ||
+		(isCompleteJSONObject(existing) && isCompleteJSONObject(fragment)) {
+		buf.args.Reset()
+		buf.args.WriteString(fragment)
+		buf.argsLen = len(fragment)
+		return
+	}
+	// True incremental delta: append verbatim.
+	buf.args.WriteString(fragment)
+	buf.argsLen += len(fragment)
+}
+
+// isCompleteJSONObject reports whether the fragment is a standalone, complete
+// JSON object (starts with '{', ends with '}', and parses as valid JSON).
+// This is used to distinguish snapshot-style argument retransmissions from
+// true incremental deltas.
+func isCompleteJSONObject(fragment string) bool {
+	trimmed := strings.TrimSpace(fragment)
+	if len(trimmed) < 2 || trimmed[0] != '{' || trimmed[len(trimmed)-1] != '}' {
+		return false
+	}
+	// Parse it to confirm it's valid JSON (not just braces around garbage).
+	var v map[string]any
+	return json.Unmarshal([]byte(trimmed), &v) == nil
+}
+
 // Flush emits all remaining buffered tool calls. Call this when the stream ends
-// (before ChunkFinish or after the channel closes).
+// (before ChunkFinish or after the channel closes). Safe to call multiple times;
+// subsequent calls are no-ops.
 func (s *ToolArgSanitizer) Flush(emit func(core.StreamChunk)) {
+	if s.flushed {
+		return
+	}
+	s.flushed = true
 	for idx := range s.buffers {
 		s.flushIndex(idx, emit)
 	}

--- a/backend/internal/transform/toolsanitize_test.go
+++ b/backend/internal/transform/toolsanitize_test.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
@@ -280,5 +281,156 @@ func TestSanitizeToolArgs_PassthroughValidArgs(t *testing.T) {
 
 	if args["limit"] != float64(50) {
 		t.Errorf("valid limit should pass through, got %v", args["limit"])
+	}
+}
+
+// TestToolArgSanitizer_SnapshotVsDelta verifies that full-snapshot argument
+// retransmissions (where each chunk re-sends the ENTIRE accumulated arguments)
+// are replaced rather than concatenated, while true incremental deltas are
+// appended verbatim. Some providers (GLM, certain OpenAI-compatible gateways)
+// send snapshots; others (Kiro, Cursor) send true deltas.
+func TestToolArgSanitizer_SnapshotVsDelta(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing string
+		fragment string
+		want     string
+	}{
+		{"empty buffer, first fragment", "", `{"file_path":"/a"}`, `{"file_path":"/a"}`},
+		{"delta append", `{"file_path":`, `"/a"}`, `{"file_path":"/a"}`},
+		{"snapshot repeat", `{"file_path":"/a"}`, `{"file_path":"/a"}`, `{"file_path":"/a"}`},
+		{"snapshot growth", `{"file_path":"/a"`, `{"file_path":"/a"}`, `{"file_path":"/a"}`},
+		{"snapshot longer", `{"file_path":"/a","limit":1`, `{"file_path":"/a","limit":100}`, `{"file_path":"/a","limit":100}`},
+		{"nested object delta", `{"config":`, `{"enabled":true}`, `{"config":{"enabled":true}`},
+		{"delta with repeated chars", `{"command":"ls -l`, `l"}`, `{"command":"ls -ll"}`},
+		{"delta with repeated prefix", `{"path":"/home/user`, `/home/user2"}`, `{"path":"/home/user/home/user2"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &toolBuffer{}
+			buf.args.WriteString(tt.existing)
+			buf.argsLen = len(tt.existing)
+			appendToolArgs(buf, tt.fragment)
+			if got := buf.args.String(); got != tt.want {
+				t.Errorf("appendToolArgs(%q, %q) = %q, want %q", tt.existing, tt.fragment, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestToolArgSanitizer_SnapshotStream simulates a provider that sends full
+// argument snapshots on every chunk (GLM-style). The sanitizer must replace
+// the buffer each time, not concatenate.
+func TestToolArgSanitizer_SnapshotStream(t *testing.T) {
+	s := NewToolArgSanitizer()
+	var emitted []core.StreamChunk
+	emit := func(c core.StreamChunk) { emitted = append(emitted, c) }
+
+	// Provider sends snapshot growth: each chunk re-sends the full args.
+	s.Process(core.StreamChunk{
+		Type: core.ChunkToolCall, Index: 0,
+		ToolCall: &core.ToolCall{ID: "tc1", Name: "Read", Arguments: json.RawMessage(`{"file_path":"/a"}`)},
+	}, emit)
+	s.Process(core.StreamChunk{
+		Type: core.ChunkToolCall, Index: 0,
+		ToolCall: &core.ToolCall{ID: "tc1", Arguments: json.RawMessage(`{"file_path":"/a","limit":100}`)},
+	}, emit)
+	s.Process(core.StreamChunk{
+		Type: core.ChunkToolCall, Index: 0,
+		ToolCall: &core.ToolCall{ID: "tc1", Arguments: json.RawMessage(`{"file_path":"/a","limit":100,"offset":0}`)},
+	}, emit)
+
+	s.Flush(emit)
+
+	if len(emitted) != 1 {
+		t.Fatalf("expected 1 emitted tool call, got %d", len(emitted))
+	}
+	args := string(emitted[0].ToolCall.Arguments)
+	// Must NOT contain concatenated snapshots.
+	if strings.Count(args, "file_path") != 1 {
+		t.Errorf("snapshot duplication detected: %s", args)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(args), &parsed); err != nil {
+		t.Fatalf("args not valid JSON: %v (%s)", err, args)
+	}
+	if parsed["limit"] != float64(100) {
+		t.Errorf("expected limit 100, got %v", parsed["limit"])
+	}
+}
+
+// multiple times does not re-emit already-flushed tool calls. This prevents
+// duplicate tool calls when upstream providers send duplicate ChunkFinish
+// events (e.g. some OpenAI-compatible gateways).
+func TestToolArgSanitizer_DoubleFlushIsIdempotent(t *testing.T) {
+	s := NewToolArgSanitizer()
+	var emitted []core.StreamChunk
+	emit := func(c core.StreamChunk) { emitted = append(emitted, c) }
+
+	// Buffer a tool call.
+	s.Process(core.StreamChunk{
+		Type:  core.ChunkToolCall,
+		Index: 0,
+		ToolCall: &core.ToolCall{
+			ID: "tc1", Name: "Read",
+			Arguments: json.RawMessage(`{"file_path":"/a"}`),
+		},
+	}, emit)
+
+	// First flush — emits the tool call.
+	s.Flush(emit)
+	if len(emitted) != 1 {
+		t.Fatalf("first flush: expected 1 emitted, got %d", len(emitted))
+	}
+
+	// Second flush — must be a no-op.
+	s.Flush(emit)
+	if len(emitted) != 1 {
+		t.Fatalf("second flush: expected still 1 emitted (idempotent), got %d", len(emitted))
+	}
+
+	// Third flush — still a no-op.
+	s.Flush(emit)
+	if len(emitted) != 1 {
+		t.Fatalf("third flush: expected still 1 emitted (idempotent), got %d", len(emitted))
+	}
+}
+
+// TestToolArgSanitizer_DuplicateChunkFinishDoesNotDoubleEmit verifies that
+// a duplicate ChunkFinish from upstream does not cause double-emission of
+// buffered tool calls.
+func TestToolArgSanitizer_DuplicateChunkFinishDoesNotDoubleEmit(t *testing.T) {
+	s := NewToolArgSanitizer()
+	var emitted []core.StreamChunk
+	emit := func(c core.StreamChunk) { emitted = append(emitted, c) }
+
+	// Buffer a tool call.
+	s.Process(core.StreamChunk{
+		Type:  core.ChunkToolCall,
+		Index: 0,
+		ToolCall: &core.ToolCall{
+			ID: "tc1", Name: "Read",
+			Arguments: json.RawMessage(`{"file_path":"/a"}`),
+		},
+	}, emit)
+
+	// First ChunkFinish — flushes and emits.
+	s.Process(core.StreamChunk{Type: core.ChunkFinish, FinishReason: core.FinishToolCalls}, emit)
+	if len(emitted) != 2 { // tool call + finish
+		t.Fatalf("after first finish: expected 2 emitted (tool+finish), got %d", len(emitted))
+	}
+
+	// Duplicate ChunkFinish — must NOT re-emit the tool call.
+	s.Process(core.StreamChunk{Type: core.ChunkFinish, FinishReason: core.FinishToolCalls}, emit)
+
+	var toolCalls int
+	for _, c := range emitted {
+		if c.Type == core.ChunkToolCall {
+			toolCalls++
+		}
+	}
+	if toolCalls != 1 {
+		t.Fatalf("duplicate finish caused double-emission: expected 1 tool call, got %d", toolCalls)
 	}
 }

--- a/backend/internal/transform/transform.go
+++ b/backend/internal/transform/transform.go
@@ -78,6 +78,17 @@ type StreamState struct {
 	Custom map[string]any
 }
 
+// ResetStreamState resets a StreamState to its initial zero values.
+// Called when a stream is being restarted or retried to prevent state
+// corruption from a previous partial stream.
+func ResetStreamState(state *StreamState) {
+	state.MessageID = ""
+	state.OpenedBlock = false
+	state.SentRole = false
+	state.ToolIndex = 0
+	state.Custom = make(map[string]any)
+}
+
 // Registry resolves codecs by dialect.
 type Registry struct {
 	codecs map[core.Dialect]Codec

--- a/backend/internal/transform/transform_test.go
+++ b/backend/internal/transform/transform_test.go
@@ -635,6 +635,31 @@ func TestCrossDialect_AnthropicImageToGemini(t *testing.T) {
 	require.Equal(t, "abc123", inlineData["data"])
 }
 
+func TestCrossDialect_AnthropicImageURLToGemini(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-sonnet-4.5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "describe"},
+				{"type": "image", "source": {"type": "url", "url": "https://example.com/photo.jpg"}}
+			]}
+		]
+	}`)
+
+	canonical, err := AnthropicCodec{}.ParseRequest(body)
+	require.NoError(t, err)
+
+	gemBody, err := GeminiCodec{}.RenderRequest(canonical)
+	require.NoError(t, err)
+	var gemReq map[string]any
+	require.NoError(t, json.Unmarshal(gemBody, &gemReq))
+	contents := gemReq["contents"].([]any)
+	parts := contents[0].(map[string]any)["parts"].([]any)
+	fileData := parts[1].(map[string]any)["fileData"].(map[string]any)
+	require.Equal(t, "https://example.com/photo.jpg", fileData["fileUri"])
+}
+
 // Anthropic URL image → parse → render to OpenAI → image_url with URL.
 func TestCrossDialect_AnthropicImageURLToOpenAI(t *testing.T) {
 	body := []byte(`{

--- a/go.work.sum
+++ b/go.work.sum
@@ -30,11 +30,13 @@ golang.org/x/exp v0.0.0-20231108232855-2478ac86f678/go.mod h1:zk2irFbV9DP96SEBUU
 golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
 golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
+golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
 golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
 golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
## Summary

- add structured failure scopes and dynamic attempt replanning so retries can switch accounts, models, or providers without repeating failed candidates
- add precise rate-limit cooldown handling, account/model health tracking, smart-affinity eviction, and an in-memory provider circuit breaker
- harden streaming and connection handling, including stale pooled-connection recovery, client-disconnect detection, and terminal stream accounting
- expand media routing for image understanding and video generation with account-pinned polling
- improve Anthropic, OpenAI, and Gemini reasoning transforms, tool-call sanitization, and stream state handling
- expand provider catalogs and OAuth metadata with regression coverage

## Behavior

- account-scoped authentication, quota, and rate-limit failures move subsequent attempts away from the affected credential
- model-scoped failures can retry another model without unnecessarily cooling the whole account
- transient provider and network failures contribute to circuit state, while client cancellations do not penalize upstream health
- stream attempts are only marked successful after clean terminal completion
- stateful media operations stay pinned to the account that created the upstream job

## Validation

- `go test -p 1 ./...`
- `go test -race -p 1 ./internal/dispatch`
- `go test -race -p 1 ./internal/pipeline`
- `go test -race -p 1 ./internal/transform`
- `git diff --check`
