### PR TITLE
fix(qoder): preserve tool history integrity

### DIFF
--- a/backend/internal/connectors/qoder.go
+++ b/backend/internal/connectors/qoder.go
@@ -113,8 +113,22 @@ type qoderPayload struct {
 }
 
 type qoderMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role       string          `json:"role"`
+	Content    string          `json:"content"`
+	Name       string          `json:"name,omitempty"`
+	ToolCalls  []qoderToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+}
+
+type qoderToolCall struct {
+	ID       string            `json:"id"`
+	Type     string            `json:"type"`
+	Function qoderToolFunction `json:"function"`
+}
+
+type qoderToolFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
 }
 
 type qoderParams struct {
@@ -150,24 +164,132 @@ type qoderBusiness struct {
 	BeginAt int64  `json:"begin_at"`
 }
 
-// normalizeMessages hoists system messages out and flattens content to plain
-// text.
+// normalizeQoderMessages hoists system instructions and renders canonical tool
+// calls/results into the OpenAI-compatible message shape accepted by Qoder.
 func normalizeQoderMessages(msgs []core.Message) (out []qoderMessage, systemText string) {
 	var sysParts []string
 	for _, m := range msgs {
 		text := m.TextContent()
-		if m.Role == core.RoleSystem {
+		if m.Role == core.RoleSystem || m.Role == core.RoleDeveloper {
 			if text != "" {
 				sysParts = append(sysParts, text)
 			}
 			continue
 		}
-		out = append(out, qoderMessage{
-			Role:    string(m.Role),
-			Content: text,
+
+		var calls []qoderToolCall
+		var results []qoderMessage
+		for _, part := range m.Content {
+			switch part.Type {
+			case core.PartToolCall:
+				if m.Role != core.RoleAssistant || part.ToolCall == nil || part.ToolCall.ID == "" {
+					continue
+				}
+				args := string(part.ToolCall.Arguments)
+				if args == "" {
+					args = "{}"
+				}
+				calls = append(calls, qoderToolCall{
+					ID:   part.ToolCall.ID,
+					Type: "function",
+					Function: qoderToolFunction{
+						Name:      part.ToolCall.Name,
+						Arguments: args,
+					},
+				})
+			case core.PartToolResult:
+				if part.ToolResult == nil || part.ToolResult.CallID == "" {
+					continue
+				}
+				results = append(results, qoderMessage{
+					Role:       string(core.RoleTool),
+					Content:    part.ToolResult.Content,
+					ToolCallID: part.ToolResult.CallID,
+				})
+			}
+		}
+
+		// Anthropic clients carry tool results and user text in one message.
+		// Qoder expects the OpenAI layout: tool messages first, then user text.
+		out = append(out, results...)
+
+		switch m.Role {
+		case core.RoleTool:
+			// Tool content was emitted above with its matching tool_call_id.
+			continue
+		case core.RoleAssistant:
+			out = append(out, qoderMessage{
+				Role:      string(m.Role),
+				Content:   text,
+				Name:      m.Name,
+				ToolCalls: calls,
+			})
+		default:
+			if text != "" || len(results) == 0 {
+				out = append(out, qoderMessage{
+					Role:    string(m.Role),
+					Content: text,
+					Name:    m.Name,
+				})
+			}
+		}
+	}
+	return repairQoderToolHistory(out), strings.Join(sysParts, "\n\n")
+}
+
+// repairQoderToolHistory moves matching tool results directly after the
+// assistant call that created them, synthesizes an empty result when missing,
+// and drops results that do not belong to an earlier call.
+func repairQoderToolHistory(msgs []qoderMessage) []qoderMessage {
+	type indexedResult struct {
+		index int
+		msg   qoderMessage
+		used  bool
+	}
+
+	results := make(map[string][]*indexedResult)
+	for i, msg := range msgs {
+		if msg.Role != string(core.RoleTool) || msg.ToolCallID == "" {
+			continue
+		}
+		results[msg.ToolCallID] = append(results[msg.ToolCallID], &indexedResult{
+			index: i,
+			msg:   msg,
 		})
 	}
-	return out, strings.Join(sysParts, "\n\n")
+
+	out := make([]qoderMessage, 0, len(msgs))
+	for i, msg := range msgs {
+		if msg.Role == string(core.RoleTool) {
+			continue
+		}
+		out = append(out, msg)
+		if msg.Role != string(core.RoleAssistant) {
+			continue
+		}
+
+		for _, call := range msg.ToolCalls {
+			var matched *indexedResult
+			for _, candidate := range results[call.ID] {
+				if !candidate.used && candidate.index > i {
+					matched = candidate
+					break
+				}
+			}
+			if matched != nil {
+				matched.used = true
+				out = append(out, matched.msg)
+				continue
+			}
+			out = append(out, qoderMessage{
+				Role:       string(core.RoleTool),
+				Content:    "",
+				ToolCallID: call.ID,
+			})
+		}
+	}
+
+	return out
 }
 
 // lastUserText returns the text of the last user message (for chat_context).
@@ -199,10 +321,8 @@ func stableChatRecordID(model string, msgs []qoderMessage, tools []json.RawMessa
 	h.Write([]byte(model))
 	for _, m := range msgs {
 		h.Write([]byte{0})
-		h.Write([]byte(m.Role))
-		if m.Content != "" {
-			h.Write([]byte{0})
-			h.Write([]byte(m.Content))
+		if encoded, err := json.Marshal(m); err == nil {
+			h.Write(encoded)
 		}
 	}
 	if len(tools) > 0 {
@@ -295,18 +415,28 @@ func normalizeQoderToolSchema(raw json.RawMessage) json.RawMessage {
 
 // buildPayload constructs the Qoder chat request payload from a canonical
 // ChatRequest and the cached model config.
-func (c *Qoder) buildPayload(req *core.ChatRequest, modelKey string, modelConfig json.RawMessage) qoderPayload {
+func (c *Qoder) buildPayload(req *core.ChatRequest, modelKey string, modelConfig json.RawMessage, accountScope string) qoderPayload {
 	msgs, systemText := normalizeQoderMessages(req.Messages)
 	tools := serializeTools(req.Tools)
 	maxTokens := resolveMaxTokens(req, modelConfig)
 	lastUser := lastUserText(msgs)
+	if req.System != "" {
+		if systemText == "" {
+			systemText = req.System
+		} else {
+			systemText = req.System + "\n\n" + systemText
+		}
+	}
 
+	recordID := stableChatRecordID(modelKey, msgs, tools, maxTokens)
 	sessionKey := req.Metadata.ContextAffinityKey
 	if sessionKey == "" {
-		sessionKey = modelKey
+		sessionKey = req.Metadata.RequestID
 	}
-	sessionID := stableHash("qoder-session", sessionKey, modelKey)
-	recordID := stableChatRecordID(modelKey, msgs, tools, maxTokens)
+	if sessionKey == "" {
+		sessionKey = recordID
+	}
+	sessionID := stableHash("qoder-session", accountScope, sessionKey, modelKey)
 
 	// Determine is_reasoning from model_config.
 	var isReasoning bool
@@ -509,7 +639,7 @@ func (c *Qoder) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cr
 		modelConfig = nil
 	}
 
-	payload := c.buildPayload(req, modelKey, modelConfig)
+	payload := c.buildPayload(req, modelKey, modelConfig, c.cosyCreds(creds).UserID)
 	payload.Stream = true
 
 	url, headers, body, err := c.signedRequest(payload, creds)
@@ -580,23 +710,39 @@ func (c *Qoder) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cr
 // Chat performs a non-streaming completion by collecting the streaming
 // response. Qoder's chat endpoint is SSE-only.
 func (c *Qoder) Chat(ctx context.Context, req *core.ChatRequest, creds core.Credentials) (*core.ChatResponse, error) {
-	req.Stream = true // Qoder is SSE-only
+	streamReq := *req
+	streamReq.Stream = true // Qoder is SSE-only
 
-	chunks, err := c.Stream(ctx, req, creds, core.StreamConfig{})
+	chunks, err := c.Stream(ctx, &streamReq, creds, core.StreamConfig{})
 	if err != nil {
 		return nil, err
 	}
 
-	// Collect all chunks into a complete response.
+	msg, finishReason, usage, err := collectQoderChunks(chunks)
+	if err != nil {
+		return nil, err
+	}
+
+	return &core.ChatResponse{
+		ID:           uuid.NewString(),
+		Model:        req.Model,
+		Message:      msg,
+		FinishReason: finishReason,
+		Usage:        usage,
+	}, nil
+}
+
+func collectQoderChunks(chunks <-chan core.StreamChunk) (core.Message, core.FinishReason, core.Usage, error) {
 	var (
 		textBuf      strings.Builder
 		thinkingBuf  strings.Builder
 		toolCalls    []*core.ToolCall
 		finishReason core.FinishReason
 		usage        core.Usage
+		streamErr    error
 	)
 
-	for ch := range chunks {
+	collect := func(ch core.StreamChunk) {
 		switch ch.Type {
 		case core.ChunkText:
 			textBuf.WriteString(ch.Delta)
@@ -614,9 +760,21 @@ func (c *Qoder) Chat(ctx context.Context, req *core.ChatRequest, creds core.Cred
 			}
 		case core.ChunkError:
 			if ch.Err != nil {
-				return nil, ch.Err
+				streamErr = ch.Err
 			}
 		}
+	}
+
+	sanitizer := transform.NewToolArgSanitizer()
+	for ch := range chunks {
+		sanitizer.Process(ch, collect)
+		if streamErr != nil {
+			return core.Message{}, "", core.Usage{}, streamErr
+		}
+	}
+	sanitizer.Flush(collect)
+	if streamErr != nil {
+		return core.Message{}, "", core.Usage{}, streamErr
 	}
 
 	msg := core.Message{
@@ -632,13 +790,7 @@ func (c *Qoder) Chat(ctx context.Context, req *core.ChatRequest, creds core.Cred
 		msg.Content = append(msg.Content, core.ContentPart{Type: core.PartToolCall, ToolCall: tc})
 	}
 
-	return &core.ChatResponse{
-		ID:           uuid.NewString(),
-		Model:        req.Model,
-		Message:      msg,
-		FinishReason: finishReason,
-		Usage:        usage,
-	}, nil
+	return msg, finishReason, usage, nil
 }
 
 // Validate probes the Qoder model list endpoint to confirm the COSY signing

--- a/backend/internal/connectors/qoder_test.go
+++ b/backend/internal/connectors/qoder_test.go
@@ -13,7 +13,7 @@ func TestQoderSerializeTools_UsesOpenAIFunctionWrapper(t *testing.T) {
 		{
 			Name:        "read_file",
 			Description: "Read a file",
-			Parameters: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`),
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`),
 		},
 	})
 
@@ -78,6 +78,211 @@ func TestQoderSerializeTools_DefaultsInvalidSchema(t *testing.T) {
 		if _, ok := schema["properties"].(map[string]any); !ok {
 			t.Fatalf("parameters.properties missing or wrong type for tool %d: %v", i, schema)
 		}
+	}
+}
+
+func TestNormalizeQoderMessages_PreservesToolPair(t *testing.T) {
+	msgs, system := normalizeQoderMessages([]core.Message{
+		{
+			Role: core.RoleAssistant,
+			Content: []core.ContentPart{
+				{Type: core.PartText, Text: "checking"},
+				{Type: core.PartToolCall, ToolCall: &core.ToolCall{
+					ID:        "tool_call_1",
+					Name:      "read_file",
+					Arguments: json.RawMessage(`{"path":"a.go"}`),
+				}},
+			},
+		},
+		{
+			Role: core.RoleUser,
+			Content: []core.ContentPart{
+				{Type: core.PartToolResult, ToolResult: &core.ToolResult{
+					CallID: "tool_call_1", Content: "package main",
+				}},
+				{Type: core.PartText, Text: "continue"},
+			},
+		},
+	})
+
+	if system != "" {
+		t.Fatalf("unexpected system text %q", system)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected assistant/tool/user messages, got %+v", msgs)
+	}
+	if len(msgs[0].ToolCalls) != 1 {
+		t.Fatalf("expected one tool call, got %+v", msgs[0])
+	}
+	call := msgs[0].ToolCalls[0]
+	if call.ID != "tool_call_1" || call.Function.Name != "read_file" ||
+		call.Function.Arguments != `{"path":"a.go"}` {
+		t.Fatalf("unexpected tool call: %+v", call)
+	}
+	if msgs[1].Role != "tool" || msgs[1].ToolCallID != "tool_call_1" ||
+		msgs[1].Content != "package main" {
+		t.Fatalf("unexpected tool result: %+v", msgs[1])
+	}
+	if msgs[2].Role != "user" || msgs[2].Content != "continue" {
+		t.Fatalf("unexpected user message: %+v", msgs[2])
+	}
+}
+
+func TestNormalizeQoderMessages_DropsOrphanResultAndKeepsText(t *testing.T) {
+	msgs, _ := normalizeQoderMessages([]core.Message{
+		{
+			Role: core.RoleUser,
+			Content: []core.ContentPart{
+				{Type: core.PartToolResult, ToolResult: &core.ToolResult{
+					CallID: "tool_call_1", Content: "stale",
+				}},
+				{Type: core.PartText, Text: "continue"},
+			},
+		},
+	})
+
+	if len(msgs) != 1 {
+		t.Fatalf("expected orphan result to be dropped, got %+v", msgs)
+	}
+	if msgs[0].Role != "user" || msgs[0].Content != "continue" {
+		t.Fatalf("unexpected remaining message: %+v", msgs[0])
+	}
+}
+
+func TestNormalizeQoderMessages_MovesDelayedResultNextToCall(t *testing.T) {
+	msgs, _ := normalizeQoderMessages([]core.Message{
+		{
+			Role: core.RoleAssistant,
+			Content: []core.ContentPart{
+				{Type: core.PartToolCall, ToolCall: &core.ToolCall{
+					ID: "tool_call_1", Name: "read_file", Arguments: json.RawMessage(`{}`),
+				}},
+			},
+		},
+		{
+			Role: core.RoleUser,
+			Content: []core.ContentPart{
+				{Type: core.PartText, Text: "intervening"},
+			},
+		},
+		{
+			Role: core.RoleTool,
+			Content: []core.ContentPart{
+				{Type: core.PartToolResult, ToolResult: &core.ToolResult{
+					CallID: "tool_call_1", Content: "result",
+				}},
+			},
+		},
+	})
+
+	if len(msgs) != 3 {
+		t.Fatalf("expected three repaired messages, got %+v", msgs)
+	}
+	if msgs[0].Role != "assistant" || msgs[1].Role != "tool" || msgs[2].Role != "user" {
+		t.Fatalf("tool result is not adjacent to assistant: %+v", msgs)
+	}
+	if msgs[1].ToolCallID != "tool_call_1" || msgs[1].Content != "result" {
+		t.Fatalf("unexpected moved result: %+v", msgs[1])
+	}
+}
+
+func TestNormalizeQoderMessages_SynthesizesMissingResult(t *testing.T) {
+	msgs, _ := normalizeQoderMessages([]core.Message{
+		{
+			Role: core.RoleAssistant,
+			Content: []core.ContentPart{
+				{Type: core.PartToolCall, ToolCall: &core.ToolCall{
+					ID: "tool_call_1", Name: "read_file", Arguments: json.RawMessage(`{}`),
+				}},
+			},
+		},
+		{
+			Role: core.RoleUser,
+			Content: []core.ContentPart{
+				{Type: core.PartText, Text: "continue"},
+			},
+		},
+	})
+
+	if len(msgs) != 3 || msgs[1].Role != "tool" || msgs[1].ToolCallID != "tool_call_1" {
+		t.Fatalf("missing tool result was not repaired: %+v", msgs)
+	}
+	if msgs[1].Content != "" {
+		t.Fatalf("synthetic result content = %q, want empty", msgs[1].Content)
+	}
+}
+
+func TestQoderBuildPayload_ScopesSessionByAccountAndRequest(t *testing.T) {
+	connector := NewQoder("qoder", "")
+	req := &core.ChatRequest{
+		Model: "ultimate",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{
+				{Type: core.PartText, Text: "hello"},
+			}},
+		},
+		Metadata: core.RequestMetadata{
+			ContextAffinityKey: "conversation-a",
+			RequestID:          "request-a",
+		},
+	}
+
+	first := connector.buildPayload(req, "ultimate", nil, "account-a")
+	retry := connector.buildPayload(req, "ultimate", nil, "account-a")
+	otherAccount := connector.buildPayload(req, "ultimate", nil, "account-b")
+
+	if first.SessionID != retry.SessionID {
+		t.Fatalf("same request should keep session id: %q != %q", first.SessionID, retry.SessionID)
+	}
+	if first.SessionID == otherAccount.SessionID {
+		t.Fatal("different accounts must not share a session id")
+	}
+
+	req.Metadata.ContextAffinityKey = ""
+	withoutAffinity := connector.buildPayload(req, "ultimate", nil, "account-a")
+	req.Metadata.RequestID = "request-b"
+	otherRequest := connector.buildPayload(req, "ultimate", nil, "account-a")
+	if withoutAffinity.SessionID == otherRequest.SessionID {
+		t.Fatal("requests without affinity must not share a session id")
+	}
+}
+
+func TestCollectQoderChunks_ReassemblesToolCall(t *testing.T) {
+	chunks := make(chan core.StreamChunk, 3)
+	chunks <- core.StreamChunk{
+		Type:  core.ChunkToolCall,
+		Index: 0,
+		ToolCall: &core.ToolCall{
+			ID:        "tool_call_1",
+			Name:      "Read",
+			Arguments: json.RawMessage(`{"file_path":"`),
+		},
+	}
+	chunks <- core.StreamChunk{
+		Type:     core.ChunkToolCall,
+		Index:    0,
+		ToolCall: &core.ToolCall{Arguments: json.RawMessage(`a.go"}`)},
+	}
+	chunks <- core.StreamChunk{
+		Type:         core.ChunkFinish,
+		FinishReason: core.FinishToolCalls,
+	}
+	close(chunks)
+
+	msg, finishReason, _, err := collectQoderChunks(chunks)
+	if err != nil {
+		t.Fatalf("collect chunks: %v", err)
+	}
+	if finishReason != core.FinishToolCalls {
+		t.Fatalf("finish reason = %q, want %q", finishReason, core.FinishToolCalls)
+	}
+	if len(msg.Content) != 1 || msg.Content[0].ToolCall == nil {
+		t.Fatalf("expected one complete tool call, got %+v", msg.Content)
+	}
+	call := msg.Content[0].ToolCall
+	if call.ID != "tool_call_1" || call.Name != "Read" ||
+		string(call.Arguments) != `{"file_path":"a.go"}` {
+		t.Fatalf("unexpected assembled tool call: %+v", call)
 	}
 }
 

--- a/backend/internal/normalizer/normalizer.go
+++ b/backend/internal/normalizer/normalizer.go
@@ -1,7 +1,7 @@
 // Package normalizer validates and repairs tool call structures in chat
 // requests before they are sent upstream. It ensures tool call IDs are
 // Anthropic-compatible, arguments are valid JSON, and every tool_use has a
-// matching tool_result.
+// matching tool_result, and every tool_result belongs to a known tool_use.
 //
 // It runs once, globally, on the canonical request — before any dialect
 // translation — so the same tool-call guarantees hold for every provider
@@ -32,6 +32,7 @@ func Apply(req *core.ChatRequest) {
 	}
 	DedupeBuiltinTools(req)
 	SanitizeToolCallIDs(req)
+	StripOrphanedToolResults(req)
 	FixMissingToolResults(req)
 }
 
@@ -109,6 +110,50 @@ func FixMissingToolResults(req *core.ChatRequest) {
 		if len(parts) > 0 {
 			out = append(out, core.Message{Role: core.RoleTool, Content: parts})
 		}
+	}
+
+	req.Messages = out
+}
+
+// StripOrphanedToolResults removes tool results whose call id does not exist on
+// an assistant message in the conversation. History truncation can remove the
+// assistant turn while leaving its result behind; strict providers reject that
+// request before inference. Non-result content in a mixed message is preserved.
+func StripOrphanedToolResults(req *core.ChatRequest) {
+	if req == nil {
+		return
+	}
+
+	knownCalls := make(map[string]bool)
+	for _, msg := range req.Messages {
+		if msg.Role != core.RoleAssistant {
+			continue
+		}
+		for _, id := range collectToolCallIDs(msg) {
+			knownCalls[id] = true
+		}
+	}
+
+	out := make([]core.Message, 0, len(req.Messages))
+	for _, msg := range req.Messages {
+		cleaned := make([]core.ContentPart, 0, len(msg.Content))
+		removed := false
+		for _, part := range msg.Content {
+			if part.Type == core.PartToolResult &&
+				(part.ToolResult == nil || !knownCalls[part.ToolResult.CallID]) {
+				removed = true
+				continue
+			}
+			cleaned = append(cleaned, part)
+		}
+
+		if removed {
+			if len(cleaned) == 0 {
+				continue
+			}
+			msg.Content = cleaned
+		}
+		out = append(out, msg)
 	}
 
 	req.Messages = out

--- a/backend/internal/normalizer/normalizer_test.go
+++ b/backend/internal/normalizer/normalizer_test.go
@@ -273,6 +273,109 @@ func TestFixMissingToolResults_AnsweredAnywhereNoDuplicate(t *testing.T) {
 	}
 }
 
+func TestStripOrphanedToolResults_RemovesToolMessage(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{
+				{Type: core.PartText, Text: "start"},
+			}},
+			{Role: core.RoleTool, Content: []core.ContentPart{
+				{Type: core.PartToolResult, ToolResult: &core.ToolResult{
+					CallID: "tool_call_1", Content: "stale",
+				}},
+			}},
+			{Role: core.RoleUser, Content: []core.ContentPart{
+				{Type: core.PartText, Text: "continue"},
+			}},
+		},
+	}
+
+	StripOrphanedToolResults(req)
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("expected orphan-only message to be removed, got %d messages", len(req.Messages))
+	}
+	for _, msg := range req.Messages {
+		if ids := collectToolResultIDs(msg); len(ids) != 0 {
+			t.Fatalf("orphan tool result survived: %v", ids)
+		}
+	}
+}
+
+func TestStripOrphanedToolResults_PreservesMixedText(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{
+				{Type: core.PartToolResult, ToolResult: &core.ToolResult{
+					CallID: "orphan", Content: "stale",
+				}},
+				{Type: core.PartText, Text: "please continue"},
+			}},
+		},
+	}
+
+	StripOrphanedToolResults(req)
+
+	if len(req.Messages) != 1 || len(req.Messages[0].Content) != 1 {
+		t.Fatalf("expected text-only message, got %+v", req.Messages)
+	}
+	if got := req.Messages[0].Content[0]; got.Type != core.PartText || got.Text != "please continue" {
+		t.Fatalf("unexpected preserved content: %+v", got)
+	}
+}
+
+func TestStripOrphanedToolResults_PreservesMatchedResult(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{
+			{Role: core.RoleAssistant, Content: []core.ContentPart{
+				{Type: core.PartToolCall, ToolCall: &core.ToolCall{ID: "tool_call_1", Name: "Read"}},
+			}},
+			{Role: core.RoleUser, Content: []core.ContentPart{
+				{Type: core.PartToolResult, ToolResult: &core.ToolResult{
+					CallID: "tool_call_1", Content: "ok",
+				}},
+			}},
+		},
+	}
+
+	StripOrphanedToolResults(req)
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("expected matched pair to remain, got %d messages", len(req.Messages))
+	}
+	if ids := collectToolResultIDs(req.Messages[1]); len(ids) != 1 || ids[0] != "tool_call_1" {
+		t.Fatalf("matched result was removed: %v", ids)
+	}
+}
+
+func TestApply_RemovesUnexpectedToolUseID(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{
+				{Type: core.PartText, Text: "first"},
+			}},
+			{Role: core.RoleAssistant, Content: []core.ContentPart{
+				{Type: core.PartText, Text: "done"},
+			}},
+			{Role: core.RoleUser, Content: []core.ContentPart{
+				{Type: core.PartText, Text: "next"},
+				{Type: core.PartToolResult, ToolResult: &core.ToolResult{
+					CallID: "tool_call_1", Content: "unexpected",
+				}},
+			}},
+		},
+	}
+
+	Apply(req)
+
+	if len(req.Messages) != 3 {
+		t.Fatalf("expected mixed user message to remain, got %d messages", len(req.Messages))
+	}
+	if len(req.Messages[2].Content) != 1 || req.Messages[2].Content[0].Type != core.PartText {
+		t.Fatalf("unexpected normalized content: %+v", req.Messages[2].Content)
+	}
+}
+
 func TestApply_Idempotent(t *testing.T) {
 	req := &core.ChatRequest{
 		Messages: []core.Message{

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -1205,7 +1205,7 @@ func (p *Pipeline) planWithCooldownRetry(ctx context.Context, tenantID string, t
 // (terse, caveman, ponytail) token-saving transforms in place, in a fixed
 // deterministic order before format translation:
 //
-//	normalizer -> slimmer -> headroom (input) -> terse -> caveman -> ponytail (output)
+//	normalizer -> slimmer -> headroom -> normalizer (input) -> terse -> caveman -> ponytail (output)
 //
 // Terse and caveman both inject system-prompt directives; if both are enabled,
 // terse runs first and caveman appends after, but in practice only one
@@ -1230,6 +1230,10 @@ func (p *Pipeline) applyTokenSaving(ctx context.Context, req *core.ChatRequest, 
 		// Fail-open: never returns an error; leaves req untouched on failure.
 		hrStats = p.headroom.Compress(ctx, req, opts.Headroom)
 	}
+
+	// Compression may remove one side of a tool call/result pair. Reconcile the
+	// final message history again before it reaches a provider connector.
+	normalizer.Apply(req)
 
 	terse.Apply(req, opts.Terse)
 	caveman.Apply(req, opts.Caveman)


### PR DESCRIPTION
## Summary

- preserve Qoder tool calls, tool results, IDs, arguments, and result content in upstream messages
- remove orphaned tool results and repair missing or misplaced tool-result pairs
- reconcile tool history again after context compression
- isolate Qoder sessions by account and request affinity
- reassemble fragmented tool calls for non-streaming responses

## Behavior

- valid tool-call histories are forwarded without losing metadata
- orphaned tool results are removed while unrelated text is preserved
- tool results are placed directly after their matching assistant tool call
- missing tool results receive an empty placeholder instead of producing an invalid history
- requests without explicit affinity no longer share a model-wide Qoder session

## Validation

- `go test ./backend/...`
- `go vet ./backend/internal/normalizer ./backend/internal/connectors ./backend/internal/pipeline`
- `git diff --check`
