### PR TITLE
fix(kiro): harden stream and response integrity

### DIFF
--- a/backend/internal/connectors/kiro.go
+++ b/backend/internal/connectors/kiro.go
@@ -820,6 +820,7 @@ func (c *Kiro) Chat(ctx context.Context, req *core.ChatRequest, creds core.Crede
 	var toolOrder []string
 	finish := core.FinishStop
 	var usage core.Usage
+	var streamErr *core.ProviderError
 
 	for ch := range stream {
 		switch ch.Type {
@@ -848,8 +849,8 @@ func (c *Kiro) Chat(ctx context.Context, req *core.ChatRequest, creds core.Crede
 				usage = *ch.Usage
 			}
 		case core.ChunkError:
-			if ch.Err != nil {
-				return nil, ch.Err
+			if ch.Err != nil && streamErr == nil {
+				streamErr = core.AsProviderError(ch.Err)
 			}
 		}
 	}
@@ -868,12 +869,32 @@ func (c *Kiro) Chat(ctx context.Context, req *core.ChatRequest, creds core.Crede
 		msg.Content = append(msg.Content, core.ContentPart{Type: core.PartToolCall, ToolCall: tc})
 	}
 
+	if streamErr != nil {
+		if usage.PromptTokens != 0 || usage.CompletionTokens != 0 || usage.TotalTokens != 0 {
+			attemptUsage := usage
+			streamErr.AttemptUsage = &attemptUsage
+		}
+		return nil, streamErr
+	}
+
+	if kind := kiroIntegrityKind(text, len(toolOrder) > 0); kind != "" {
+		attemptUsage := usage
+		return nil, &core.ProviderError{
+			Kind:                   core.ErrUpstream,
+			Scope:                  core.FailureScopeRequest,
+			Provider:               c.id,
+			Model:                  req.Model,
+			Message:                "kiro response integrity check failed: " + kind,
+			RetrySystemInstruction: kiroRepairInstructions[kind],
+			AttemptUsage:           &attemptUsage,
+		}
+	}
+
 	return &core.ChatResponse{Model: req.Model, Message: msg, FinishReason: finish, Usage: usage}, nil
 }
 
 // pipeKiroResponse reads an HTTP eventstream response into a buffered channel,
-// converting frames to canonical chunks. The caller is responsible for closing
-// resp.Body after draining the returned channel.
+// converting frames to canonical chunks and closing the body at EOF.
 func (c *Kiro) pipeKiroResponse(ctx context.Context, resp *http.Response, req *core.ChatRequest, ttft *ttftTracker) <-chan core.StreamChunk {
 	ch := make(chan core.StreamChunk, 64)
 	go func() {
@@ -893,9 +914,14 @@ func (c *Kiro) pipeKiroResponse(ctx context.Context, resp *http.Response, req *c
 			frame, ferr := parser.next()
 			if ferr != nil {
 				if ferr != errEventStreamEOF {
-					ch <- core.StreamChunk{
+					errChunk := core.StreamChunk{
 						Type: core.ChunkError,
 						Err:  &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Model: req.Model, Message: ferr.Error(), Cause: ferr},
+					}
+					select {
+					case ch <- errChunk:
+					case <-ctx.Done():
+						return
 					}
 				}
 				break
@@ -904,6 +930,13 @@ func (c *Kiro) pipeKiroResponse(ctx context.Context, resp *http.Response, req *c
 				continue
 			}
 			for _, chunk := range kiroFrameToChunks(frame, seenTools, &hasTool) {
+				if chunk.Type == core.ChunkError && chunk.Err != nil {
+					pe := core.AsProviderError(chunk.Err)
+					copy := *pe
+					copy.Provider = c.id
+					copy.Model = req.Model
+					chunk.Err = &copy
+				}
 				if chunk.Type == core.ChunkUsage {
 					usageSeen = true
 				}
@@ -933,11 +966,7 @@ func (c *Kiro) pipeKiroResponse(ctx context.Context, resp *http.Response, req *c
 }
 
 // Stream performs a streaming call, parsing the AWS EventStream into canonical
-// chunks. After the first response is fully buffered it is passed through the
-// integrity gate: if the model returned only an ellipsis, a short future-action
-// announcement, or a malformed tool call, a single retry is issued with a
-// repair instruction appended to the system prompt. The buffered chunks of the
-// winning attempt are then forwarded to the caller.
+// chunks and forwarding each one as soon as it arrives.
 func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Credentials, cfg core.StreamConfig) (<-chan core.StreamChunk, error) {
 	releaseAccount, err := c.acquireAccountSlot(ctx, creds, req.Model)
 	if err != nil {
@@ -945,7 +974,7 @@ func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cre
 	}
 
 	profileArn := kiroResolveProfileArn(creds)
-	body, err := c.codec.RenderRequestWithProfile(req, profileArn)
+	body, err := c.codec.RenderRequestForAccount(req, profileArn, creds.AccountID)
 	if err != nil {
 		releaseAccount()
 		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}
@@ -963,24 +992,7 @@ func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cre
 		defer releaseAccount()
 
 		ttft := newTTFTTracker(cfg)
-		chunks, content, hasTool, toolErr := drainKiroStream(c.pipeKiroResponse(ctx, resp, req, ttft))
-
-		kind := kiroIntegrityKind(content, hasTool, toolErr)
-		if kind != "" {
-			repairedReq := kiroAppendRepair(req, kind)
-			repairedBody, rerr := c.codec.RenderRequestWithProfile(repairedReq, profileArn)
-			if rerr == nil {
-				resp2, rerr2 := c.openStreamWithFailover(ctx, req.Model, repairedBody, c.headers(creds), c.endpoints(creds))
-				if rerr2 == nil {
-					retryChunks, _, _, _ := drainKiroStream(c.pipeKiroResponse(ctx, resp2, repairedReq, nil))
-					if len(retryChunks) > 0 {
-						chunks = retryChunks
-					}
-				}
-			}
-		}
-
-		for _, ch := range chunks {
+		for ch := range c.pipeKiroResponse(ctx, resp, req, ttft) {
 			select {
 			case out <- ch:
 			case <-ctx.Done():
@@ -992,13 +1004,9 @@ func (c *Kiro) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cre
 }
 
 // kiroIntegrityKind inspects accumulated stream output and returns the repair
-// kind needed ("ellipsis", "short_final", "tool"), or "" when the response is
-// acceptable. hasTool indicates a tool call was present; toolErr is set when a
-// tool payload was malformed.
-func kiroIntegrityKind(content string, hasTool bool, toolErr string) string {
-	if toolErr != "" {
-		return "tool"
-	}
+// kind needed ("ellipsis" or "short_final"), or "" when the response is
+// acceptable. Tool payload integrity is validated while parsing its event.
+func kiroIntegrityKind(content string, hasTool bool) string {
 	text := strings.TrimSpace(strings.ReplaceAll(content, "\u2019", "'"))
 	if text == "..." || text == "\u2026" {
 		return "ellipsis"
@@ -1021,46 +1029,6 @@ func kiroIntegrityKind(content string, hasTool bool, toolErr string) string {
 		return "short_final"
 	}
 	return ""
-}
-
-// kiroAppendRepair returns a copy of req with the repair instruction appended
-// to the system prompt.
-func kiroAppendRepair(req *core.ChatRequest, kind string) *core.ChatRequest {
-	instruction, ok := kiroRepairInstructions[kind]
-	if !ok {
-		instruction = "Retry the previous incomplete response."
-	}
-	copy := *req
-	if copy.System != "" {
-		copy.System = copy.System + "\n\n" + instruction
-	} else {
-		copy.System = instruction
-	}
-	return &copy
-}
-
-// drainKiroStream drains a stream channel into a buffer slice and tracks
-// content/tool state needed by the integrity gate. Returns collected chunks,
-// accumulated text content, whether a tool call was seen, and any tool error.
-func drainKiroStream(ch <-chan core.StreamChunk) ([]core.StreamChunk, string, bool, string) {
-	var chunks []core.StreamChunk
-	var content strings.Builder
-	hasTool := false
-	toolErr := ""
-	for c := range ch {
-		chunks = append(chunks, c)
-		switch c.Type {
-		case core.ChunkText:
-			content.WriteString(c.Delta)
-		case core.ChunkToolCall:
-			hasTool = true
-		case core.ChunkError:
-			if c.Err != nil {
-				toolErr = c.Err.Error()
-			}
-		}
-	}
-	return chunks, content.String(), hasTool, toolErr
 }
 
 // estimateKiroUsage produces a best-effort token estimate for a Kiro response
@@ -1129,8 +1097,21 @@ func kiroFrameToChunks(frame *eventStreamFrame, seenTools map[string]bool, hasTo
 		}
 
 	case "toolUseEvent":
-		chunks = append(chunks, kiroToolUseChunks(frame.payload, seenTools)...)
-		if len(chunks) > 0 {
+		toolChunks, err := kiroToolUseChunks(frame.payload, seenTools)
+		if err != nil {
+			chunks = append(chunks, core.StreamChunk{
+				Type: core.ChunkError,
+				Err: &core.ProviderError{
+					Kind:                   core.ErrUpstream,
+					Scope:                  core.FailureScopeRequest,
+					Message:                "kiro response integrity check failed: malformed tool call: " + err.Error(),
+					RetrySystemInstruction: kiroRepairInstructions["tool"],
+				},
+			})
+			break
+		}
+		chunks = append(chunks, toolChunks...)
+		if len(toolChunks) > 0 {
 			*hasTool = true
 		}
 
@@ -1211,60 +1192,91 @@ func extractKiroReasoning(payload []byte) string {
 	return obj.ReasoningContentEvent.Content
 }
 
-func kiroToolUseChunks(payload []byte, seenTools map[string]bool) []core.StreamChunk {
-	parseOne := func(raw json.RawMessage) []core.StreamChunk {
+func kiroToolUseChunks(payload []byte, seenTools map[string]bool) ([]core.StreamChunk, error) {
+	workingSeen := make(map[string]bool, len(seenTools))
+	for id, seen := range seenTools {
+		workingSeen[id] = seen
+	}
+
+	parseOne := func(raw json.RawMessage) ([]core.StreamChunk, error) {
 		var t struct {
 			ToolUseID string          `json:"toolUseId"`
 			Name      string          `json:"name"`
 			Input     json.RawMessage `json:"input"`
 		}
-		if json.Unmarshal(raw, &t) != nil {
-			return nil
+		if err := json.Unmarshal(raw, &t); err != nil {
+			return nil, fmt.Errorf("invalid payload: %w", err)
 		}
+		t.Name = strings.TrimSpace(t.Name)
+		if t.Name == "" {
+			return nil, fmt.Errorf("tool name is empty")
+		}
+		if len(t.Input) == 0 || strings.TrimSpace(string(t.Input)) == "null" {
+			return nil, fmt.Errorf("tool arguments are missing")
+		}
+
+		args := t.Input
+		var asStr string
+		if json.Unmarshal(t.Input, &asStr) == nil {
+			asStr = strings.TrimSpace(asStr)
+			if asStr == "" || !json.Valid([]byte(asStr)) {
+				return nil, fmt.Errorf("tool arguments are not valid JSON")
+			}
+			args = json.RawMessage(asStr)
+		} else if !json.Valid(t.Input) {
+			return nil, fmt.Errorf("tool arguments are not valid JSON")
+		}
+
 		id := t.ToolUseID
 		if id == "" {
 			id = "call_" + uuid.NewString()
 		}
 		var chunks []core.StreamChunk
-		if !seenTools[id] {
-			seenTools[id] = true
+		if !workingSeen[id] {
+			workingSeen[id] = true
 			chunks = append(chunks, core.StreamChunk{
 				Type:     core.ChunkToolCall,
 				ToolCall: &core.ToolCall{ID: id, Name: t.Name, Arguments: json.RawMessage("")},
 			})
 		}
-		if len(t.Input) > 0 {
-			args := t.Input
-			// Input may be a JSON string or object; normalize to a string of JSON.
-			var asStr string
-			if json.Unmarshal(t.Input, &asStr) == nil {
-				args = json.RawMessage(asStr)
-			}
-			chunks = append(chunks, core.StreamChunk{
-				Type:     core.ChunkToolCall,
-				ToolCall: &core.ToolCall{ID: id, Arguments: args},
-			})
-		}
-		return chunks
+		chunks = append(chunks, core.StreamChunk{
+			Type:     core.ChunkToolCall,
+			ToolCall: &core.ToolCall{ID: id, Arguments: args},
+		})
+		return chunks, nil
 	}
 
-	// Payload may be a single tool-use object or an array.
-	trimmed := payload
-	for len(trimmed) > 0 && (trimmed[0] == ' ' || trimmed[0] == '\n' || trimmed[0] == '\t') {
-		trimmed = trimmed[1:]
+	commitSeen := func() {
+		for id, seen := range workingSeen {
+			seenTools[id] = seen
+		}
 	}
+
+	trimmed := []byte(strings.TrimSpace(string(payload)))
 	if len(trimmed) > 0 && trimmed[0] == '[' {
 		var arr []json.RawMessage
-		if json.Unmarshal(payload, &arr) != nil {
-			return nil
+		if err := json.Unmarshal(payload, &arr); err != nil {
+			return nil, fmt.Errorf("invalid tool list: %w", err)
+		}
+		if len(arr) == 0 {
+			return nil, fmt.Errorf("tool list is empty")
 		}
 		var chunks []core.StreamChunk
 		for _, item := range arr {
-			chunks = append(chunks, parseOne(item)...)
+			itemChunks, err := parseOne(item)
+			if err != nil {
+				return nil, err
+			}
+			chunks = append(chunks, itemChunks...)
 		}
-		return chunks
+		commitSeen()
+		return chunks, nil
 	}
-	return parseOne(payload)
+	chunks, err := parseOne(payload)
+	if err == nil {
+		commitSeen()
+	}
+	return chunks, err
 }
 
 // ---- AWS EventStream binary parser ------------------------------------------
@@ -1308,7 +1320,7 @@ func (p *eventStreamParser) next() (*eventStreamFrame, error) {
 				return nil, errEventStreamEOF
 			}
 			if err == io.EOF {
-				return nil, errEventStreamEOF
+				return nil, fmt.Errorf("eventstream: truncated prelude: %w", io.ErrUnexpectedEOF)
 			}
 			return nil, err
 		}
@@ -1323,7 +1335,7 @@ func (p *eventStreamParser) next() (*eventStreamFrame, error) {
 	for len(p.buf) < totalLen {
 		if err := p.fill(); err != nil {
 			if err == io.EOF {
-				return nil, errEventStreamEOF
+				return nil, fmt.Errorf("eventstream: truncated frame: %w", io.ErrUnexpectedEOF)
 			}
 			return nil, err
 		}
@@ -1341,6 +1353,7 @@ func (p *eventStreamParser) fill() error {
 	n, err := p.r.Read(tmp)
 	if n > 0 {
 		p.buf = append(p.buf, tmp[:n]...)
+		return nil
 	}
 	return err
 }

--- a/backend/internal/connectors/kiro_test.go
+++ b/backend/internal/connectors/kiro_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -76,6 +77,41 @@ func TestEventStreamParser_DecodesFrames(t *testing.T) {
 	if events[0] != "assistantResponseEvent" || events[2] != "messageStopEvent" {
 		t.Errorf("unexpected event order: %v", events)
 	}
+}
+
+type eofWithDataReader struct {
+	data []byte
+	read bool
+}
+
+func (r *eofWithDataReader) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+	r.read = true
+	n := copy(p, r.data)
+	return n, io.EOF
+}
+
+func TestEventStreamParserProcessesDataReturnedWithEOF(t *testing.T) {
+	parser := newEventStreamParser(&eofWithDataReader{
+		data: encodeEventStreamFrame("assistantResponseEvent", []byte(`{"content":"hello"}`)),
+	})
+
+	frame, err := parser.next()
+	require.NoError(t, err)
+	require.Equal(t, "assistantResponseEvent", frame.headers[":event-type"])
+
+	_, err = parser.next()
+	require.Equal(t, errEventStreamEOF, err)
+}
+
+func TestEventStreamParserRejectsTruncatedFrame(t *testing.T) {
+	frame := encodeEventStreamFrame("assistantResponseEvent", []byte(`{"content":"hello"}`))
+	parser := newEventStreamParser(bytes.NewReader(frame[:len(frame)-1]))
+
+	_, err := parser.next()
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
 
 func TestKiroFrameToChunks_TextAndStop(t *testing.T) {
@@ -469,64 +505,139 @@ func TestKiroIntegrityKind(t *testing.T) {
 	cases := []struct {
 		content string
 		hasTool bool
-		toolErr string
 		want    string
 	}{
-		{"hello world", false, "", ""},
-		{"...", false, "", "ellipsis"},
-		{"\u2026", false, "", "ellipsis"},
-		{"", false, "malformed tool", "tool"},
-		{"Let me check the status", false, "", "short_final"},
-		{"I will verify the deployment", false, "", "short_final"},
-		{"Done. The deployment is complete.", false, "", ""},
-		{"Let me check the status", true, "", ""},
-		{"現在我確認一下", false, "", "short_final"},
-		{"Let me verify: status is 200 OK", false, "", ""},
+		{"hello world", false, ""},
+		{"...", false, "ellipsis"},
+		{"\u2026", false, "ellipsis"},
+		{"Let me check the status", false, "short_final"},
+		{"I will verify the deployment", false, "short_final"},
+		{"Done. The deployment is complete.", false, ""},
+		{"Let me check the status", true, ""},
+		{"現在我確認一下", false, "short_final"},
+		{"Let me verify: status is 200 OK", false, ""},
 	}
 	for _, tc := range cases {
-		got := kiroIntegrityKind(tc.content, tc.hasTool, tc.toolErr)
+		got := kiroIntegrityKind(tc.content, tc.hasTool)
 		if got != tc.want {
-			t.Errorf("kiroIntegrityKind(%q, hasTool=%v, toolErr=%q) = %q, want %q",
-				tc.content, tc.hasTool, tc.toolErr, got, tc.want)
+			t.Errorf("kiroIntegrityKind(%q, hasTool=%v) = %q, want %q",
+				tc.content, tc.hasTool, got, tc.want)
 		}
 	}
 }
 
-func TestKiroAppendRepair(t *testing.T) {
-	req := &core.ChatRequest{Model: "claude-sonnet-4.5", System: "be helpful"}
-	out := kiroAppendRepair(req, "ellipsis")
-	if !strings.Contains(out.System, "be helpful") {
-		t.Error("original system should be preserved")
-	}
-	if !strings.Contains(out.System, "ellipsis") {
-		t.Error("repair instruction should mention ellipsis")
-	}
-	if req.System == out.System {
-		t.Error("original req must not be mutated")
-	}
+func TestKiroFrameToChunksMalformedToolRequestsRepair(t *testing.T) {
+	frame := mustDecode(t, encodeEventStreamFrame("toolUseEvent",
+		[]byte(`{"toolUseId":"t1","input":{"city":"SF"}}`)))
+	hasTool := false
+	chunks := kiroFrameToChunks(frame, map[string]bool{}, &hasTool)
 
-	noSystem := &core.ChatRequest{Model: "claude-sonnet-4.5"}
-	out2 := kiroAppendRepair(noSystem, "short_final")
-	if out2.System == "" {
-		t.Error("repair should set system even when originally empty")
+	require.Len(t, chunks, 1)
+	require.Equal(t, core.ChunkError, chunks[0].Type)
+	pe := core.AsProviderError(chunks[0].Err)
+	require.Equal(t, core.FailureScopeRequest, pe.Scope)
+	require.NotEmpty(t, pe.RetrySystemInstruction)
+	require.False(t, hasTool)
+}
+
+func TestKiroToolUseChunksValidatesArgumentsAtomically(t *testing.T) {
+	t.Run("empty object is valid", func(t *testing.T) {
+		seen := map[string]bool{}
+		chunks, err := kiroToolUseChunks(
+			[]byte(`{"toolUseId":"t1","name":"lookup","input":{}}`),
+			seen,
+		)
+		require.NoError(t, err)
+		require.Len(t, chunks, 2)
+		require.JSONEq(t, `{}`, string(chunks[1].ToolCall.Arguments))
+		require.True(t, seen["t1"])
+	})
+
+	t.Run("invalid JSON string is rejected", func(t *testing.T) {
+		seen := map[string]bool{}
+		_, err := kiroToolUseChunks(
+			[]byte(`{"toolUseId":"t1","name":"lookup","input":"not-json"}`),
+			seen,
+		)
+		require.Error(t, err)
+		require.Empty(t, seen)
+	})
+
+	t.Run("invalid array item does not commit earlier tools", func(t *testing.T) {
+		seen := map[string]bool{}
+		_, err := kiroToolUseChunks([]byte(`[
+			{"toolUseId":"t1","name":"lookup","input":{}},
+			{"toolUseId":"t2","input":{}}
+		]`), seen)
+		require.Error(t, err)
+		require.Empty(t, seen)
+	})
+}
+
+func TestKiroStreamForwardsBeforeUpstreamEOF(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeEventStreamFrame("assistantResponseEvent", []byte(`{"content":"hello"}`)))
+		w.(http.Flusher).Flush()
+		<-release
+		_, _ = w.Write(encodeEventStreamFrame("messageStopEvent", []byte(`{}`)))
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	conn := NewKiro("kiro", srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	stream, err := conn.Stream(ctx, &core.ChatRequest{
+		Model: "model",
+		Messages: []core.Message{{
+			Role:    core.RoleUser,
+			Content: []core.ContentPart{{Type: core.PartText, Text: "hello"}},
+		}},
+	}, core.Credentials{BaseURL: srv.URL}, core.StreamConfig{})
+	require.NoError(t, err)
+
+	select {
+	case chunk := <-stream:
+		require.Equal(t, core.ChunkText, chunk.Type)
+		require.Equal(t, "hello", chunk.Delta)
+	case <-time.After(time.Second):
+		t.Fatal("first chunk was not forwarded while the upstream stream remained open")
 	}
 }
 
-func TestDrainKiroStream(t *testing.T) {
-	ch := make(chan core.StreamChunk, 4)
-	ch <- core.StreamChunk{Type: core.ChunkText, Delta: "hello "}
-	ch <- core.StreamChunk{Type: core.ChunkText, Delta: "world"}
-	ch <- core.StreamChunk{Type: core.ChunkToolCall, ToolCall: &core.ToolCall{ID: "t1", Name: "fn"}}
-	ch <- core.StreamChunk{Type: core.ChunkFinish, FinishReason: core.FinishStop}
-	close(ch)
+func TestKiroChatIncompleteResponseReturnsRoutedRepair(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeEventStreamFrame("assistantResponseEvent", []byte(`{"content":"..."}`)))
+		_, _ = w.Write(encodeEventStreamFrame("usageEvent", []byte(`{"inputTokens":3,"outputTokens":1}`)))
+		_, _ = w.Write(encodeEventStreamFrame("messageStopEvent", []byte(`{}`)))
+	}))
+	defer srv.Close()
 
-	chunks, content, hasTool, toolErr := drainKiroStream(ch)
-	require.Equal(t, 4, len(chunks))
-	require.Equal(t, "hello world", content)
-	require.True(t, hasTool)
-	require.Equal(t, "", toolErr)
+	conn := NewKiro("kiro", srv.URL)
+	resp, err := conn.Chat(context.Background(), &core.ChatRequest{
+		Model: "model",
+		Messages: []core.Message{{
+			Role:    core.RoleUser,
+			Content: []core.ContentPart{{Type: core.PartText, Text: "hello"}},
+		}},
+	}, core.Credentials{BaseURL: srv.URL})
+	if err == nil {
+		t.Fatalf("expected repair error, got response %+v", resp)
+	}
+
+	pe := core.AsProviderError(err)
+	require.Equal(t, core.ErrUpstream, pe.Kind)
+	require.Equal(t, core.FailureScopeRequest, pe.Scope)
+	require.NotEmpty(t, pe.RetrySystemInstruction)
+	require.NotNil(t, pe.AttemptUsage)
+	require.Equal(t, 4, pe.AttemptUsage.TotalTokens)
+	require.Equal(t, int32(1), calls.Load())
 }
-
 
 func TestKiroMetadataCachesReturnCopies(t *testing.T) {
 	accountID := "cache-account"

--- a/backend/internal/core/errors.go
+++ b/backend/internal/core/errors.go
@@ -71,6 +71,13 @@ type ProviderError struct {
 	Message string
 	// RetryAfter, when non-zero, is the upstream-suggested cooldown.
 	RetryAfter time.Duration
+	// RetrySystemInstruction requests one centrally routed retry with an
+	// additional system instruction. Connectors use this for completed
+	// responses that are structurally invalid or clearly incomplete.
+	RetrySystemInstruction string
+	// AttemptUsage captures tokens consumed by a completed attempt that is being
+	// retried for response integrity. The pipeline adds it to terminal usage.
+	AttemptUsage *Usage
 	// Cause is the wrapped underlying error.
 	Cause error
 }

--- a/backend/internal/pipeline/attempt_planner.go
+++ b/backend/internal/pipeline/attempt_planner.go
@@ -98,6 +98,15 @@ func (p *attemptPlanner) AfterFailure(ctx context.Context, failed dispatch.Attem
 	return p.current, true
 }
 
+func (p *attemptPlanner) AfterRepair(ctx context.Context, failed dispatch.Attempt, pe *core.ProviderError) (dispatch.Attempt, bool) {
+	if next, ok := p.AfterFailure(ctx, failed, pe); ok {
+		return next, true
+	}
+	p.current = failed
+	p.remaining = true
+	return failed, true
+}
+
 func stableTargetOrder(initial []dispatch.Attempt, original []dispatch.Target) []dispatch.Target {
 	out := make([]dispatch.Target, 0, len(original))
 	seen := make(map[dispatch.Target]struct{}, len(original))

--- a/backend/internal/pipeline/attempt_planner_test.go
+++ b/backend/internal/pipeline/attempt_planner_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,6 +33,14 @@ func (plannerConnector) Stream(context.Context, *core.ChatRequest, core.Credenti
 }
 
 func newPlannerDispatcher(t *testing.T) *dispatch.Dispatcher {
+	return newPlannerDispatcherWithAccounts(t, "acc-1", "acc-2")
+}
+
+func newPlannerDispatcherWithAccounts(t *testing.T, accountIDs ...string) *dispatch.Dispatcher {
+	return newPlannerDispatcherWithConnector(t, plannerConnector{}, accountIDs...)
+}
+
+func newPlannerDispatcherWithConnector(t *testing.T, conn core.Connector, accountIDs ...string) *dispatch.Dispatcher {
 	t.Helper()
 	ctx := context.Background()
 	db, err := store.Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: ":memory:"}, t.TempDir())
@@ -46,7 +55,7 @@ func newPlannerDispatcher(t *testing.T) *dispatch.Dispatcher {
 	require.NoError(t, err)
 	secrets := vault.New(sealer)
 
-	for i, id := range []string{"acc-1", "acc-2"} {
+	for i, id := range accountIDs {
 		now := time.Now()
 		account := store.Account{
 			ID: id, TenantID: store.DefaultTenantID, Provider: "openai",
@@ -57,7 +66,7 @@ func newPlannerDispatcher(t *testing.T) *dispatch.Dispatcher {
 		require.NoError(t, db.Accounts().Create(ctx, account))
 	}
 
-	d := dispatch.New(plannerConnectorSource{conn: plannerConnector{}}, db.Accounts(), secrets)
+	d := dispatch.New(plannerConnectorSource{conn: conn}, db.Accounts(), secrets)
 	d.SetRoutingSource(db.Routing())
 	return d
 }
@@ -108,4 +117,119 @@ func TestAttemptPlannerAccountFailureSkipsCredentialAcrossModels(t *testing.T) {
 
 	_, ok = planner.AfterFailure(ctx, second, &core.ProviderError{Kind: core.ErrAuth})
 	require.False(t, ok)
+}
+
+func TestAttemptPlannerRepairPrefersAnotherAccount(t *testing.T) {
+	ctx := context.Background()
+	d := newPlannerDispatcher(t)
+	targets := []dispatch.Target{{Provider: "openai", Model: "gpt-4o"}}
+	initial, err := d.Plan(ctx, store.DefaultTenantID, targets, core.NewCapabilitySet())
+	require.NoError(t, err)
+	planner := newAttemptPlanner(d, store.DefaultTenantID, targets, core.NewCapabilitySet(), dispatch.PlanOptions{}, initial)
+
+	first, ok := planner.Current()
+	require.True(t, ok)
+	second, ok := planner.AfterRepair(ctx, first, &core.ProviderError{
+		Kind: core.ErrUpstream, Scope: core.FailureScopeRequest,
+	})
+	require.True(t, ok)
+	require.Equal(t, "acc-2", second.Account.ID)
+}
+
+func TestAttemptPlannerRepairRetriesOnlyAccountOnce(t *testing.T) {
+	ctx := context.Background()
+	d := newPlannerDispatcherWithAccounts(t, "acc-1")
+	targets := []dispatch.Target{{Provider: "openai", Model: "gpt-4o"}}
+	initial, err := d.Plan(ctx, store.DefaultTenantID, targets, core.NewCapabilitySet())
+	require.NoError(t, err)
+	planner := newAttemptPlanner(d, store.DefaultTenantID, targets, core.NewCapabilitySet(), dispatch.PlanOptions{}, initial)
+
+	first, ok := planner.Current()
+	require.True(t, ok)
+	retry, ok := planner.AfterRepair(ctx, first, &core.ProviderError{
+		Kind: core.ErrUpstream, Scope: core.FailureScopeRequest,
+	})
+	require.True(t, ok)
+	require.Equal(t, first.Key(), retry.Key())
+
+	_, ok = planner.AfterFailure(ctx, retry, &core.ProviderError{
+		Kind: core.ErrUpstream, Scope: core.FailureScopeRequest,
+	})
+	require.False(t, ok)
+}
+
+type repairPipelineConnector struct {
+	mu       sync.Mutex
+	systems  []string
+	accounts []string
+}
+
+func (*repairPipelineConnector) ID() string            { return "openai" }
+func (*repairPipelineConnector) Dialect() core.Dialect { return core.DialectOpenAI }
+func (c *repairPipelineConnector) Chat(_ context.Context, req *core.ChatRequest, creds core.Credentials) (*core.ChatResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.systems = append(c.systems, req.System)
+	c.accounts = append(c.accounts, creds.AccountID)
+	if len(c.systems) == 1 {
+		return nil, &core.ProviderError{
+			Kind:                   core.ErrUpstream,
+			Scope:                  core.FailureScopeRequest,
+			Message:                "incomplete response",
+			RetrySystemInstruction: "complete the previous response",
+			AttemptUsage: &core.Usage{
+				PromptTokens: 5, CompletionTokens: 1, TotalTokens: 6,
+				Source: core.UsageSourceProvider,
+			},
+		}
+	}
+	return &core.ChatResponse{
+		Model: req.Model,
+		Message: core.Message{
+			Role:    core.RoleAssistant,
+			Content: []core.ContentPart{{Type: core.PartText, Text: "done"}},
+		},
+		FinishReason: core.FinishStop,
+		Usage: core.Usage{
+			PromptTokens: 6, CompletionTokens: 2, TotalTokens: 8,
+			Source: core.UsageSourceProvider,
+		},
+	}, nil
+}
+func (*repairPipelineConnector) Stream(context.Context, *core.ChatRequest, core.Credentials, core.StreamConfig) (<-chan core.StreamChunk, error) {
+	ch := make(chan core.StreamChunk)
+	close(ch)
+	return ch, nil
+}
+
+func TestPipelineRepairReroutesAndAccountsForBothAttempts(t *testing.T) {
+	conn := &repairPipelineConnector{}
+	d := newPlannerDispatcherWithConnector(t, conn, "acc-1", "acc-2")
+	p := New(Deps{Dispatcher: d})
+	req := &core.ChatRequest{
+		Model:  "gpt-4o",
+		System: "original",
+		Messages: []core.Message{{
+			Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hello"}},
+		}},
+		Metadata: core.RequestMetadata{TenantID: store.DefaultTenantID},
+	}
+
+	result, err := p.Chat(context.Background(), req, Options{
+		Targets: []dispatch.Target{{Provider: "openai", Model: "gpt-4o"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "acc-2", result.AccountID)
+	require.Equal(t, 11, result.Response.Usage.PromptTokens)
+	require.Equal(t, 3, result.Response.Usage.CompletionTokens)
+	require.Equal(t, 14, result.Response.Usage.TotalTokens)
+	require.Equal(t, "original", req.System)
+
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	require.Equal(t, []string{"acc-1", "acc-2"}, conn.accounts)
+	require.Equal(t, []string{
+		"original",
+		"original\n\ncomplete the previous response",
+	}, conn.systems)
 }

--- a/backend/internal/pipeline/pipeline.go
+++ b/backend/internal/pipeline/pipeline.go
@@ -255,6 +255,9 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 	var lastAttempt dispatch.Attempt
 	var lastLatency time.Duration
 	fellBack := false // tracks whether the current request triggered ≥1 fallback
+	attemptBaseReq := req
+	repairInstructionApplied := false
+	var priorAttemptUsage core.Usage
 	planner := newAttemptPlanner(p.dispatcher, req.Metadata.TenantID, opts.Targets, required, opts.PlanOpts, attempts)
 	attempt, hasAttempt := planner.Current()
 	for i := 0; hasAttempt; i++ {
@@ -262,7 +265,7 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 		started := time.Now()
 		p.log.Debug("attempt start", "i", i, "provider", attempt.Target.Provider,
 			"model", attempt.Target.Model, "account", attempt.Account.ID)
-		attemptReq := cloneForAttempt(req, attempt.Target.Model)
+		attemptReq := cloneForAttempt(attemptBaseReq, attempt.Target.Model)
 
 		// Soft-degrade unsupported modalities. Stripping replaces input
 		// modalities the resolved profile cannot handle with text placeholders,
@@ -304,7 +307,7 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 			if reqTimeout := p.resolvedRequestTimeout(); reqTimeout > 0 {
 				streamCtx, streamCancel = context.WithTimeout(streamCtx, reqTimeout)
 			}
-			streamReq := cloneForAttempt(req, attempt.Target.Model)
+			streamReq := cloneForAttempt(attemptBaseReq, attempt.Target.Model)
 			stream, sErr := attempt.Conn.Stream(streamCtx, streamReq, attempt.Creds, core.StreamConfig{})
 			if sErr == nil {
 				sResp, drainErr := drainStream(stream, req.Model)
@@ -333,6 +336,14 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 		if callErr != nil {
 			pe := providerErrorForAttempt(callErr, attempt)
 			lastErr = pe
+			if pe.AttemptUsage != nil {
+				priorAttemptUsage = addAttemptUsage(priorAttemptUsage, *pe.AttemptUsage)
+			}
+			repairRetry := pe.RetrySystemInstruction != "" && !repairInstructionApplied
+			if repairRetry {
+				attemptBaseReq = cloneWithSystemInstruction(req, pe.RetrySystemInstruction)
+				repairInstructionApplied = true
+			}
 			p.dispatcher.NoteFailure(ctx, attempt.Account.ID, pe)
 			if p.metrics != nil {
 				p.metrics.RecordUpstreamError(attempt.Target.Provider, string(pe.Kind))
@@ -340,12 +351,18 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 			if !pe.Fallbackable() {
 				p.recordFailureTelemetry(req.Metadata, attempt, pe, latency, false)
 				p.log.Debug("attempt not fallbackable, aborting", "kind", pe.Kind)
-				pe, cost := p.recordAttemptTerminal(ctx, req.Metadata, attempt, pe, core.Usage{},
+				pe, cost := p.recordAttemptTerminal(ctx, req.Metadata, attempt, pe, priorAttemptUsage,
 					latency, time.Since(requestStarted), 0, nil, fellBack)
 				p.budgetConfirm(scope, cost)
 				return nil, pe
 			}
-			nextAttempt, canFallback := planner.AfterFailure(ctx, attempt, pe)
+			var nextAttempt dispatch.Attempt
+			var canFallback bool
+			if repairRetry {
+				nextAttempt, canFallback = planner.AfterRepair(ctx, attempt, pe)
+			} else {
+				nextAttempt, canFallback = planner.AfterFailure(ctx, attempt, pe)
+			}
 			p.recordFailureTelemetry(req.Metadata, attempt, pe, latency, canFallback)
 			if !canFallback {
 				break
@@ -358,6 +375,11 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 				"provider", attempt.Target.Provider, "model", attempt.Target.Model, "kind", pe.Kind)
 			attempt = nextAttempt
 			continue
+		}
+
+		if priorAttemptUsage.PromptTokens != 0 || priorAttemptUsage.CompletionTokens != 0 ||
+			priorAttemptUsage.TotalTokens != 0 {
+			resp.Usage = addAttemptUsage(priorAttemptUsage, resp.Usage)
 		}
 
 		// Reset backoff and clear model cooldown on success.
@@ -406,7 +428,7 @@ func (p *Pipeline) Chat(ctx context.Context, req *core.ChatRequest, opts Options
 	if lastAttempt.Target.Provider == "" && lastAttempt.Target.Model == "" {
 		lastAttempt = attemptForTargets(opts.Targets)
 	}
-	pe, cost := p.recordAttemptTerminal(ctx, req.Metadata, lastAttempt, lastErr, core.Usage{},
+	pe, cost := p.recordAttemptTerminal(ctx, req.Metadata, lastAttempt, lastErr, priorAttemptUsage,
 		lastLatency, time.Since(requestStarted), 0, nil, fellBack)
 	p.budgetConfirm(scope, cost)
 	return nil, pe
@@ -1060,6 +1082,33 @@ func mergeUsage(old, new core.Usage) core.Usage {
 	return old
 }
 
+func addAttemptUsage(total, attempt core.Usage) core.Usage {
+	totalTokens := total.TotalTokens
+	if totalTokens == 0 {
+		totalTokens = total.PromptTokens + total.CompletionTokens
+	}
+	attemptTokens := attempt.TotalTokens
+	if attemptTokens == 0 {
+		attemptTokens = attempt.PromptTokens + attempt.CompletionTokens
+	}
+
+	total.PromptTokens += attempt.PromptTokens
+	total.CompletionTokens += attempt.CompletionTokens
+	total.TotalTokens = totalTokens + attemptTokens
+	total.CachedTokens += attempt.CachedTokens
+	total.CacheWriteTokens += attempt.CacheWriteTokens
+	total.ReasoningTokens += attempt.ReasoningTokens
+
+	switch {
+	case total.Source == "":
+		total.Source = attempt.Source
+	case attempt.Source == "":
+	case total.Source != attempt.Source:
+		total.Source = core.UsageSourceEstimated
+	}
+	return total
+}
+
 // preflight runs validation and the budget guard before any upstream call.
 // It uses Reserve() instead of Check() to prevent the TOCTOU race where
 // concurrent requests all pass the budget check before any usage is recorded.
@@ -1653,6 +1702,20 @@ func (p *Pipeline) cacheStore(ctx context.Context, vec []float32, resp *core.Cha
 func cloneForAttempt(req *core.ChatRequest, model string) *core.ChatRequest {
 	clone := *req
 	clone.Model = model
+	return &clone
+}
+
+func cloneWithSystemInstruction(req *core.ChatRequest, instruction string) *core.ChatRequest {
+	clone := *req
+	instruction = strings.TrimSpace(instruction)
+	if instruction == "" {
+		return &clone
+	}
+	if strings.TrimSpace(clone.System) == "" {
+		clone.System = instruction
+	} else {
+		clone.System += "\n\n" + instruction
+	}
 	return &clone
 }
 

--- a/backend/internal/pipeline/pipeline_test.go
+++ b/backend/internal/pipeline/pipeline_test.go
@@ -188,6 +188,40 @@ func TestMergeUsage(t *testing.T) {
 	}
 }
 
+func TestAddAttemptUsageSumsCompletedAttempts(t *testing.T) {
+	first := core.Usage{
+		PromptTokens: 10, CompletionTokens: 4, TotalTokens: 14,
+		CachedTokens: 3, Source: core.UsageSourceProvider,
+	}
+	second := core.Usage{
+		PromptTokens: 12, CompletionTokens: 8, TotalTokens: 20,
+		ReasoningTokens: 2, Source: core.UsageSourceProvider,
+	}
+	total := addAttemptUsage(first, second)
+
+	if total.PromptTokens != 22 || total.CompletionTokens != 12 || total.TotalTokens != 34 {
+		t.Fatalf("unexpected summed usage: %+v", total)
+	}
+	if total.CachedTokens != 3 || total.ReasoningTokens != 2 {
+		t.Fatalf("usage details were not summed: %+v", total)
+	}
+	if total.Source != core.UsageSourceProvider {
+		t.Fatalf("usage source = %q, want provider", total.Source)
+	}
+}
+
+func TestCloneWithSystemInstructionDoesNotMutateOriginal(t *testing.T) {
+	req := &core.ChatRequest{System: "original"}
+	clone := cloneWithSystemInstruction(req, "repair")
+
+	if req.System != "original" {
+		t.Fatalf("original request was mutated: %q", req.System)
+	}
+	if clone.System != "original\n\nrepair" {
+		t.Fatalf("clone system = %q", clone.System)
+	}
+}
+
 func TestSafeBuffer_SmallStream(t *testing.T) {
 	var buf safeBuffer
 	data := []byte("hello world")

--- a/backend/internal/transform/kiro.go
+++ b/backend/internal/transform/kiro.go
@@ -1,6 +1,8 @@
 package transform
 
 import (
+	"container/list"
+	"crypto/sha256"
 	"fmt"
 	"strconv"
 	"strings"
@@ -14,15 +16,109 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
 
-var kiroSessionIDs sync.Map
+const (
+	kiroSessionTTL        = 24 * time.Hour
+	kiroSessionMaxEntries = 10_000
+)
 
-func kiroResolveConversationID(affinityKey string) string {
-	if affinityKey == "" {
+type kiroSessionEntry struct {
+	scope     string
+	id        string
+	expiresAt time.Time
+}
+
+type kiroSessionCache struct {
+	mu         sync.Mutex
+	entries    map[string]*list.Element
+	recency    *list.List
+	ttl        time.Duration
+	maxEntries int
+	now        func() time.Time
+}
+
+func newKiroSessionCache(ttl time.Duration, maxEntries int) *kiroSessionCache {
+	return &kiroSessionCache{
+		entries:    make(map[string]*list.Element),
+		recency:    list.New(),
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		now:        time.Now,
+	}
+}
+
+var kiroSessions = newKiroSessionCache(kiroSessionTTL, kiroSessionMaxEntries)
+
+func (c *kiroSessionCache) resolve(scope string) string {
+	if scope == "" || c == nil || c.maxEntries <= 0 || c.ttl <= 0 {
 		return uuid.NewString()
 	}
-	id := uuid.NewString()
-	actual, _ := kiroSessionIDs.LoadOrStore(affinityKey, id)
-	return actual.(string)
+
+	now := c.now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, ok := c.entries[scope]; ok {
+		entry := elem.Value.(*kiroSessionEntry)
+		if entry.expiresAt.After(now) {
+			entry.expiresAt = now.Add(c.ttl)
+			c.recency.MoveToFront(elem)
+			return entry.id
+		}
+		c.remove(elem)
+	}
+
+	for {
+		elem := c.recency.Back()
+		if elem == nil {
+			break
+		}
+		entry := elem.Value.(*kiroSessionEntry)
+		if entry.expiresAt.After(now) {
+			break
+		}
+		c.remove(elem)
+	}
+	for len(c.entries) >= c.maxEntries {
+		c.remove(c.recency.Back())
+	}
+
+	entry := &kiroSessionEntry{
+		scope:     scope,
+		id:        uuid.NewString(),
+		expiresAt: now.Add(c.ttl),
+	}
+	c.entries[scope] = c.recency.PushFront(entry)
+	return entry.id
+}
+
+func (c *kiroSessionCache) remove(elem *list.Element) {
+	if elem == nil {
+		return
+	}
+	entry := elem.Value.(*kiroSessionEntry)
+	delete(c.entries, entry.scope)
+	c.recency.Remove(elem)
+}
+
+func kiroConversationScope(req *core.ChatRequest, profileArn, accountID string) string {
+	if req == nil || req.Metadata.ContextAffinityKey == "" {
+		return ""
+	}
+	raw := strings.Join([]string{
+		req.Metadata.TenantID,
+		req.Metadata.ProjectID,
+		req.Metadata.APIKeyID,
+		accountID,
+		profileArn,
+		req.Model,
+		req.Metadata.ContextAffinityKey,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(raw))
+	return string(sum[:])
+}
+
+func kiroResolveConversationID(req *core.ChatRequest, profileArn, accountID string) string {
+	return kiroSessions.resolve(kiroConversationScope(req, profileArn, accountID))
 }
 
 // KiroCodec renders canonical requests to AWS CodeWhisperer's
@@ -227,6 +323,14 @@ func (c KiroCodec) RenderRequest(req *core.ChatRequest) ([]byte, error) {
 // the profileArn resolved for that key. OAuth/social connections pass "" here
 // since their tokens are accepted without an explicit profile.
 func (KiroCodec) RenderRequestWithProfile(req *core.ChatRequest, profileArn string) ([]byte, error) {
+	return KiroCodec{}.renderRequest(req, profileArn, "")
+}
+
+func (KiroCodec) RenderRequestForAccount(req *core.ChatRequest, profileArn, accountID string) ([]byte, error) {
+	return KiroCodec{}.renderRequest(req, profileArn, accountID)
+}
+
+func (KiroCodec) renderRequest(req *core.ChatRequest, profileArn, accountID string) ([]byte, error) {
 	upstream, agentic, modelThinking := resolveKiroModel(req.Model)
 
 	thinking := modelThinking || kiroThinkingEnabled(req, req.Model)
@@ -254,7 +358,7 @@ func (KiroCodec) RenderRequestWithProfile(req *core.ChatRequest, profileArn stri
 	payload := map[string]any{
 		"conversationState": map[string]any{
 			"chatTriggerType": "MANUAL",
-			"conversationId":  kiroResolveConversationID(req.Metadata.ContextAffinityKey),
+			"conversationId":  kiroResolveConversationID(req, profileArn, accountID),
 			"currentMessage":  map[string]any{"userInputMessage": current},
 			"history":         history,
 		},

--- a/backend/internal/transform/kiro_test.go
+++ b/backend/internal/transform/kiro_test.go
@@ -3,7 +3,9 @@ package transform
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
@@ -1234,78 +1236,150 @@ func TestNormalizeKiroVersionDashes(t *testing.T) {
 	}
 }
 
-func TestKiroResolveConversationID_StickyPerKey(t *testing.T) {
-	key := "test-affinity-key-" + t.Name()
-	kiroSessionIDs.Delete(key)
-	t.Cleanup(func() { kiroSessionIDs.Delete(key) })
+func TestKiroSessionCacheStickyUntilTTL(t *testing.T) {
+	now := time.Unix(1000, 0)
+	cache := newKiroSessionCache(time.Hour, 4)
+	cache.now = func() time.Time { return now }
 
-	id1 := kiroResolveConversationID(key)
-	id2 := kiroResolveConversationID(key)
+	id1 := cache.resolve("scope")
+	id2 := cache.resolve("scope")
 	if id1 != id2 {
-		t.Errorf("same affinity key should return same conversationId: %q != %q", id1, id2)
+		t.Errorf("same scope should return same conversationId: %q != %q", id1, id2)
 	}
-	if id1 == "" {
-		t.Error("conversationId should not be empty")
-	}
-}
-
-func TestKiroResolveConversationID_EmptyKeyNewEachTime(t *testing.T) {
-	id1 := kiroResolveConversationID("")
-	id2 := kiroResolveConversationID("")
-	if id1 == id2 {
-		t.Error("empty affinity key should produce distinct conversationIds each call")
+	now = now.Add(time.Hour + time.Second)
+	id3 := cache.resolve("scope")
+	if id3 == id1 {
+		t.Error("expired scope should receive a new conversationId")
 	}
 }
 
-func TestKiroResolveConversationID_DifferentKeysDistinct(t *testing.T) {
-	k1 := "session-a-" + t.Name()
-	k2 := "session-b-" + t.Name()
-	kiroSessionIDs.Delete(k1)
-	kiroSessionIDs.Delete(k2)
-	t.Cleanup(func() {
-		kiroSessionIDs.Delete(k1)
-		kiroSessionIDs.Delete(k2)
-	})
+func TestKiroSessionCacheEvictsLeastRecentEntryAtCapacity(t *testing.T) {
+	cache := newKiroSessionCache(time.Hour, 2)
+	firstB := cache.resolve("b")
+	_ = cache.resolve("a")
+	_ = cache.resolve("b")
+	_ = cache.resolve("c")
 
-	id1 := kiroResolveConversationID(k1)
-	id2 := kiroResolveConversationID(k2)
-	if id1 == id2 {
-		t.Errorf("different affinity keys should produce different conversationIds: both %q", id1)
+	if len(cache.entries) != 2 {
+		t.Fatalf("cache entries = %d, want 2", len(cache.entries))
+	}
+	if secondB := cache.resolve("b"); secondB != firstB {
+		t.Error("recently used entry should not be evicted")
+	}
+	if _, ok := cache.entries["a"]; ok {
+		t.Error("least recently used entry should be evicted")
 	}
 }
 
-func TestKiro_RenderRequest_UsesAffinityKeyForConversationID(t *testing.T) {
-	key := "render-affinity-" + t.Name()
-	kiroSessionIDs.Delete(key)
-	t.Cleanup(func() { kiroSessionIDs.Delete(key) })
+func TestKiroSessionCacheConcurrentResolveIsSticky(t *testing.T) {
+	cache := newKiroSessionCache(time.Hour, 4)
+	const workers = 64
+	ids := make(chan string, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			ids <- cache.resolve("scope")
+		}()
+	}
+	wg.Wait()
+	close(ids)
 
+	var first string
+	for id := range ids {
+		if first == "" {
+			first = id
+			continue
+		}
+		if id != first {
+			t.Fatalf("concurrent resolves returned different conversationIds: %q != %q", first, id)
+		}
+	}
+}
+
+func TestKiroResolveConversationIDScopesAccountTenantAndModel(t *testing.T) {
+	req := &core.ChatRequest{
+		Model: "claude-sonnet-4.5",
+		Metadata: core.RequestMetadata{
+			TenantID:           "tenant-a",
+			ProjectID:          "project-a",
+			APIKeyID:           "key-a",
+			ContextAffinityKey: "session-" + t.Name(),
+		},
+	}
+	id := kiroResolveConversationID(req, "profile-a", "account-a")
+	if again := kiroResolveConversationID(req, "profile-a", "account-a"); again != id {
+		t.Errorf("same scope should stay sticky: %q != %q", id, again)
+	}
+	if other := kiroResolveConversationID(req, "profile-a", "account-b"); other == id {
+		t.Error("different accounts must not share a conversationId")
+	}
+
+	otherTenant := *req
+	otherTenant.Metadata.TenantID = "tenant-b"
+	if other := kiroResolveConversationID(&otherTenant, "profile-a", "account-a"); other == id {
+		t.Error("different tenants must not share a conversationId")
+	}
+
+	otherModel := *req
+	otherModel.Model = "claude-opus-4.5"
+	if other := kiroResolveConversationID(&otherModel, "profile-a", "account-a"); other == id {
+		t.Error("different models must not share a conversationId")
+	}
+}
+
+func TestKiroResolveConversationIDWithoutAffinityIsNotSticky(t *testing.T) {
+	req := &core.ChatRequest{Model: "claude-sonnet-4.5"}
+	first := kiroResolveConversationID(req, "profile-a", "account-a")
+	second := kiroResolveConversationID(req, "profile-a", "account-a")
+	if first == second {
+		t.Error("requests without an affinity key must receive independent conversationIds")
+	}
+}
+
+func TestKiroRenderRequestUsesAccountScopedConversationID(t *testing.T) {
 	req := &core.ChatRequest{
 		Model:    "claude-sonnet-4.5",
 		Messages: []core.Message{{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}}},
-		Metadata: core.RequestMetadata{ContextAffinityKey: key},
+		Metadata: core.RequestMetadata{
+			TenantID: "tenant", APIKeyID: "key",
+			ContextAffinityKey: "render-affinity-" + t.Name(),
+		},
 	}
 
-	body1, err := KiroCodec{}.RenderRequest(req)
+	body1, err := KiroCodec{}.RenderRequestForAccount(req, "profile", "account-a")
 	if err != nil {
 		t.Fatal(err)
 	}
-	body2, err := KiroCodec{}.RenderRequest(req)
+	body2, err := KiroCodec{}.RenderRequestForAccount(req, "profile", "account-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body3, err := KiroCodec{}.RenderRequestForAccount(req, "profile", "account-b")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var env1, env2 map[string]any
+	var env1, env2, env3 map[string]any
 	if err := json.Unmarshal(body1, &env1); err != nil {
 		t.Fatal(err)
 	}
 	if err := json.Unmarshal(body2, &env2); err != nil {
 		t.Fatal(err)
 	}
+	if err := json.Unmarshal(body3, &env3); err != nil {
+		t.Fatal(err)
+	}
 
 	cs1 := env1["conversationState"].(map[string]any)
 	cs2 := env2["conversationState"].(map[string]any)
+	cs3 := env3["conversationState"].(map[string]any)
 	if cs1["conversationId"] != cs2["conversationId"] {
 		t.Errorf("same affinity key should produce same conversationId across renders: %q != %q",
 			cs1["conversationId"], cs2["conversationId"])
+	}
+	if cs1["conversationId"] == cs3["conversationId"] {
+		t.Error("different accounts must render different conversationIds")
 	}
 }


### PR DESCRIPTION
## Summary

- validate Kiro tool-use payloads and truncated AWS EventStream frames instead of silently accepting malformed responses
- route one response-integrity repair retry through the central pipeline with account fallback
- preserve usage from completed attempts that are discarded and retried
- scope Kiro conversation sessions by tenant, project, API key, account, profile, model, and affinity
- bound the session cache with expiration and least-recently-used eviction

## Behavior

- malformed tool calls and clearly incomplete final responses trigger one repair attempt
- retry planning prefers another healthy account and can reuse the original attempt when no alternative is available
- prompt and completion usage from every completed attempt remains billable and observable
- truncated event streams surface an upstream error instead of appearing as a clean end of stream
- unrelated accounts and conversations no longer share provider-side conversation IDs

## Coverage

- response-integrity retry and fallback planning
- accumulated usage across repair attempts
- malformed and valid tool-use events
- fragmented, truncated, and zero-byte event-stream reads
- session reuse, isolation, expiration, and bounded eviction
