### PR TITLE
fix: grok-cli proxy headers, effort model aliases, and foreign import body limit

### DIFF
--- a/backend/internal/connectors/openai_responses.go
+++ b/backend/internal/connectors/openai_responses.go
@@ -25,6 +25,17 @@ type OpenAIResponses struct {
 	codec       transform.OpenAIResponsesCodec
 }
 
+// Identity headers required by cli-chat-proxy.grok.com for the grok-cli
+// provider. Without x-grok-client-version the proxy returns HTTP 426 with
+// "Your Grok CLI version (none) is outdated".
+const (
+	grokCLIVersion          = "0.2.93"
+	grokCLIClientIdentifier = "grok-shell"
+	grokCLITokenAuth        = "xai-grok-cli"
+	grokCLIAuthenticateResp = "authenticate-response"
+	grokCLIClientMode       = "headless"
+)
+
 // NewOpenAIResponses builds a Responses connector.
 func NewOpenAIResponses(id, defaultBaseURL string) *OpenAIResponses {
 	return &OpenAIResponses{id: id, defaultBase: defaultBaseURL}
@@ -87,6 +98,14 @@ func (c *OpenAIResponses) headers(creds core.Credentials) map[string]string {
 		h["Authorization"] = bearer(creds.AccessToken)
 	case creds.APIKey != "":
 		h["Authorization"] = bearer(creds.APIKey)
+	}
+	if c.id == "grok-cli" {
+		h["x-grok-client-version"] = grokCLIVersion
+		h["x-grok-client-identifier"] = grokCLIClientIdentifier
+		h["X-XAI-Token-Auth"] = grokCLITokenAuth
+		h["x-authenticateresponse"] = grokCLIAuthenticateResp
+		h["x-grok-client-mode"] = grokCLIClientMode
+		h["User-Agent"] = fmt.Sprintf("grok-shell/%s (linux; x86_64)", grokCLIVersion)
 	}
 	return mergeHeaders(h, creds.Headers)
 }
@@ -194,7 +213,7 @@ func (c *OpenAIResponses) Stream(ctx context.Context, req *core.ChatRequest, cre
 		// so Codex clients don't hang waiting for a terminal event.
 		if !terminalSeen {
 			out <- core.StreamChunk{
-				Type: core.ChunkText,
+				Type:  core.ChunkText,
 				Delta: formatResponsesFailureAndDone(),
 			}
 		}

--- a/backend/internal/connectors/openai_responses_headers_test.go
+++ b/backend/internal/connectors/openai_responses_headers_test.go
@@ -1,0 +1,54 @@
+package connectors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIResponsesGrokCLIHeaders(t *testing.T) {
+	c := NewOpenAIResponses("grok-cli", "https://cli-chat-proxy.grok.com/v1/responses")
+
+	headers := c.headers(core.Credentials{AccessToken: "tok_test"})
+
+	require.Equal(t, "Bearer tok_test", headers["Authorization"])
+	require.Equal(t, grokCLIVersion, headers["x-grok-client-version"])
+	require.Equal(t, grokCLIClientIdentifier, headers["x-grok-client-identifier"])
+	require.Equal(t, grokCLITokenAuth, headers["X-XAI-Token-Auth"])
+	require.Equal(t, grokCLIAuthenticateResp, headers["x-authenticateresponse"])
+	require.Equal(t, grokCLIClientMode, headers["x-grok-client-mode"])
+	require.Equal(t, fmt.Sprintf("grok-shell/%s (linux; x86_64)", grokCLIVersion), headers["User-Agent"])
+}
+
+func TestOpenAIResponsesGrokCLIHeadersAllowOverrides(t *testing.T) {
+	c := NewOpenAIResponses("grok-cli", "https://cli-chat-proxy.grok.com/v1/responses")
+
+	headers := c.headers(core.Credentials{
+		AccessToken: "tok_test",
+		Headers: map[string]string{
+			"x-grok-client-version": "9.9.9",
+			"User-Agent":            "custom-ua",
+		},
+	})
+
+	require.Equal(t, "Bearer tok_test", headers["Authorization"])
+	require.Equal(t, "9.9.9", headers["x-grok-client-version"])
+	require.Equal(t, "custom-ua", headers["User-Agent"])
+	require.Equal(t, grokCLIClientIdentifier, headers["x-grok-client-identifier"])
+}
+
+func TestOpenAIResponsesCodexHeadersUnaffected(t *testing.T) {
+	c := NewOpenAIResponses("codex", "https://chatgpt.com/backend-api/codex/responses")
+
+	headers := c.headers(core.Credentials{AccessToken: "tok_test"})
+
+	require.Equal(t, "Bearer tok_test", headers["Authorization"])
+	require.Empty(t, headers["x-grok-client-version"])
+	require.Empty(t, headers["x-grok-client-identifier"])
+	require.Empty(t, headers["X-XAI-Token-Auth"])
+	require.Empty(t, headers["x-authenticateresponse"])
+	require.Empty(t, headers["x-grok-client-mode"])
+	require.Empty(t, headers["User-Agent"])
+}

--- a/backend/internal/gateway/admin_foreign_import.go
+++ b/backend/internal/gateway/admin_foreign_import.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,11 @@ import (
 	"github.com/mydisha/keirouter/backend/internal/store"
 	"github.com/mydisha/keirouter/backend/internal/vault"
 )
+
+// foreignImportMaxBytes caps 9router/OmniRoute backup JSON uploads.
+// Larger than chat maxBodyBytes because full router exports can include
+// many accounts, combos, and provider nodes in one document.
+const foreignImportMaxBytes = 64 << 20 // 64 MiB
 
 // Foreign config import: convert a 9router (or OmniRoute) backup JSON into
 // KeiRouter's native data model. Credentials are re-sealed under the local
@@ -51,8 +57,14 @@ type foreignImportResult struct {
 func (s *Server) adminImportForeignConfig(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4<<20))
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, foreignImportMaxBytes))
 	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge,
+				fmt.Sprintf("import body too large: max %d MiB", foreignImportMaxBytes>>20))
+			return
+		}
 		writeError(w, http.StatusBadRequest, "read body: "+err.Error())
 		return
 	}

--- a/backend/internal/gateway/admin_foreign_import_body_test.go
+++ b/backend/internal/gateway/admin_foreign_import_body_test.go
@@ -1,0 +1,39 @@
+package gateway
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// zeroReader returns infinite zero bytes without allocating a large buffer.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func TestAdminImportForeignConfigBodyTooLarge(t *testing.T) {
+	s, _ := newBulkTestServer(t)
+
+	// Stream slightly more than the cap without allocating 64 MiB.
+	body := io.LimitReader(zeroReader{}, foreignImportMaxBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/admin/import/foreign", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.adminImportForeignConfig(rec, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	msg := rec.Body.String()
+	require.True(t,
+		strings.Contains(msg, "too large") || strings.Contains(msg, "64") || strings.Contains(msg, "MiB"),
+		"expected oversized body message, got %q", msg)
+}

--- a/backend/internal/transform/openai_responses.go
+++ b/backend/internal/transform/openai_responses.go
@@ -318,8 +318,17 @@ func rawToString(raw json.RawMessage) string {
 // ---- request rendering (outbound to Codex/Responses provider) ---------------
 
 func (OpenAIResponsesCodec) RenderRequest(req *core.ChatRequest) ([]byte, error) {
+	// Catalog aliases like grok-4.5-high / gpt-5.3-codex-high are not real
+	// upstream model IDs. Strip the effort suffix and emit reasoning.effort
+	// instead. Explicit req.Reasoning.Effort wins over the suffix value.
+	model, suffixEffort := splitResponsesEffortModel(req.Model)
+	effort := suffixEffort
+	if req.Reasoning != nil && strings.TrimSpace(req.Reasoning.Effort) != "" {
+		effort = strings.TrimSpace(req.Reasoning.Effort)
+	}
+
 	out := map[string]any{
-		"model":  req.Model,
+		"model":  model,
 		"stream": req.Stream,
 		"store":  false,
 	}
@@ -327,6 +336,9 @@ func (OpenAIResponsesCodec) RenderRequest(req *core.ChatRequest) ([]byte, error)
 		out["instructions"] = req.System
 	} else {
 		out["instructions"] = ""
+	}
+	if isResponsesReasoningEffortEnabled(effort) {
+		out["reasoning"] = map[string]any{"effort": effort}
 	}
 	// NOTE: temperature, max_tokens, top_p are intentionally NOT included.
 	// These are Chat Completions parameters that the Responses API does not
@@ -454,6 +466,27 @@ func (OpenAIResponsesCodec) RenderRequest(req *core.ChatRequest) ([]byte, error)
 	}
 
 	return json.Marshal(out)
+}
+
+// splitResponsesEffortModel peels a trailing effort suffix off a synthetic
+// catalog model id (e.g. "grok-4.5-high" → "grok-4.5", "high"). Longest
+// suffixes are checked first so "-xhigh" wins over "-high".
+func splitResponsesEffortModel(model string) (base, effort string) {
+	for _, suf := range []string{"-xhigh", "-high", "-medium", "-low", "-none"} {
+		if strings.HasSuffix(model, suf) && len(model) > len(suf) {
+			return strings.TrimSuffix(model, suf), strings.TrimPrefix(suf, "-")
+		}
+	}
+	return model, ""
+}
+
+func isResponsesReasoningEffortEnabled(effort string) bool {
+	switch strings.ToLower(strings.TrimSpace(effort)) {
+	case "", "none", "off", "disable", "disabled":
+		return false
+	default:
+		return true
+	}
 }
 
 // ---- unary response parsing (from Codex/Responses provider) -----------------

--- a/backend/internal/transform/openai_responses_test.go
+++ b/backend/internal/transform/openai_responses_test.go
@@ -397,6 +397,103 @@ func TestResponses_RenderRequest_WithTools(t *testing.T) {
 	require.Equal(t, "get_weather", parsed.Tools[0].Name)
 }
 
+func TestResponses_RenderRequest_EffortSuffixModel(t *testing.T) {
+	tests := []struct {
+		name          string
+		model         string
+		reasoning     *core.ReasoningConfig
+		wantModel     string
+		wantEffort    string
+		wantReasoning bool
+	}{
+		{
+			name:          "grok high suffix",
+			model:         "grok-4.5-high",
+			wantModel:     "grok-4.5",
+			wantEffort:    "high",
+			wantReasoning: true,
+		},
+		{
+			name:          "grok medium suffix",
+			model:         "grok-4.5-medium",
+			wantModel:     "grok-4.5",
+			wantEffort:    "medium",
+			wantReasoning: true,
+		},
+		{
+			name:          "grok low suffix",
+			model:         "grok-4.5-low",
+			wantModel:     "grok-4.5",
+			wantEffort:    "low",
+			wantReasoning: true,
+		},
+		{
+			name:          "base model no reasoning",
+			model:         "grok-4.5",
+			wantModel:     "grok-4.5",
+			wantReasoning: false,
+		},
+		{
+			name:          "explicit effort wins",
+			model:         "grok-4.5",
+			reasoning:     &core.ReasoningConfig{Effort: "high"},
+			wantModel:     "grok-4.5",
+			wantEffort:    "high",
+			wantReasoning: true,
+		},
+		{
+			name:          "explicit effort wins over suffix",
+			model:         "grok-4.5-low",
+			reasoning:     &core.ReasoningConfig{Effort: "high"},
+			wantModel:     "grok-4.5",
+			wantEffort:    "high",
+			wantReasoning: true,
+		},
+		{
+			name:          "codex high suffix",
+			model:         "gpt-5.3-codex-high",
+			wantModel:     "gpt-5.3-codex",
+			wantEffort:    "high",
+			wantReasoning: true,
+		},
+		{
+			name:          "none suffix strips without reasoning",
+			model:         "grok-4.5-none",
+			wantModel:     "grok-4.5",
+			wantReasoning: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &core.ChatRequest{
+				Model:     tc.model,
+				Reasoning: tc.reasoning,
+				Messages: []core.Message{
+					{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+				},
+			}
+			body, err := OpenAIResponsesCodec{}.RenderRequest(req)
+			require.NoError(t, err)
+
+			var parsed struct {
+				Model     string `json:"model"`
+				Reasoning *struct {
+					Effort string `json:"effort"`
+				} `json:"reasoning"`
+			}
+			require.NoError(t, json.Unmarshal(body, &parsed))
+			require.Equal(t, tc.wantModel, parsed.Model)
+			if tc.wantReasoning {
+				require.NotNil(t, parsed.Reasoning)
+				require.Equal(t, tc.wantEffort, parsed.Reasoning.Effort)
+			} else {
+				require.Nil(t, parsed.Reasoning)
+			}
+		})
+	}
+}
+
 func toStrings(b [][]byte) []string {
 	out := make([]string, len(b))
 	for i, x := range b {


### PR DESCRIPTION
## Summary
   - Send Grok CLI proxy identity headers for `grok-cli` so requests no longer fail with HTTP 426 (`Your Grok CLI version (none) is outdated`).
   - Map Responses catalog effort suffixes like `grok-4.5-high` to the real upstream model (`grok-4.5`) plus `reasoning.effort`.
   - Raise 9router/OmniRoute foreign import max body size from **4 MiB → 64 MiB**, and return a clear **413** when the backup is still too large.

   ## Context
   After importing a 9router backup and wiring `grok-cli`, two failures blocked usage:

   1. **Foreign import** rejected large JSON dumps with:
      `read body: http: request body too large`
   2. **Grok CLI** chat failed with:
      - first: version gate `426` because no CLI identity headers were sent
      - then: `400 Model not found: grok-4.5-high` because catalog aliases were forwarded as literal model IDs

   ## Changes
   ### `backend/internal/connectors/openai_responses.go`
   For provider id `grok-cli`, inject cli-chat-proxy identity headers:
   - `x-grok-client-version`
   - `x-grok-client-identifier`
   - `X-XAI-Token-Auth`
   - `x-authenticateresponse`
   - `x-grok-client-mode`
   - `User-Agent`

   ### `backend/internal/transform/openai_responses.go`
   In `RenderRequest`:
   - strip trailing effort suffixes (`-xhigh`, `-high`, `-medium`, `-low`, `-none`)
   - emit `reasoning.effort` when effort is enabled
   - explicit `req.Reasoning.Effort` wins over suffix-derived effort

   ### `backend/internal/gateway/admin_foreign_import.go`
   - replace hard-coded `4<<20` with `foreignImportMaxBytes = 64 << 20`
   - map `*http.MaxBytesError` → HTTP 413 with `import body too large: max 64 MiB`

   ### Tests
   - `openai_responses_headers_test.go`
   - effort-suffix render coverage in `openai_responses_test.go`
   - `admin_foreign_import_body_test.go` for oversized body handling

   ## Notes / residual risks
   - Grok client version is pinned (`0.2.93`) and may need future bumps if the proxy raises its minimum.
   - Effort-suffix stripping is generic for Responses providers; it assumes catalog aliases, not real upstream model IDs ending in those suffixes.
   - Foreign import still loads the full JSON into memory; dumps larger than 64 MiB will still be rejected (now with a clearer error).