### PR TITLE
fix: stabilize account handling for credits, backoff, and codex + Qoder PAT support

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -38,6 +38,11 @@ type ServerConfig struct {
 	Port int    `koanf:"port"`
 	// StreamStallTimeout aborts a stream that produces no bytes for this long.
 	StreamStallTimeout time.Duration `koanf:"stream_stall_timeout"`
+	// StreamHeartbeatInterval emits an SSE comment on client streams that have
+	// been silent for this long, so reverse proxies and load balancers between
+	// KeiRouter and the client do not drop the connection as idle while the
+	// upstream model is thinking. Zero disables heartbeats.
+	StreamHeartbeatInterval time.Duration `koanf:"stream_heartbeat_interval"`
 	// RequestTimeout bounds non-streaming upstream calls.
 	RequestTimeout time.Duration `koanf:"request_timeout"`
 	// CORSOrigins lists allowed dashboard origins ("*" permitted for local).
@@ -258,8 +263,11 @@ func Default() Config {
 			// 60s prevents premature stall timeouts for codex/Responses
 			// streams which may have longer thinking periods between chunks.
 			StreamStallTimeout: 60 * time.Second,
-			RequestTimeout:     5 * time.Minute,
-			CORSOrigins:        []string{"*"},
+			// 15s keeps connections alive through common proxy idle timeouts
+			// (nginx defaults to 60s) without meaningful bandwidth cost.
+			StreamHeartbeatInterval: 15 * time.Second,
+			RequestTimeout:          5 * time.Minute,
+			CORSOrigins:             []string{"*"},
 		},
 		Database: DatabaseConfig{
 			Driver:          "sqlite",

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 func TestLoadAllowPrivateBaseURLFromEnv(t *testing.T) {
@@ -34,6 +35,35 @@ func TestLoadAllowPrivateBaseURLFromEnv(t *testing.T) {
 				t.Fatalf("AllowPrivateBaseURL = false, want true")
 			}
 		})
+	}
+}
+
+func TestStreamHeartbeatIntervalConfig(t *testing.T) {
+	if got := Default().Server.StreamHeartbeatInterval; got != 15*time.Second {
+		t.Fatalf("default StreamHeartbeatInterval = %v, want 15s", got)
+	}
+
+	path := t.TempDir() + "/config.yaml"
+	if err := os.WriteFile(path, []byte("server:\n  stream_heartbeat_interval: 9s\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got := cfg.Server.StreamHeartbeatInterval; got != 9*time.Second {
+		t.Fatalf("StreamHeartbeatInterval = %v, want 9s", got)
+	}
+}
+
+func TestStreamHeartbeatIntervalFromEnv(t *testing.T) {
+	t.Setenv("KEIROUTER_SERVER__STREAM_HEARTBEAT_INTERVAL", "7s")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got := cfg.Server.StreamHeartbeatInterval; got != 7*time.Second {
+		t.Fatalf("StreamHeartbeatInterval = %v, want 7s", got)
 	}
 }
 

--- a/backend/internal/connectors/catalog.go
+++ b/backend/internal/connectors/catalog.go
@@ -113,8 +113,9 @@ func freeProviders() []ProviderSpec {
 			Color: "#4285F4", Website: "https://github.com/google-gemini/gemini-cli", Deprecated: true, Notice: risk},
 		{ID: "qoder", DisplayName: "Qoder", Alias: "qd", Dialect: core.DialectQoder,
 			BaseURL:  "https://api3.qoder.sh/algo/api/v2/service/pro/sse/agent_chat_generation",
-			AuthKind: "oauth", AuthModes: []string{"oauth"}, ServiceKinds: llm(),
-			Color: "#EC4899", Website: "https://qoder.com", Deprecated: true, Notice: risk},
+			AuthKind: "oauth", AuthModes: []string{"oauth", "api_key"}, ServiceKinds: llm(),
+			Color: "#EC4899", Website: "https://qoder.com", APIKeyURL: "https://qoder.com/account/integrations",
+			Deprecated: true, Notice: risk},
 	}
 }
 

--- a/backend/internal/connectors/classify429.go
+++ b/backend/internal/connectors/classify429.go
@@ -31,6 +31,37 @@ var quotaPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)daily free allocation`),
 }
 
+// creditsPatterns matches provider error text indicating the account's paid
+// balance is depleted. Unlike calendar quotas these never recover on their
+// own — the user must top up or renew — so they warrant parking the account
+// rather than scheduling a quota-window cooldown.
+var creditsPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)insufficient[ _]?(?:credit|balance|fund)`),
+	regexp.MustCompile(`(?i)insufficient[ _]?quota`),
+	regexp.MustCompile(`(?i)out of credits`),
+	regexp.MustCompile(`(?i)no credits? remaining`),
+	regexp.MustCompile(`(?i)credit.{0,40}(?:exhaust|too low|deplet)`),
+	regexp.MustCompile(`(?i)balance.{0,40}(?:too low|insufficient|exhaust|deplet)`),
+	regexp.MustCompile(`(?i)(?:purchase|buy|add).{0,20}credits`),
+	regexp.MustCompile(`(?i)\btop[- ]?up\b`),
+	regexp.MustCompile(`(?i)payment required`),
+}
+
+// looksLikeCreditsExhausted reports whether the provider error body indicates
+// a depleted paid balance rather than a resettable quota or transient rate
+// limit. Used to classify errors into a terminal credits-exhausted state.
+func looksLikeCreditsExhausted(body string) bool {
+	if body == "" {
+		return false
+	}
+	for _, re := range creditsPatterns {
+		if re.MatchString(body) {
+			return true
+		}
+	}
+	return false
+}
+
 // rateLimitPatterns matches transient rate-limit text. These are short-term
 // backoffs, not long-term quota exhaustion.
 var rateLimitPatterns = []*regexp.Regexp{
@@ -212,10 +243,10 @@ func positiveDuration(at time.Time) time.Duration {
 	return 0
 }
 
-// classify429 determines whether a 429 response is a transient rate limit or
-// a hard quota exhaustion, and extracts any upstream-provided retry hint.
-// Returns (kind, retryAfter).
-func classify429(resp *http.Response, body []byte) (kind core.ErrorKind, retryAfter time.Duration) {
+// classify429 determines whether a 429 response is a transient rate limit, a
+// hard quota exhaustion, or a depleted paid balance, and extracts any
+// upstream-provided retry hint. Returns (kind, retryAfter, creditsExhausted).
+func classify429(resp *http.Response, body []byte) (kind core.ErrorKind, retryAfter time.Duration, creditsExhausted bool) {
 	// Extract retry hints from headers first.
 	retryAfter = parseResetFromHeaders(resp)
 	if retryAfter <= 0 {
@@ -223,14 +254,21 @@ func classify429(resp *http.Response, body []byte) (kind core.ErrorKind, retryAf
 	}
 
 	bodyStr := string(body)
-	// Hard quota exhaustion takes precedence: long cooldown, no point retrying
-	// before the calendar/quota window rolls over.
+	// A depleted balance takes precedence over everything: it never recovers
+	// on its own, so the dispatcher parks the account instead of scheduling a
+	// quota-window cooldown.
+	if looksLikeCreditsExhausted(bodyStr) {
+		return core.ErrQuotaExhausted, retryAfter, true
+	}
+
+	// Hard quota exhaustion next: long cooldown, no point retrying before the
+	// calendar/quota window rolls over.
 	if looksLikeQuotaExhausted(bodyStr) {
 		// If no explicit retry hint, use a conservative long default.
 		if retryAfter <= 0 {
 			retryAfter = 30 * time.Minute
 		}
-		return core.ErrQuotaExhausted, retryAfter
+		return core.ErrQuotaExhausted, retryAfter, false
 	}
 
 	// Transient rate limit: short exponential backoff. If no header hint,
@@ -238,5 +276,5 @@ func classify429(resp *http.Response, body []byte) (kind core.ErrorKind, retryAf
 	if retryAfter <= 0 {
 		retryAfter = 5 * time.Second
 	}
-	return core.ErrRateLimit, retryAfter
+	return core.ErrRateLimit, retryAfter, false
 }

--- a/backend/internal/connectors/classify429_test.go
+++ b/backend/internal/connectors/classify429_test.go
@@ -111,7 +111,7 @@ func TestClassify429_QuotaExhausted(t *testing.T) {
 	resp.Header.Set("Content-Type", "application/json")
 
 	body := []byte(`{"error": {"message": "daily free allocation used up", "type": "quota_error"}}`)
-	kind, retryAfter := classify429(resp, body)
+	kind, retryAfter, _ := classify429(resp, body)
 
 	require.Equal(t, core.ErrQuotaExhausted, kind)
 	require.Equal(t, 30*time.Minute, retryAfter, "default quota cooldown should be 30m")
@@ -122,7 +122,7 @@ func TestClassify429_QuotaExhausted_WithRetryAfter(t *testing.T) {
 	resp.Header.Set("Retry-After", "3600")
 
 	body := []byte(`{"error": {"message": "monthly quota exceeded"}}`)
-	kind, retryAfter := classify429(resp, body)
+	kind, retryAfter, _ := classify429(resp, body)
 
 	require.Equal(t, core.ErrQuotaExhausted, kind)
 	require.Equal(t, time.Hour, retryAfter, "should use upstream Retry-After for quota")
@@ -132,7 +132,7 @@ func TestClassify429_RateLimit(t *testing.T) {
 	resp := &http.Response{Header: http.Header{}}
 
 	body := []byte(`{"error": {"message": "too many requests", "type": "rate_limit"}}`)
-	kind, retryAfter := classify429(resp, body)
+	kind, retryAfter, _ := classify429(resp, body)
 
 	require.Equal(t, core.ErrRateLimit, kind)
 	require.Equal(t, 5*time.Second, retryAfter, "default rate-limit backoff should be 5s")
@@ -143,7 +143,7 @@ func TestClassify429_RateLimit_WithRetryAfter(t *testing.T) {
 	resp.Header.Set("Retry-After", "10")
 
 	body := []byte(`{"error": {"message": "rate limit exceeded"}}`)
-	kind, retryAfter := classify429(resp, body)
+	kind, retryAfter, _ := classify429(resp, body)
 
 	require.Equal(t, core.ErrRateLimit, kind)
 	require.Equal(t, 10*time.Second, retryAfter)
@@ -156,7 +156,7 @@ func TestClassify429_XRateLimitReset(t *testing.T) {
 	resp.Header.Set("X-RateLimit-Reset", strconv.FormatInt(resetTime, 10))
 
 	body := []byte(`{"error": {"message": "rate limit"}}`)
-	kind, retryAfter := classify429(resp, body)
+	kind, retryAfter, _ := classify429(resp, body)
 
 	require.Equal(t, core.ErrRateLimit, kind)
 	require.True(t, retryAfter > 55*time.Second && retryAfter <= 60*time.Second,
@@ -204,4 +204,88 @@ func TestHTTPStatusError_429RateLimit_RetryAfter(t *testing.T) {
 
 	require.Equal(t, core.ErrRateLimit, pe.Kind)
 	require.Equal(t, 2*time.Minute, pe.RetryAfter)
+}
+
+func TestLooksLikeCreditsExhausted(t *testing.T) {
+	tests := []struct {
+		body string
+		want bool
+	}{
+		{"", false},
+		{"rate limit exceeded", false},
+		{"daily quota exceeded", false},
+		{"insufficient credits", true},
+		{"Insufficient balance", true},
+		{"insufficient funds for this request", true},
+		{"insufficient_quota", true},
+		{"You exceeded your current quota, please check your plan and billing details. insufficient_quota", true},
+		{"out of credits", true},
+		{"no credits remaining", true},
+		{"Your credit balance is too low to access the API.", true},
+		{"account balance depleted", true},
+		{"please purchase more credits", true},
+		{"top up your account to continue", true},
+		{"stop updating the dashboard", false},
+		{"Payment Required", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.body, func(t *testing.T) {
+			if got := looksLikeCreditsExhausted(tt.body); got != tt.want {
+				t.Errorf("looksLikeCreditsExhausted(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassify429_CreditsExhausted(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	body := []byte(`{"error": {"message": "Insufficient credits. Please top up your account.", "type": "insufficient_quota"}}`)
+
+	kind, _, credits := classify429(resp, body)
+
+	require.Equal(t, core.ErrQuotaExhausted, kind)
+	require.True(t, credits, "a dry balance must be flagged as credits exhausted")
+}
+
+func TestHTTPStatusError_402SetsCreditsExhausted(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusPaymentRequired,
+		Header:     http.Header{},
+	}
+	body := []byte(`{"error": {"message": "Payment required"}}`)
+
+	pe := core.AsProviderError(httpStatusError("test", "model", resp, body))
+
+	require.Equal(t, core.ErrQuotaExhausted, pe.Kind)
+	require.True(t, pe.CreditsExhausted)
+	require.Equal(t, core.FailureScopeAccount, pe.EffectiveScope())
+}
+
+func TestHTTPStatusError_400CreditBalanceTooLow(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{},
+	}
+	body := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the API. Please go to Plans & Billing to upgrade or purchase credits."}}`)
+
+	pe := core.AsProviderError(httpStatusError("test", "model", resp, body))
+
+	require.Equal(t, core.ErrQuotaExhausted, pe.Kind,
+		"a 400 describing a dry balance must fall back, not surface as bad request")
+	require.True(t, pe.CreditsExhausted)
+	require.Equal(t, core.FailureScopeAccount, pe.EffectiveScope())
+}
+
+func TestHTTPStatusError_403InsufficientBalance(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{},
+	}
+	body := []byte(`{"error": {"message": "Insufficient Balance", "type": "unknown_error"}}`)
+
+	pe := core.AsProviderError(httpStatusError("test", "model", resp, body))
+
+	require.Equal(t, core.ErrQuotaExhausted, pe.Kind)
+	require.True(t, pe.CreditsExhausted)
 }

--- a/backend/internal/connectors/codex.go
+++ b/backend/internal/connectors/codex.go
@@ -1,0 +1,164 @@
+package connectors
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+// codexClientVersion mirrors the Codex CLI release the ChatGPT backend expects.
+// The /codex/models endpoint gates entries by minimal_client_version and the
+// responses endpoint favors requests that look like the official CLI, so keep
+// this reasonably current.
+const codexClientVersion = "0.144.0"
+
+// codexEffortLevels are the reasoning-effort suffixes accepted on Codex model
+// ids (e.g. "gpt-5.3-codex-high"). The ChatGPT Codex backend only knows base
+// model ids, so the suffix is stripped and folded into reasoning.effort.
+// "xhigh" is listed before "high" so the longer suffix wins. "max"/"ultra" are
+// deliberately absent: they collide with real model ids (gpt-5.1-codex-max)
+// and are only valid as gpt-5.6 alias suffixes (see codexGPT56AliasSuffix).
+var codexEffortLevels = []string{"xhigh", "high", "medium", "low", "minimal", "none"}
+
+// codexGPT56AliasSuffix matches the gpt-5.6 family's -max/-ultra effort alias
+// ids (e.g. "gpt-5.6-sol-ultra"), tolerating the dash-for-dot version typo.
+var codexGPT56AliasSuffix = regexp.MustCompile(`^(gpt-5[.-]6-(?:sol|terra|luna))-(max|ultra)$`)
+
+// codexModelAliases maps convenience ids to real ChatGPT Codex backend ids.
+// The backend has no bare "gpt-5.6"; the 5.6 family ships as sol/terra/luna.
+var codexModelAliases = map[string]string{
+	"gpt-5.6": "gpt-5.6-sol",
+}
+
+// codexDashVersion matches a dash between two digits ("gpt-5-6"), the common
+// misspelling of the dotted version ids ("gpt-5.6") Codex actually uses.
+// Sending the dashed form upstream fails with 400 "model is not supported".
+var codexDashVersion = regexp.MustCompile(`(\d)-(\d)`)
+
+// codexModelKnown reports whether id is in the curated Codex catalog.
+func codexModelKnown(id string) bool {
+	for _, spec := range providerModels["codex"] {
+		if spec.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveCodexModel normalizes a requested model id to the id the ChatGPT
+// Codex backend understands. It strips a reasoning-effort suffix (returned
+// separately), tolerates dash-for-dot version typos, and resolves aliases.
+// Unknown ids are passed through (the catalog may lag upstream releases);
+// the upstream 400 is then classified as model-unavailable for fallback.
+func resolveCodexModel(model string) (string, string) {
+	effort := ""
+	base := model
+	if m := codexGPT56AliasSuffix.FindStringSubmatch(base); m != nil {
+		base, effort = m[1], m[2]
+	} else {
+		for _, level := range codexEffortLevels {
+			if strings.HasSuffix(base, "-"+level) {
+				base = strings.TrimSuffix(base, "-"+level)
+				effort = level
+				break
+			}
+		}
+	}
+	if codexModelKnown(base) {
+		return base, effort
+	}
+	norm := codexDashVersion.ReplaceAllString(base, "$1.$2")
+	if alias, ok := codexModelAliases[norm]; ok {
+		return alias, effort
+	}
+	return norm, effort
+}
+
+// codexEffortsGPT56 is the wire enum the gpt-5.6 family accepts, taken from
+// the backend's own 400 message: "Supported values are: 'none', 'minimal',
+// 'low', 'medium', 'high', and 'max'." — note "max" replaced "xhigh".
+var codexEffortsGPT56 = map[string]bool{
+	"none": true, "minimal": true, "low": true, "medium": true, "high": true, "max": true,
+}
+
+// codexEffortsLegacy is the wire enum pre-5.6 Codex models accept (the
+// original codex CLI set, topping out at "xhigh").
+var codexEffortsLegacy = map[string]bool{
+	"none": true, "minimal": true, "low": true, "medium": true, "high": true, "xhigh": true,
+}
+
+// normalizeCodexEffort maps any client-supplied effort onto the wire enum the
+// target model actually accepts. Clients speak many dialects here: Claude Code
+// sends "adaptive", Responses clients send "xhigh"/"max"/"ultra", and the
+// backend hard-rejects values outside its per-family enum, so nothing may pass
+// through unvalidated.
+func normalizeCodexEffort(model, effort string) string {
+	e := strings.ToLower(strings.TrimSpace(effort))
+	switch e {
+	case "", "auto", "adaptive", "default":
+		// "Model decides" modes have no Codex wire value; use the CLI default.
+		e = "medium"
+	case "off", "disabled":
+		e = "none"
+	}
+	if strings.HasPrefix(model, "gpt-5.6") {
+		if e == "xhigh" || e == "ultra" {
+			// Ultra is a client-side delegation concept; the wire effort is max.
+			e = "max"
+		}
+		if !codexEffortsGPT56[e] {
+			e = "medium"
+		}
+		return e
+	}
+	if e == "max" || e == "ultra" {
+		e = "xhigh"
+	}
+	if !codexEffortsLegacy[e] {
+		e = "medium"
+	}
+	return e
+}
+
+// prepareCodexRequest normalizes the model id and reasoning config for the
+// ChatGPT Codex backend. It returns a shallow copy so a fallback to another
+// provider still dispatches with the caller's original request.
+func prepareCodexRequest(req *core.ChatRequest) *core.ChatRequest {
+	model, effort := resolveCodexModel(req.Model)
+	out := *req
+	out.Model = model
+	// An effort suffix is an explicit selection and overrides any
+	// client-injected reasoning default (mirrors the codex CLI); otherwise
+	// honor the client's effort. Either way the value is normalized onto the
+	// model's wire enum — all Codex models are reasoning models and the
+	// backend rejects unknown values (e.g. Claude Code's "adaptive").
+	if effort == "" && out.Reasoning != nil {
+		effort = out.Reasoning.Effort
+	}
+	out.Reasoning = &core.ReasoningConfig{Effort: normalizeCodexEffort(model, effort)}
+	return &out
+}
+
+// applyCodexHeaders mirrors the identity headers the official Codex CLI sends
+// on inference calls. chatgpt-account-id is the critical one: without it,
+// tokens for accounts with multiple workspaces can bind to the wrong ChatGPT
+// account and surface auth or model-access errors.
+func applyCodexHeaders(h map[string]string, creds core.Credentials) {
+	h["OpenAI-Beta"] = "responses=experimental"
+	h["originator"] = "codex_cli_rs"
+	h["version"] = codexClientVersion
+	h["User-Agent"] = "codex_cli_rs/" + codexClientVersion
+	// Stable per-account session id gives the backend prompt-cache affinity.
+	if creds.AccountID != "" {
+		h["session_id"] = creds.AccountID
+	}
+	// keirouter's own OAuth flow stores chatgpt_account_id; imported accounts
+	// may carry the CLI/9router-style keys instead.
+	for _, key := range []string{"chatgpt_account_id", "workspaceId", "accountId", "chatgptAccountId"} {
+		if v := creds.Extra[key]; v != "" {
+			h["chatgpt-account-id"] = v
+			break
+		}
+	}
+}

--- a/backend/internal/connectors/codex.go
+++ b/backend/internal/connectors/codex.go
@@ -31,10 +31,13 @@ var codexModelAliases = map[string]string{
 	"gpt-5.6": "gpt-5.6-sol",
 }
 
-// codexDashVersion matches a dash between two digits ("gpt-5-6"), the common
-// misspelling of the dotted version ids ("gpt-5.6") Codex actually uses.
-// Sending the dashed form upstream fails with 400 "model is not supported".
-var codexDashVersion = regexp.MustCompile(`(\d)-(\d)`)
+// codexDashVersion matches a dashed version segment right after the "gpt"
+// prefix ("gpt-5-6"), the common misspelling of the dotted version ids
+// ("gpt-5.6") Codex actually uses — sending the dashed form upstream fails
+// with 400 "model is not supported". Anchoring to the prefix keeps later
+// digit-dash-digit runs intact, e.g. a date-suffixed snapshot id like
+// "gpt-5.1-codex-max-2025-11-13".
+var codexDashVersion = regexp.MustCompile(`^(gpt-\d+)-(\d+)`)
 
 // codexModelKnown reports whether id is in the curated Codex catalog.
 func codexModelKnown(id string) bool {

--- a/backend/internal/connectors/codex_test.go
+++ b/backend/internal/connectors/codex_test.go
@@ -1,0 +1,120 @@
+package connectors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+)
+
+func TestResolveCodexModel(t *testing.T) {
+	cases := []struct {
+		in     string
+		model  string
+		effort string
+	}{
+		// The reported failure: dash typo of a dotted version, with no exact
+		// upstream id — alias lands on the 5.6 flagship.
+		{"gpt-5-6", "gpt-5.6-sol", ""},
+		{"gpt-5.6", "gpt-5.6-sol", ""},
+		{"gpt-5-6-high", "gpt-5.6-sol", "high"},
+		// Known catalog ids pass through untouched.
+		{"gpt-5.6-terra", "gpt-5.6-terra", ""},
+		{"gpt-5-codex", "gpt-5-codex", ""},
+		{"gpt-5.3-codex-spark", "gpt-5.3-codex-spark", ""},
+		// Effort suffixes are stripped and returned separately.
+		{"gpt-5.3-codex-xhigh", "gpt-5.3-codex", "xhigh"},
+		{"gpt-5.3-codex-high", "gpt-5.3-codex", "high"},
+		{"gpt-5.1-codex-mini-high", "gpt-5.1-codex-mini", "high"},
+		{"gpt-5.5-none", "gpt-5.5", "none"},
+		// gpt-5.6 family -max/-ultra alias suffixes (dash typo tolerated); a
+		// bare "-max" elsewhere stays part of the model id (gpt-5.1-codex-max).
+		{"gpt-5.6-sol-ultra", "gpt-5.6-sol", "ultra"},
+		{"gpt-5-6-terra-max", "gpt-5.6-terra", "max"},
+		{"gpt-5.1-codex-max", "gpt-5.1-codex-max", ""},
+		// Unknown ids pass through (normalized) for upstream to decide.
+		{"gpt-5.9-nova", "gpt-5.9-nova", ""},
+	}
+	for _, tc := range cases {
+		model, effort := resolveCodexModel(tc.in)
+		require.Equal(t, tc.model, model, "model for %q", tc.in)
+		require.Equal(t, tc.effort, effort, "effort for %q", tc.in)
+	}
+}
+
+func TestPrepareCodexRequest(t *testing.T) {
+	// Effort suffix overrides a client-injected reasoning default.
+	req := &core.ChatRequest{Model: "gpt-5.3-codex-xhigh", Reasoning: &core.ReasoningConfig{Effort: "medium"}}
+	out := prepareCodexRequest(req)
+	require.Equal(t, "gpt-5.3-codex", out.Model)
+	require.Equal(t, "xhigh", out.Reasoning.Effort)
+	// The caller's request is untouched (fallback to another provider must
+	// dispatch with the original model id).
+	require.Equal(t, "gpt-5.3-codex-xhigh", req.Model)
+	require.Equal(t, "medium", req.Reasoning.Effort)
+
+	// No suffix + no client reasoning -> default medium effort.
+	out = prepareCodexRequest(&core.ChatRequest{Model: "gpt-5.5"})
+	require.Equal(t, "gpt-5.5", out.Model)
+	require.Equal(t, "medium", out.Reasoning.Effort)
+
+	// Client-provided effort is preserved when the model has no suffix.
+	out = prepareCodexRequest(&core.ChatRequest{Model: "gpt-5.5", Reasoning: &core.ReasoningConfig{Effort: "low"}})
+	require.Equal(t, "low", out.Reasoning.Effort)
+
+	// Claude Code's adaptive thinking (the reported 400) is normalized to the
+	// CLI default instead of leaking an invalid wire value upstream.
+	out = prepareCodexRequest(&core.ChatRequest{Model: "gpt-5-6", Reasoning: &core.ReasoningConfig{Effort: "adaptive"}})
+	require.Equal(t, "gpt-5.6-sol", out.Model)
+	require.Equal(t, "medium", out.Reasoning.Effort)
+
+	// Ultra alias suffix resolves to the gpt-5.6 wire top value "max".
+	out = prepareCodexRequest(&core.ChatRequest{Model: "gpt-5.6-sol-ultra"})
+	require.Equal(t, "gpt-5.6-sol", out.Model)
+	require.Equal(t, "max", out.Reasoning.Effort)
+}
+
+func TestNormalizeCodexEffort(t *testing.T) {
+	cases := []struct {
+		model, effort, want string
+	}{
+		// gpt-5.6 family: enum is none/minimal/low/medium/high/max (no xhigh).
+		{"gpt-5.6-sol", "adaptive", "medium"},
+		{"gpt-5.6-sol", "xhigh", "max"},
+		{"gpt-5.6-terra", "ultra", "max"},
+		{"gpt-5.6-luna", "max", "max"},
+		{"gpt-5.6-sol", "minimal", "minimal"},
+		{"gpt-5.6-sol", "off", "none"},
+		{"gpt-5.6-sol", "bogus", "medium"},
+		// Legacy codex models: enum tops out at xhigh (no max).
+		{"gpt-5.3-codex", "max", "xhigh"},
+		{"gpt-5.3-codex", "xhigh", "xhigh"},
+		{"gpt-5.5", "adaptive", "medium"},
+		{"gpt-5.5", "auto", "medium"},
+		{"gpt-5.5", "", "medium"},
+		{"gpt-5.5", "HIGH", "high"},
+		{"gpt-5-codex", "bogus", "medium"},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, normalizeCodexEffort(tc.model, tc.effort), "model=%s effort=%s", tc.model, tc.effort)
+	}
+}
+
+func TestApplyCodexHeaders(t *testing.T) {
+	h := map[string]string{}
+	applyCodexHeaders(h, core.Credentials{
+		AccountID: "acc-1",
+		Extra:     map[string]string{"chatgpt_account_id": "wk-123"},
+	})
+	require.Equal(t, "codex_cli_rs", h["originator"])
+	require.Equal(t, "responses=experimental", h["OpenAI-Beta"])
+	require.Equal(t, codexClientVersion, h["version"])
+	require.Equal(t, "wk-123", h["chatgpt-account-id"])
+	require.Equal(t, "acc-1", h["session_id"])
+
+	// Imported accounts may carry the CLI-style key instead.
+	h = map[string]string{}
+	applyCodexHeaders(h, core.Credentials{Extra: map[string]string{"chatgptAccountId": "wk-456"}})
+	require.Equal(t, "wk-456", h["chatgpt-account-id"])
+}

--- a/backend/internal/connectors/codex_test.go
+++ b/backend/internal/connectors/codex_test.go
@@ -35,6 +35,10 @@ func TestResolveCodexModel(t *testing.T) {
 		{"gpt-5.1-codex-max", "gpt-5.1-codex-max", ""},
 		// Unknown ids pass through (normalized) for upstream to decide.
 		{"gpt-5.9-nova", "gpt-5.9-nova", ""},
+		{"gpt-5-1-codex", "gpt-5.1-codex", ""},
+		// The dash-typo rewrite is anchored to the version segment: a
+		// date-suffixed snapshot id must survive untouched.
+		{"gpt-5.1-codex-max-2025-11-13", "gpt-5.1-codex-max-2025-11-13", ""},
 	}
 	for _, tc := range cases {
 		model, effort := resolveCodexModel(tc.in)

--- a/backend/internal/connectors/httpclient.go
+++ b/backend/internal/connectors/httpclient.go
@@ -636,19 +636,42 @@ func shouldRetryFreshConnection(ctx context.Context, err error) bool {
 func httpStatusError(provider, model string, resp *http.Response, body []byte) error {
 	kind := core.ErrUpstream
 	var retryAfter time.Duration
+	var creditsExhausted bool
 	switch {
 	case resp.StatusCode == http.StatusTooManyRequests:
-		// Classify 429 into transient rate-limit vs hard quota exhaustion.
-		// Quota exhaustion gets a much longer cooldown than per-minute throttling.
-		kind, retryAfter = classify429(resp, body)
+		// Classify 429 into transient rate-limit vs hard quota exhaustion vs
+		// depleted paid balance. Quota exhaustion gets a much longer cooldown
+		// than per-minute throttling; a dry balance parks the account.
+		kind, retryAfter, creditsExhausted = classify429(resp, body)
 	case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
 		kind = core.ErrAuth
+		// Some gateways report a depleted balance as 403 rather than 402.
+		if looksLikeCreditsExhausted(string(body)) {
+			kind = core.ErrQuotaExhausted
+			creditsExhausted = true
+		}
 	case resp.StatusCode == http.StatusPaymentRequired:
 		kind = core.ErrQuotaExhausted
+		creditsExhausted = true
 	case resp.StatusCode == http.StatusNotFound:
 		kind = core.ErrModelUnavailable
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
 		kind = core.ErrBadRequest
+		// Some backends report unknown or inaccessible models as a plain 400
+		// (Codex: "The 'X' model is not supported when using Codex with a
+		// ChatGPT account"). Classify those as model-unavailable so chains
+		// fall back to the next model/provider instead of hard-failing the
+		// request.
+		if isModelUnsupportedBody(body) {
+			kind = core.ErrModelUnavailable
+		}
+		// Anthropic-style APIs return "credit balance is too low" as a plain
+		// 400 invalid_request_error. Treat it as a depleted balance so chains
+		// fall back to the next account instead of surfacing a request error.
+		if kind == core.ErrBadRequest && looksLikeCreditsExhausted(string(body)) {
+			kind = core.ErrQuotaExhausted
+			creditsExhausted = true
+		}
 	}
 
 	scope := core.FailureScopeProvider
@@ -662,13 +685,14 @@ func httpStatusError(provider, model string, resp *http.Response, body []byte) e
 	}
 
 	pe := &core.ProviderError{
-		Kind:       kind,
-		Scope:      scope,
-		Provider:   provider,
-		Model:      model,
-		StatusCode: resp.StatusCode,
-		Message:    truncateError(body),
-		RetryAfter: retryAfter,
+		Kind:             kind,
+		Scope:            scope,
+		Provider:         provider,
+		Model:            model,
+		StatusCode:       resp.StatusCode,
+		Message:          truncateError(body),
+		RetryAfter:       retryAfter,
+		CreditsExhausted: creditsExhausted,
 	}
 	// Preserve the existing Retry-After header parsing for non-429 errors.
 	if pe.RetryAfter <= 0 {
@@ -683,6 +707,34 @@ func httpStatusError(provider, model string, resp *http.Response, body []byte) e
 		}
 	}
 	return pe
+}
+
+// modelUnsupportedPhrases are error-body fragments that reliably indicate the
+// requested model cannot be served by this provider/account (unknown id, no
+// access) rather than a malformed request. Matched case-insensitively and only
+// on bodies that mention "model" to avoid misclassifying generic errors.
+var modelUnsupportedPhrases = []string{
+	"model is not supported", "model not supported",
+	"model is not available", "model not available",
+	"model not found", "model_not_found", "deployment_not_found",
+	"invalid model", "unknown model",
+	"model does not exist", "does not exist or you do not have access",
+	"access to model", "access to the model",
+}
+
+// isModelUnsupportedBody reports whether a 4xx body describes a model the
+// provider/account cannot serve.
+func isModelUnsupportedBody(body []byte) bool {
+	s := strings.ToLower(string(body))
+	if !strings.Contains(s, "model") {
+		return false
+	}
+	for _, p := range modelUnsupportedPhrases {
+		if strings.Contains(s, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // checkNonJSONResponse detects a successful (non-error) HTTP response whose

--- a/backend/internal/connectors/models.go
+++ b/backend/internal/connectors/models.go
@@ -58,7 +58,9 @@ var providerModels = map[string][]ModelSpec{
 		k("dall-e-2", "DALL-E 2", core.ServiceImage),
 	},
 	"codex": {
-		m("gpt-5.5", "GPT-5.5"), m("gpt-5.4", "GPT-5.4"), m("gpt-5.2", "GPT-5.2"), m("gpt-5.1", "GPT-5.1"),
+		m("gpt-5.6-sol", "GPT-5.6 Sol"), m("gpt-5.6-terra", "GPT-5.6 Terra"), m("gpt-5.6-luna", "GPT-5.6 Luna"),
+		m("gpt-5.5", "GPT-5.5"), m("gpt-5.4", "GPT-5.4"), m("gpt-5.4-mini", "GPT-5.4 Mini"),
+		m("gpt-5.2", "GPT-5.2"), m("gpt-5.1", "GPT-5.1"),
 		m("gpt-5.3-codex", "GPT-5.3 Codex"), m("gpt-5.3-codex-xhigh", "GPT-5.3 Codex (xHigh)"),
 		m("gpt-5.3-codex-high", "GPT-5.3 Codex (High)"), m("gpt-5.3-codex-low", "GPT-5.3 Codex (Low)"),
 		m("gpt-5.3-codex-none", "GPT-5.3 Codex (None)"), m("gpt-5.3-codex-spark", "GPT-5.3 Codex (Spark)"),

--- a/backend/internal/connectors/openai_responses.go
+++ b/backend/internal/connectors/openai_responses.go
@@ -27,7 +27,13 @@ type OpenAIResponses struct {
 
 // NewOpenAIResponses builds a Responses connector.
 func NewOpenAIResponses(id, defaultBaseURL string) *OpenAIResponses {
-	return &OpenAIResponses{id: id, defaultBase: defaultBaseURL}
+	return &OpenAIResponses{
+		id:          id,
+		defaultBase: defaultBaseURL,
+		// The ChatGPT Codex backend needs a tailored request shape (reasoning
+		// summary, encrypted-content include, default instructions).
+		codec: transform.OpenAIResponsesCodec{Codex: id == "codex"},
+	}
 }
 
 func (c *OpenAIResponses) ID() string            { return c.id }
@@ -70,9 +76,10 @@ func (c *OpenAIResponses) Validate(ctx context.Context, creds core.Credentials) 
 	base = strings.TrimSuffix(base, "/responses")
 	modelsURL := base + "/models"
 	// Codex's ChatGPT backend rejects the models probe without a client_version
-	// query param (mirrors the codex CLI).
+	// query param (mirrors the codex CLI). Stale versions silently omit newer
+	// models from the listing, so reuse the CLI version we impersonate.
 	if c.id == "codex" {
-		modelsURL += "?client_version=1.0.0"
+		modelsURL += "?client_version=" + codexClientVersion
 	}
 	if _, err := doJSONMethod(ctx, http.MethodGet, c.id, "validate", modelsURL, nil, c.headers(creds)); err != nil {
 		return fmt.Errorf("validation failed for %s: %w", c.id, err)
@@ -88,12 +95,20 @@ func (c *OpenAIResponses) headers(creds core.Credentials) map[string]string {
 	case creds.APIKey != "":
 		h["Authorization"] = bearer(creds.APIKey)
 	}
+	// Codex requires the CLI identity headers (chatgpt-account-id, originator,
+	// ...) on inference calls; a bare Authorization header is not enough.
+	if c.id == "codex" {
+		applyCodexHeaders(h, creds)
+	}
 	return mergeHeaders(h, creds.Headers)
 }
 
 // Chat performs a non-streaming Responses call.
 func (c *OpenAIResponses) Chat(ctx context.Context, req *core.ChatRequest, creds core.Credentials) (*core.ChatResponse, error) {
 	req.Stream = false
+	if c.id == "codex" {
+		req = prepareCodexRequest(req)
+	}
 	body, err := c.codec.RenderRequest(req)
 	if err != nil {
 		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}
@@ -115,6 +130,9 @@ func (c *OpenAIResponses) Chat(ctx context.Context, req *core.ChatRequest, creds
 // for zero-copy same-dialect piping.
 func (c *OpenAIResponses) StreamRaw(ctx context.Context, req *core.ChatRequest, creds core.Credentials, cfg core.StreamConfig) (io.ReadCloser, http.Header, error) {
 	req.Stream = true
+	if c.id == "codex" {
+		req = prepareCodexRequest(req)
+	}
 	body, err := c.codec.RenderRequest(req)
 	if err != nil {
 		return nil, nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}
@@ -130,6 +148,9 @@ func (c *OpenAIResponses) StreamRaw(ctx context.Context, req *core.ChatRequest, 
 // Stream performs a streaming Responses call, reading the typed SSE event stream.
 func (c *OpenAIResponses) Stream(ctx context.Context, req *core.ChatRequest, creds core.Credentials, cfg core.StreamConfig) (<-chan core.StreamChunk, error) {
 	req.Stream = true
+	if c.id == "codex" {
+		req = prepareCodexRequest(req)
+	}
 	body, err := c.codec.RenderRequest(req)
 	if err != nil {
 		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}

--- a/backend/internal/connectors/providers_test.go
+++ b/backend/internal/connectors/providers_test.go
@@ -732,7 +732,7 @@ func TestXiaomiMiMo_Chat_RateLimit(t *testing.T) {
 func TestXiaomiMiMo_Chat_BadRequest(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprint(w, `{"error":{"message":"Model not found","type":"invalid_request_error"}}`)
+		fmt.Fprint(w, `{"error":{"message":"Invalid request: messages field is required","type":"invalid_request_error"}}`)
 	}))
 	defer srv.Close()
 
@@ -750,6 +750,32 @@ func TestXiaomiMiMo_Chat_BadRequest(t *testing.T) {
 	pe := core.AsProviderError(err)
 	require.Equal(t, core.ErrBadRequest, pe.Kind)
 	require.False(t, pe.Fallbackable(), "4xx request errors must not trigger fallback")
+}
+
+// TestChat_ModelNotFound400 verifies that a 400 whose body describes an
+// unknown/inaccessible model is classified model-unavailable (model scope) so
+// chains can fall back to the next model/provider instead of hard-failing.
+func TestChat_ModelNotFound400(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"detail":"The 'gpt-5-6' model is not supported when using Codex with a ChatGPT account."}`)
+	}))
+	defer srv.Close()
+
+	c := NewOpenAICompatible("xiaomi-mimo", srv.URL)
+	req := &core.ChatRequest{
+		Model:  "nonexistent-model",
+		Stream: false,
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+		},
+	}
+	_, err := c.Chat(context.Background(), req, core.Credentials{APIKey: "test-key"})
+	require.Error(t, err)
+
+	pe := core.AsProviderError(err)
+	require.Equal(t, core.ErrModelUnavailable, pe.Kind)
+	require.Equal(t, core.FailureScopeModel, pe.EffectiveScope())
 }
 
 func TestXiaomiMiMo_Validate(t *testing.T) {

--- a/backend/internal/connectors/qoder.go
+++ b/backend/internal/connectors/qoder.go
@@ -285,8 +285,9 @@ func (c *Qoder) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaR
 
 // qoderQuotaFromStatus maps a user/status payload into a QuotaResult. Mirrors
 // OmniRoute's parseQoderUserStatusUsage: exhausted quota reports a 0-remaining
-// bar; pooled team/enterprise seats or accounts with no per-user counter report
-// the plan only (a limit:0 bar would render as 0%/exhausted in the UI).
+// bar; pooled team/enterprise seats report a shared-pool note; accounts with no
+// per-user counter (trials) report a not-metered note (a limit:0 bar would
+// render as 0%/exhausted in the UI).
 func qoderQuotaFromStatus(st *qoderUserStatus) *QuotaResult {
 	plan := prettifyQoderPlan(st.Plan, st.UserTag)
 	resetAt := qoderResetAt(st.NextResetAt)
@@ -306,8 +307,13 @@ func qoderQuotaFromStatus(st *qoderUserStatus) *QuotaResult {
 			PlanName:     plan,
 		})
 		result.Message = "Quota exceeded."
-	case pooled || quota <= 0:
-		result.Message = plan + " plan · pooled quota"
+	case pooled:
+		result.Message = plan + " plan · shared team pool"
+	case quota <= 0:
+		// Trial / individual plans that Qoder does not meter with a per-user
+		// counter report quota:0 while isQuotaExceeded stays false. There is no
+		// remaining-credit number to show, so name the plan and say so plainly.
+		result.Message = plan + " plan · usage not metered by Qoder"
 	default:
 		result.Quotas = append(result.Quotas, QuotaEntry{
 			ResourceType: "requests",

--- a/backend/internal/connectors/qoder.go
+++ b/backend/internal/connectors/qoder.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 	qoderlib "github.com/mydisha/keirouter/backend/internal/qoder"
@@ -40,13 +41,19 @@ type Qoder struct {
 	// Model catalog cache (COSY-signed /algo/api/v2/model/list).
 	mu      sync.RWMutex
 	catalog map[string]*qoderCatalogEntry // keyed by user_id
-
-	// Resolved-session cache for PAT connections, keyed by the pt-* token. A
-	// PAT is exchanged for a short-lived jt-* job token and the owner's real
-	// COSY identity (uid/email/name), reused until the job token nears expiry.
-	jtMu        sync.Mutex
-	patSessions map[string]qoderPATSession
 }
+
+// qoderPATCache is the process-wide resolved-session cache for PAT
+// connections, keyed by the pt-* token. It is shared by every Qoder instance
+// (dispatch connectors and the quota source) and the exchange is
+// single-flighted, so each PAT holds at most one live jt-* job token at a
+// time even under concurrent cold-cache requests — the upstream may
+// invalidate earlier job tokens when a new one is minted.
+var qoderPATCache = struct {
+	sync.Mutex
+	sessions map[string]qoderPATSession
+	flight   singleflight.Group
+}{sessions: make(map[string]qoderPATSession)}
 
 // qoderCatalogEntry is a cached model catalog for one Qoder account.
 type qoderCatalogEntry struct {
@@ -83,7 +90,6 @@ func NewQoder(id, defaultBaseURL string) *Qoder {
 		id:          id,
 		defaultBase: defaultBaseURL,
 		catalog:     make(map[string]*qoderCatalogEntry),
-		patSessions: make(map[string]qoderPATSession),
 	}
 }
 
@@ -171,34 +177,51 @@ func (c *Qoder) resolveCosyCreds(ctx context.Context, creds core.Credentials) (q
 
 // resolveQoderSession returns a cached job token plus the owner's real COSY
 // identity for the PAT, refreshing when the cache is empty or near expiry.
+// The refresh is single-flighted per PAT: concurrent cold-cache callers share
+// one exchange instead of minting competing job tokens.
 func (c *Qoder) resolveQoderSession(ctx context.Context, pat string) (qoderPATSession, error) {
-	c.jtMu.Lock()
-	if sess, ok := c.patSessions[pat]; ok && time.Now().Before(sess.expiresAt) {
-		c.jtMu.Unlock()
+	qoderPATCache.Lock()
+	if sess, ok := qoderPATCache.sessions[pat]; ok && time.Now().Before(sess.expiresAt) {
+		qoderPATCache.Unlock()
 		return sess, nil
 	}
-	c.jtMu.Unlock()
+	qoderPATCache.Unlock()
 
-	token, ttl, err := c.exchangeJobToken(ctx, pat)
+	v, err, _ := qoderPATCache.flight.Do(pat, func() (any, error) {
+		// A previous flight may have refreshed the session while this caller
+		// was queued behind it.
+		qoderPATCache.Lock()
+		if sess, ok := qoderPATCache.sessions[pat]; ok && time.Now().Before(sess.expiresAt) {
+			qoderPATCache.Unlock()
+			return sess, nil
+		}
+		qoderPATCache.Unlock()
+
+		token, ttl, err := c.exchangeJobToken(ctx, pat)
+		if err != nil {
+			return qoderPATSession{}, err
+		}
+		st, err := c.fetchUserStatus(ctx, token)
+		if err != nil {
+			return qoderPATSession{}, err
+		}
+
+		sess := qoderPATSession{
+			jobToken:  token,
+			uid:       st.ID,
+			email:     st.Email,
+			name:      st.Name,
+			expiresAt: time.Now().Add(ttl),
+		}
+		qoderPATCache.Lock()
+		qoderPATCache.sessions[pat] = sess
+		qoderPATCache.Unlock()
+		return sess, nil
+	})
 	if err != nil {
 		return qoderPATSession{}, err
 	}
-	st, err := c.fetchUserStatus(ctx, token)
-	if err != nil {
-		return qoderPATSession{}, err
-	}
-
-	sess := qoderPATSession{
-		jobToken:  token,
-		uid:       st.ID,
-		email:     st.Email,
-		name:      st.Name,
-		expiresAt: time.Now().Add(ttl),
-	}
-	c.jtMu.Lock()
-	c.patSessions[pat] = sess
-	c.jtMu.Unlock()
-	return sess, nil
+	return v.(qoderPATSession), nil
 }
 
 // qoderUserStatus is the token owner's account profile from user/status. The
@@ -256,9 +279,9 @@ func (c *Qoder) fetchUserStatus(ctx context.Context, jobToken string) (*qoderUse
 // --- Quota -----------------------------------------------------------------
 
 func init() {
-	// Register a self-contained instance for quota lookups. NewQoder is required
-	// (not a bare &Qoder{}) so the patSessions map is initialised before
-	// FetchQuota resolves a job token.
+	// Register an instance for quota lookups. PAT sessions live in the shared
+	// package-level qoderPATCache, so quota fetches reuse the job token minted
+	// by the dispatch connector instead of performing a second exchange.
 	RegisterQuotaSource("qoder", NewQoder("qoder", ""))
 }
 

--- a/backend/internal/connectors/qoder.go
+++ b/backend/internal/connectors/qoder.go
@@ -1,6 +1,7 @@
 package connectors
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -24,6 +25,13 @@ import (
 //   - WAF-bypass body encoding (&Encode=1)
 //   - COSY signing (RSA+AES+MD5 with ~17 Cosy-* headers)
 //   - SSE envelope unwrapping ({statusCodeValue, body} → plain OpenAI chunks)
+//
+// Two auth methods are supported. OAuth device-token connections store
+// user_id/machine_id/email in creds.Extra and carry the access token as the
+// COSY security_oauth_token. Personal Access Token (PAT, pt-*) connections
+// carry the PAT in creds.APIKey; a raw PAT cannot sign COSY directly, so it is
+// first exchanged for a short-lived job token (jt-*) that becomes the COSY
+// security_oauth_token (mirrors qodercli's headless PAT flow).
 type Qoder struct {
 	id          string
 	defaultBase string
@@ -32,6 +40,12 @@ type Qoder struct {
 	// Model catalog cache (COSY-signed /algo/api/v2/model/list).
 	mu      sync.RWMutex
 	catalog map[string]*qoderCatalogEntry // keyed by user_id
+
+	// Resolved-session cache for PAT connections, keyed by the pt-* token. A
+	// PAT is exchanged for a short-lived jt-* job token and the owner's real
+	// COSY identity (uid/email/name), reused until the job token nears expiry.
+	jtMu        sync.Mutex
+	patSessions map[string]qoderPATSession
 }
 
 // qoderCatalogEntry is a cached model catalog for one Qoder account.
@@ -40,7 +54,28 @@ type qoderCatalogEntry struct {
 	rawConfigs map[string]json.RawMessage // key → full model_config JSON
 }
 
+// qoderPATSession is a cached PAT resolution: the exchanged jt-* job token
+// plus the token owner's real COSY identity fetched from user/status. The
+// COSY envelope's uid must be this real user id, not a synthetic value.
+type qoderPATSession struct {
+	jobToken  string
+	uid       string
+	email     string
+	name      string
+	expiresAt time.Time
+}
+
 const qoderCatalogTTL = 1 * time.Hour
+
+// Job-token lifetime bounds. Qoder issues job tokens valid for ~24h; refresh a
+// little early to avoid signing with a just-expired token.
+const (
+	qoderJobTokenDefaultTTL = 23 * time.Hour
+	qoderJobTokenMinTTL     = 1 * time.Minute
+	// qoderJobTokenRefreshSkew refreshes the job token a little before its
+	// reported expiry so a signed request never uses a just-expired token.
+	qoderJobTokenRefreshSkew = 5 * time.Minute
+)
 
 // NewQoder builds a Qoder connector.
 func NewQoder(id, defaultBaseURL string) *Qoder {
@@ -48,6 +83,7 @@ func NewQoder(id, defaultBaseURL string) *Qoder {
 		id:          id,
 		defaultBase: defaultBaseURL,
 		catalog:     make(map[string]*qoderCatalogEntry),
+		patSessions: make(map[string]qoderPATSession),
 	}
 }
 
@@ -69,9 +105,38 @@ func (c *Qoder) cosyCreds(creds core.Credentials) qoderlib.CosyCreds {
 	}
 }
 
+// qoderPATToken resolves the raw Personal Access Token from the credentials.
+// The PAT arrives in the dedicated APIKey field; imported connections may
+// carry it as the access token instead.
+func qoderPATToken(creds core.Credentials) string {
+	if creds.APIKey != "" {
+		return creds.APIKey
+	}
+	return creds.AccessToken
+}
+
+// qoderIsPAT reports whether the credentials authenticate with a Personal
+// Access Token rather than an OAuth device-token session. Account creation
+// marks PAT connections with qoder_auth_method=pat; the pt-* prefix is a
+// belt-and-suspenders fallback for imported credentials.
+func qoderIsPAT(creds core.Credentials) bool {
+	if creds.Extra["qoder_auth_method"] == "pat" {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimSpace(qoderPATToken(creds)), "pt-")
+}
+
 // validateCreds returns an error when the credential is missing the fields
-// required for COSY signing.
+// required for COSY signing. PAT connections only need the PAT itself (the
+// job token and synthetic uid are derived at request time); OAuth connections
+// need the user_id and access token captured at connect time.
 func (c *Qoder) validateCreds(creds core.Credentials) error {
+	if qoderIsPAT(creds) {
+		if qoderPATToken(creds) == "" {
+			return &core.ProviderError{Kind: core.ErrAuth, Provider: c.id, Message: "qoder credential is missing personal access token; reconnect the account"}
+		}
+		return nil
+	}
 	cc := c.cosyCreds(creds)
 	if cc.UserID == "" {
 		return &core.ProviderError{Kind: core.ErrAuth, Provider: c.id, Message: "qoder credential is missing user_id; reconnect the account"}
@@ -80,6 +145,320 @@ func (c *Qoder) validateCreds(creds core.Credentials) error {
 		return &core.ProviderError{Kind: core.ErrAuth, Provider: c.id, Message: "qoder credential is missing access token; reconnect the account"}
 	}
 	return nil
+}
+
+// resolveCosyCreds returns the COSY signing material for a request. OAuth
+// connections use their stored fields directly. PAT connections exchange the
+// PAT for a short-lived job token and pair it with the token owner's real
+// user id (fetched from user/status) — the upstream rejects a synthetic uid
+// with "Login expired".
+func (c *Qoder) resolveCosyCreds(ctx context.Context, creds core.Credentials) (qoderlib.CosyCreds, error) {
+	if !qoderIsPAT(creds) {
+		return c.cosyCreds(creds), nil
+	}
+	sess, err := c.resolveQoderSession(ctx, qoderPATToken(creds))
+	if err != nil {
+		return qoderlib.CosyCreds{}, err
+	}
+	return qoderlib.CosyCreds{
+		UserID:    sess.uid,
+		AuthToken: sess.jobToken,
+		Name:      sess.name,
+		Email:     sess.email,
+		MachineID: creds.Extra["machine_id"],
+	}, nil
+}
+
+// resolveQoderSession returns a cached job token plus the owner's real COSY
+// identity for the PAT, refreshing when the cache is empty or near expiry.
+func (c *Qoder) resolveQoderSession(ctx context.Context, pat string) (qoderPATSession, error) {
+	c.jtMu.Lock()
+	if sess, ok := c.patSessions[pat]; ok && time.Now().Before(sess.expiresAt) {
+		c.jtMu.Unlock()
+		return sess, nil
+	}
+	c.jtMu.Unlock()
+
+	token, ttl, err := c.exchangeJobToken(ctx, pat)
+	if err != nil {
+		return qoderPATSession{}, err
+	}
+	st, err := c.fetchUserStatus(ctx, token)
+	if err != nil {
+		return qoderPATSession{}, err
+	}
+
+	sess := qoderPATSession{
+		jobToken:  token,
+		uid:       st.ID,
+		email:     st.Email,
+		name:      st.Name,
+		expiresAt: time.Now().Add(ttl),
+	}
+	c.jtMu.Lock()
+	c.patSessions[pat] = sess
+	c.jtMu.Unlock()
+	return sess, nil
+}
+
+// qoderUserStatus is the token owner's account profile from user/status. The
+// id is the real COSY uid; email/name fill the COSY user-info envelope; the
+// plan/quota fields drive the account quota panel.
+type qoderUserStatus struct {
+	ID              string  `json:"id"`
+	Name            string  `json:"name"`
+	Email           string  `json:"email"`
+	UserType        string  `json:"userType"`
+	Quota           float64 `json:"quota"`
+	IsQuotaExceeded bool    `json:"isQuotaExceeded"`
+	Plan            string  `json:"plan"`
+	UserTag         string  `json:"userTag"`
+	NextResetAt     int64   `json:"nextResetAt"`
+}
+
+// fetchUserStatus reads the token owner's account profile from user/status
+// using a plain Bearer job token (no COSY). The returned id is the real COSY
+// uid; email and name fill the COSY user-info envelope; plan/quota fields feed
+// FetchQuota.
+func (c *Qoder) fetchUserStatus(ctx context.Context, jobToken string) (*qoderUserStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, qoderlib.UserStatusURL, nil)
+	if err != nil {
+		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Message: err.Error(), Cause: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+jobToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := proxyClient(ctx).Do(req)
+	if err != nil {
+		return nil, &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Message: "qoder user status: " + err.Error(), Cause: err}
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 16*1024))
+	if resp.StatusCode >= 400 {
+		kind := core.ErrUpstream
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			kind = core.ErrAuth
+		}
+		return nil, &core.ProviderError{Kind: kind, Provider: c.id, StatusCode: resp.StatusCode, Message: "qoder user status failed: " + truncateError(body)}
+	}
+
+	var status qoderUserStatus
+	if err := json.Unmarshal(body, &status); err != nil {
+		return nil, &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Message: "qoder user status: parse: " + err.Error(), Cause: err}
+	}
+	if strings.TrimSpace(status.ID) == "" {
+		return nil, &core.ProviderError{Kind: core.ErrAuth, Provider: c.id, Message: "qoder user status returned no user id; check the personal access token"}
+	}
+	return &status, nil
+}
+
+// --- Quota -----------------------------------------------------------------
+
+func init() {
+	// Register a self-contained instance for quota lookups. NewQoder is required
+	// (not a bare &Qoder{}) so the patSessions map is initialised before
+	// FetchQuota resolves a job token.
+	RegisterQuotaSource("qoder", NewQoder("qoder", ""))
+}
+
+// FetchQuota reports the Qoder account's plan and request quota, read from the
+// non-COSY user/status endpoint. Only PAT connections expose a queryable quota;
+// other cases return a plain message (not an error) so the UI degrades cleanly.
+func (c *Qoder) FetchQuota(ctx context.Context, creds core.Credentials) (*QuotaResult, error) {
+	if !qoderIsPAT(creds) {
+		return &QuotaResult{Message: "Qoder quota is only available for Personal Access Token connections."}, nil
+	}
+	if qoderPATToken(creds) == "" {
+		return &QuotaResult{Message: "No personal access token; cannot fetch quota."}, nil
+	}
+	sess, err := c.resolveQoderSession(ctx, qoderPATToken(creds))
+	if err != nil {
+		return nil, err
+	}
+	st, err := c.fetchUserStatus(ctx, sess.jobToken)
+	if err != nil {
+		return nil, err
+	}
+	return qoderQuotaFromStatus(st), nil
+}
+
+// qoderQuotaFromStatus maps a user/status payload into a QuotaResult. Mirrors
+// OmniRoute's parseQoderUserStatusUsage: exhausted quota reports a 0-remaining
+// bar; pooled team/enterprise seats or accounts with no per-user counter report
+// the plan only (a limit:0 bar would render as 0%/exhausted in the UI).
+func qoderQuotaFromStatus(st *qoderUserStatus) *QuotaResult {
+	plan := prettifyQoderPlan(st.Plan, st.UserTag)
+	resetAt := qoderResetAt(st.NextResetAt)
+	userType := strings.ToLower(strings.TrimSpace(st.UserType))
+	pooled := userType == "teams" || userType == "enterprise"
+	quota := int(st.Quota)
+
+	result := &QuotaResult{PlanName: plan}
+	switch {
+	case st.IsQuotaExceeded:
+		result.Quotas = append(result.Quotas, QuotaEntry{
+			ResourceType: "requests",
+			Used:         quota,
+			Limit:        quota,
+			Remaining:    0,
+			ResetAt:      resetAt,
+			PlanName:     plan,
+		})
+		result.Message = "Quota exceeded."
+	case pooled || quota <= 0:
+		result.Message = plan + " plan · pooled quota"
+	default:
+		result.Quotas = append(result.Quotas, QuotaEntry{
+			ResourceType: "requests",
+			Used:         0,
+			Limit:        quota,
+			Remaining:    quota,
+			ResetAt:      resetAt,
+			PlanName:     plan,
+		})
+	}
+	return result
+}
+
+// prettifyQoderPlan turns Qoder's PLAN_TIER_* enum / userTag into a label.
+// The userTag (e.g. "Pro Trial") is preferred when present.
+func prettifyQoderPlan(plan, userTag string) string {
+	if tag := strings.TrimSpace(userTag); tag != "" {
+		return tag
+	}
+	stripped := strings.TrimSpace(plan)
+	if len(stripped) >= len("PLAN_TIER_") && strings.EqualFold(stripped[:len("PLAN_TIER_")], "PLAN_TIER_") {
+		stripped = stripped[len("PLAN_TIER_"):]
+	}
+	if stripped == "" {
+		return "Qoder"
+	}
+	words := strings.FieldsFunc(stripped, func(r rune) bool { return r == '_' || r == ' ' })
+	for i, w := range words {
+		if w == "" {
+			continue
+		}
+		words[i] = strings.ToUpper(w[:1]) + strings.ToLower(w[1:])
+	}
+	return strings.Join(words, " ")
+}
+
+// qoderResetAt renders the epoch-millisecond reset time as RFC3339 (empty when
+// unset). RFC3339 is understood by both the account quota bar and the quota
+// page's countdown formatter; a bare millisecond string would not parse.
+func qoderResetAt(nextResetAt int64) string {
+	if nextResetAt <= 0 {
+		return ""
+	}
+	return time.UnixMilli(nextResetAt).UTC().Format(time.RFC3339)
+}
+
+// exchangeJobToken POSTs the PAT to Qoder's job-token exchange and returns the
+// jt-* job token plus its lifetime. A raw PAT cannot sign COSY directly; this
+// mirrors qodercli's headless exchange step.
+func (c *Qoder) exchangeJobToken(ctx context.Context, pat string) (string, time.Duration, error) {
+	reqBody, err := json.Marshal(map[string]string{"personal_token": pat})
+	if err != nil {
+		return "", 0, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Message: err.Error(), Cause: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, qoderlib.JobTokenExchangeURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", 0, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Message: err.Error(), Cause: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := proxyClient(ctx).Do(req)
+	if err != nil {
+		return "", 0, &core.ProviderError{Kind: core.ErrUpstream, Provider: c.id, Message: "qoder job token exchange: " + err.Error(), Cause: err}
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 8*1024))
+	if resp.StatusCode >= 400 {
+		kind := core.ErrUpstream
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			kind = core.ErrAuth
+		}
+		return "", 0, &core.ProviderError{Kind: kind, Provider: c.id, StatusCode: resp.StatusCode, Message: "qoder job token exchange failed: " + truncateError(body)}
+	}
+
+	token, ttl := parseQoderJobToken(body)
+	if token == "" {
+		return "", 0, &core.ProviderError{Kind: core.ErrAuth, Provider: c.id, Message: "qoder job token exchange returned no job token; check the personal access token"}
+	}
+	return token, ttl, nil
+}
+
+// parseQoderJobToken extracts the jt-* job token and its lifetime from the
+// (loosely-specified) exchange response. The token appears under "token" (or
+// job_token/jobToken/jt) at the root or under a data object. Expiry is taken
+// from the RFC3339 expires_at when present; the numeric expires_in is reported
+// in milliseconds. Defaults to ~24h and is clamped to a sane minimum.
+func parseQoderJobToken(body []byte) (string, time.Duration) {
+	type jobTokenFields struct {
+		JobToken     string  `json:"job_token"`
+		JobTokenCaml string  `json:"jobToken"`
+		JT           string  `json:"jt"`
+		Token        string  `json:"token"`
+		ExpiresAt    string  `json:"expires_at"`
+		ExpiresIn    float64 `json:"expires_in"`
+		ExpiresInCml float64 `json:"expiresIn"`
+	}
+	var root struct {
+		jobTokenFields
+		Data jobTokenFields `json:"data"`
+	}
+	if json.Unmarshal(body, &root) != nil {
+		return "", 0
+	}
+	candidates := []string{
+		root.JobToken, root.JobTokenCaml, root.JT, root.Token,
+		root.Data.JobToken, root.Data.JobTokenCaml, root.Data.JT, root.Data.Token,
+	}
+	var token string
+	for _, cand := range candidates {
+		if trimmed := strings.TrimSpace(cand); strings.HasPrefix(trimmed, "jt-") {
+			token = trimmed
+			break
+		}
+	}
+	if token == "" {
+		return "", 0
+	}
+
+	ttl := qoderJobTokenDefaultTTL
+	derived := false
+	// Prefer the absolute expiry timestamp; refresh a little before it lapses.
+	for _, ts := range []string{root.ExpiresAt, root.Data.ExpiresAt} {
+		if t, err := time.Parse(time.RFC3339, strings.TrimSpace(ts)); err == nil {
+			if d := time.Until(t); d > 0 {
+				ttl = d
+				derived = true
+			}
+			break
+		}
+	}
+	// Fall back to the numeric expires_in (milliseconds).
+	if !derived {
+		for _, ms := range []float64{root.ExpiresIn, root.ExpiresInCml, root.Data.ExpiresIn, root.Data.ExpiresInCml} {
+			if ms > 0 {
+				ttl = time.Duration(ms) * time.Millisecond
+				derived = true
+				break
+			}
+		}
+	}
+	// Refresh slightly early so a signed request never uses a just-expired
+	// token. Only skew a server-reported lifetime, never the static default.
+	if derived && ttl > qoderJobTokenRefreshSkew {
+		ttl -= qoderJobTokenRefreshSkew
+	}
+	if ttl < qoderJobTokenMinTTL {
+		ttl = qoderJobTokenMinTTL
+	}
+	return token, ttl
 }
 
 // --- Request body building --------------------------------------------------
@@ -508,8 +887,7 @@ func (c *Qoder) buildPayload(req *core.ChatRequest, modelKey string, modelConfig
 // fetchModelCatalog fetches the live model list from api3.qoder.sh and caches
 // the raw model_config blocks by key. This is required because Qoder silently
 // downgrades to a different model when the wrong model_config is sent.
-func (c *Qoder) fetchModelCatalog(ctx context.Context, creds core.Credentials) (map[string]json.RawMessage, error) {
-	cc := c.cosyCreds(creds)
+func (c *Qoder) fetchModelCatalog(ctx context.Context, cc qoderlib.CosyCreds) (map[string]json.RawMessage, error) {
 	cacheKey := cc.UserID
 
 	// Check cache first.
@@ -578,8 +956,8 @@ func (c *Qoder) fetchModelCatalog(ctx context.Context, creds core.Credentials) (
 
 // modelConfigForKey resolves the model_config block for a given model key,
 // fetching the catalog if needed.
-func (c *Qoder) modelConfigForKey(ctx context.Context, creds core.Credentials, modelKey string) (json.RawMessage, error) {
-	configs, err := c.fetchModelCatalog(ctx, creds)
+func (c *Qoder) modelConfigForKey(ctx context.Context, cc qoderlib.CosyCreds, modelKey string) (json.RawMessage, error) {
+	configs, err := c.fetchModelCatalog(ctx, cc)
 	if err != nil {
 		return nil, err
 	}
@@ -594,8 +972,7 @@ func (c *Qoder) modelConfigForKey(ctx context.Context, creds core.Credentials, m
 
 // signedRequest builds the COSY-signed, WAF-encoded request for the Qoder chat
 // endpoint. Returns the URL, headers, and encoded body ready for sending.
-func (c *Qoder) signedRequest(payload qoderPayload, creds core.Credentials) (url string, headers map[string]string, body []byte, err error) {
-	cc := c.cosyCreds(creds)
+func (c *Qoder) signedRequest(payload qoderPayload, cc qoderlib.CosyCreds) (url string, headers map[string]string, body []byte, err error) {
 	url = qoderlib.ChatURLEncoded
 
 	plainBody, err := json.Marshal(payload)
@@ -632,17 +1009,22 @@ func (c *Qoder) Stream(ctx context.Context, req *core.ChatRequest, creds core.Cr
 		return nil, err
 	}
 
+	cc, err := c.resolveCosyCreds(ctx, creds)
+	if err != nil {
+		return nil, err
+	}
+
 	modelKey := resolveModelKey(req.Model)
-	modelConfig, err := c.modelConfigForKey(ctx, creds, modelKey)
+	modelConfig, err := c.modelConfigForKey(ctx, cc, modelKey)
 	if err != nil {
 		// Non-fatal: use a minimal model_config and let upstream decide.
 		modelConfig = nil
 	}
 
-	payload := c.buildPayload(req, modelKey, modelConfig, c.cosyCreds(creds).UserID)
+	payload := c.buildPayload(req, modelKey, modelConfig, cc.UserID)
 	payload.Stream = true
 
-	url, headers, body, err := c.signedRequest(payload, creds)
+	url, headers, body, err := c.signedRequest(payload, cc)
 	if err != nil {
 		return nil, &core.ProviderError{Kind: core.ErrInternal, Provider: c.id, Model: req.Model, Message: err.Error(), Cause: err}
 	}
@@ -799,8 +1181,11 @@ func (c *Qoder) Validate(ctx context.Context, creds core.Credentials) error {
 	if err := c.validateCreds(creds); err != nil {
 		return err
 	}
-	_, err := c.fetchModelCatalog(ctx, creds)
+	cc, err := c.resolveCosyCreds(ctx, creds)
 	if err != nil {
+		return fmt.Errorf("validation failed for %s: %w", c.id, err)
+	}
+	if _, err := c.fetchModelCatalog(ctx, cc); err != nil {
 		return fmt.Errorf("validation failed for %s: %w", c.id, err)
 	}
 	return nil
@@ -873,7 +1258,12 @@ func (c *Qoder) ListModels(ctx context.Context, creds core.Credentials) ([]Model
 		return nil, err
 	}
 
-	configs, err := c.fetchModelCatalog(ctx, creds)
+	cc, err := c.resolveCosyCreds(ctx, creds)
+	if err != nil {
+		return nil, err
+	}
+
+	configs, err := c.fetchModelCatalog(ctx, cc)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/connectors/qoder_test.go
+++ b/backend/internal/connectors/qoder_test.go
@@ -451,8 +451,8 @@ func TestQoderQuotaFromStatus(t *testing.T) {
 	if len(trial.Quotas) != 0 {
 		t.Fatalf("trial quotas = %d, want 0 (pooled/plan-only)", len(trial.Quotas))
 	}
-	if trial.Message == "" {
-		t.Fatalf("trial message empty, want a plan message")
+	if trial.Message != "Pro Trial plan · usage not metered by Qoder" {
+		t.Fatalf("trial message = %q, want the not-metered note", trial.Message)
 	}
 
 	// A finite per-user quota renders a full-remaining bar with an RFC3339 reset.
@@ -482,8 +482,8 @@ func TestQoderQuotaFromStatus(t *testing.T) {
 	team := qoderQuotaFromStatus(&qoderUserStatus{
 		UserType: "teams", Quota: 0, IsQuotaExceeded: false, UserTag: "Team",
 	})
-	if len(team.Quotas) != 0 || team.Message == "" {
-		t.Fatalf("team quota = %+v msg=%q, want plan-only pooled", team.Quotas, team.Message)
+	if len(team.Quotas) != 0 || team.Message != "Team plan · shared team pool" {
+		t.Fatalf("team quota = %+v msg=%q, want plan-only shared team pool", team.Quotas, team.Message)
 	}
 }
 

--- a/backend/internal/connectors/qoder_test.go
+++ b/backend/internal/connectors/qoder_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/mydisha/keirouter/backend/internal/core"
 )
@@ -306,5 +307,196 @@ func TestUnwrapQoderSSELineWithError_SurfacesEnvelopeError(t *testing.T) {
 	}
 	if pe.Message != "Invalid tool parameters" {
 		t.Fatalf("message = %q, want Invalid tool parameters", pe.Message)
+	}
+}
+
+func TestQoderIsPAT_DetectsAuthMethodAndPrefix(t *testing.T) {
+	cases := []struct {
+		name  string
+		creds core.Credentials
+		want  bool
+	}{
+		{
+			name:  "marked pat",
+			creds: core.Credentials{APIKey: "pt-abc", Extra: map[string]string{"qoder_auth_method": "pat"}},
+			want:  true,
+		},
+		{
+			name:  "pt prefix without marker",
+			creds: core.Credentials{APIKey: "pt-abc"},
+			want:  true,
+		},
+		{
+			name:  "oauth access token",
+			creds: core.Credentials{AccessToken: "dt-xyz", Extra: map[string]string{"user_id": "u1"}},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := qoderIsPAT(tc.creds); got != tc.want {
+				t.Fatalf("qoderIsPAT = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestQoderPATToken_PrefersAPIKey(t *testing.T) {
+	if got := qoderPATToken(core.Credentials{APIKey: "pt-key", AccessToken: "pt-token"}); got != "pt-key" {
+		t.Fatalf("qoderPATToken = %q, want pt-key", got)
+	}
+	if got := qoderPATToken(core.Credentials{AccessToken: "pt-token"}); got != "pt-token" {
+		t.Fatalf("qoderPATToken fallback = %q, want pt-token", got)
+	}
+}
+
+func TestQoderValidateCreds_PATRequiresToken(t *testing.T) {
+	connector := NewQoder("qoder", "")
+
+	// A PAT-marked credential with no token must be rejected as an auth error.
+	err := connector.validateCreds(core.Credentials{Extra: map[string]string{"qoder_auth_method": "pat"}})
+	var pe *core.ProviderError
+	if !errors.As(err, &pe) || pe.Kind != core.ErrAuth {
+		t.Fatalf("expected auth ProviderError, got %v", err)
+	}
+
+	// A PAT-marked credential with a token passes without OAuth fields.
+	if err := connector.validateCreds(core.Credentials{APIKey: "pt-abc", Extra: map[string]string{"qoder_auth_method": "pat"}}); err != nil {
+		t.Fatalf("validateCreds(pat) = %v, want nil", err)
+	}
+}
+
+func TestParseQoderJobToken(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantToken string
+		wantTTL   time.Duration
+	}{
+		{
+			// expires_in is milliseconds; the ~24h lifetime is kept minus skew.
+			name:      "root token with expires_in millis",
+			body:      `{"token":"jt-root","expires_in":86400000}`,
+			wantToken: "jt-root",
+			wantTTL:   24*time.Hour - qoderJobTokenRefreshSkew,
+		},
+		{
+			name:      "nested data jobToken defaults ttl",
+			body:      `{"data":{"jobToken":"jt-nested"}}`,
+			wantToken: "jt-nested",
+			wantTTL:   qoderJobTokenDefaultTTL,
+		},
+		{
+			name:      "non jt token ignored",
+			body:      `{"token":"pt-not-a-job-token"}`,
+			wantToken: "",
+			wantTTL:   0,
+		},
+		{
+			// A sub-skew lifetime is clamped up to the minimum.
+			name:      "tiny expiry clamped to min",
+			body:      `{"jt":"jt-small","expires_in":1}`,
+			wantToken: "jt-small",
+			wantTTL:   qoderJobTokenMinTTL,
+		},
+		{
+			name:      "invalid json",
+			body:      `not-json`,
+			wantToken: "",
+			wantTTL:   0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			token, ttl := parseQoderJobToken([]byte(tc.body))
+			if token != tc.wantToken {
+				t.Fatalf("token = %q, want %q", token, tc.wantToken)
+			}
+			if ttl != tc.wantTTL {
+				t.Fatalf("ttl = %v, want %v", ttl, tc.wantTTL)
+			}
+		})
+	}
+}
+
+func TestParseQoderJobToken_ExpiresAtTimestamp(t *testing.T) {
+	// The RFC3339 expires_at takes precedence over expires_in. The captured
+	// real response reports both; the absolute timestamp should win.
+	expiresAt := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	body := `{"token":"jt-abc","expires_at":"` + expiresAt + `","expires_in":86400000}`
+	token, ttl := parseQoderJobToken([]byte(body))
+	if token != "jt-abc" {
+		t.Fatalf("token = %q, want jt-abc", token)
+	}
+	// ~24h minus the refresh skew, allowing a small window for test runtime.
+	want := 24*time.Hour - qoderJobTokenRefreshSkew
+	if ttl > want || ttl < want-time.Minute {
+		t.Fatalf("ttl = %v, want ~%v", ttl, want)
+	}
+}
+
+func TestQoderQuotaFromStatus(t *testing.T) {
+	reset := int64(1786374621453)
+	wantReset := time.UnixMilli(reset).UTC().Format(time.RFC3339)
+
+	// Pro Trial with quota:0 and not exceeded — the captured real account. It
+	// must report the plan (from userTag) with no misleading usage bar.
+	trial := qoderQuotaFromStatus(&qoderUserStatus{
+		UserType: "personal_professional_trial", Quota: 0, IsQuotaExceeded: false,
+		Plan: "PLAN_TIER_PRO_TRIAL", UserTag: "Pro Trial", NextResetAt: reset,
+	})
+	if trial.PlanName != "Pro Trial" {
+		t.Fatalf("trial plan = %q, want Pro Trial", trial.PlanName)
+	}
+	if len(trial.Quotas) != 0 {
+		t.Fatalf("trial quotas = %d, want 0 (pooled/plan-only)", len(trial.Quotas))
+	}
+	if trial.Message == "" {
+		t.Fatalf("trial message empty, want a plan message")
+	}
+
+	// A finite per-user quota renders a full-remaining bar with an RFC3339 reset.
+	metered := qoderQuotaFromStatus(&qoderUserStatus{
+		UserType: "personal", Quota: 500, IsQuotaExceeded: false,
+		Plan: "PLAN_TIER_PRO", NextResetAt: reset,
+	})
+	if metered.PlanName != "Pro" {
+		t.Fatalf("metered plan = %q, want Pro (prettified from PLAN_TIER_PRO)", metered.PlanName)
+	}
+	if len(metered.Quotas) != 1 {
+		t.Fatalf("metered quotas = %d, want 1", len(metered.Quotas))
+	}
+	if q := metered.Quotas[0]; q.Limit != 500 || q.Remaining != 500 || q.ResetAt != wantReset {
+		t.Fatalf("metered quota = %+v, want limit 500 remaining 500 reset %s", q, wantReset)
+	}
+
+	// Exhausted quota reports a 0-remaining bar so routing can skip the account.
+	exceeded := qoderQuotaFromStatus(&qoderUserStatus{
+		UserType: "personal", Quota: 100, IsQuotaExceeded: true, UserTag: "Pro", NextResetAt: reset,
+	})
+	if len(exceeded.Quotas) != 1 || exceeded.Quotas[0].Remaining != 0 {
+		t.Fatalf("exceeded quota = %+v, want a single 0-remaining entry", exceeded.Quotas)
+	}
+
+	// Team seats draw from a pooled org quota; quota:0 there means pooled.
+	team := qoderQuotaFromStatus(&qoderUserStatus{
+		UserType: "teams", Quota: 0, IsQuotaExceeded: false, UserTag: "Team",
+	})
+	if len(team.Quotas) != 0 || team.Message == "" {
+		t.Fatalf("team quota = %+v msg=%q, want plan-only pooled", team.Quotas, team.Message)
+	}
+}
+
+func TestPrettifyQoderPlan(t *testing.T) {
+	cases := []struct{ plan, tag, want string }{
+		{"PLAN_TIER_PRO_TRIAL", "Pro Trial", "Pro Trial"}, // userTag preferred
+		{"PLAN_TIER_PRO_TRIAL", "", "Pro Trial"},          // prettified enum
+		{"PLAN_TIER_ENTERPRISE", "", "Enterprise"},
+		{"", "", "Qoder"}, // fallback
+	}
+	for _, tc := range cases {
+		if got := prettifyQoderPlan(tc.plan, tc.tag); got != tc.want {
+			t.Errorf("prettifyQoderPlan(%q, %q) = %q, want %q", tc.plan, tc.tag, got, tc.want)
+		}
 	}
 }

--- a/backend/internal/core/errors.go
+++ b/backend/internal/core/errors.go
@@ -71,6 +71,11 @@ type ProviderError struct {
 	Message string
 	// RetryAfter, when non-zero, is the upstream-suggested cooldown.
 	RetryAfter time.Duration
+	// CreditsExhausted marks a quota_exhausted error caused by a depleted
+	// paid balance rather than a scheduled quota window. A dry balance never
+	// recovers on its own — the user must top up — so the dispatcher parks
+	// the account for a long horizon and flags it for the dashboard.
+	CreditsExhausted bool
 	// RetrySystemInstruction requests one centrally routed retry with an
 	// additional system instruction. Connectors use this for completed
 	// responses that are structurally invalid or clearly incomplete.

--- a/backend/internal/dispatch/dispatch.go
+++ b/backend/internal/dispatch/dispatch.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"sort"
 	"sync"
 	"time"
@@ -59,7 +60,24 @@ const (
 	ProviderCircuitMaxCooldown = 2 * time.Minute
 	// ProviderCircuitResetWindow forgets isolated failures after a quiet period.
 	ProviderCircuitResetWindow = time.Minute
+	// FailureDedupWindow collapses concurrent failures on one account into a
+	// single cooldown escalation. Without it, N in-flight requests failing on
+	// the same credential advance the backoff level N steps at once.
+	FailureDedupWindow = 5 * time.Second
+	// BackoffJitterFraction is the maximum random extension applied to locally
+	// computed cooldowns so accounts that failed together do not all become
+	// eligible again at the same instant.
+	BackoffJitterFraction = 0.25
+	// CreditsExhaustedCooldown parks an account whose paid balance is
+	// depleted. A dry balance only recovers when the user tops up or the plan
+	// renews, so probing every half hour just burns requests — one automatic
+	// retry per day plus manual reset via the dashboard covers recovery.
+	CreditsExhaustedCooldown = 24 * time.Hour
 )
+
+// maxRecentFailureEntries bounds the failure-dedup map; expired entries are
+// swept lazily once the map reaches this size.
+const maxRecentFailureEntries = 4096
 
 // Target is one candidate in a fallback chain.
 type Target struct {
@@ -147,6 +165,10 @@ type Dispatcher struct {
 	selectionLocks sync.Map
 	circuitMu      sync.Mutex
 	circuits       map[string]providerCircuit
+	// recentFailures tracks the last cooldown escalation per account (or
+	// account+model) so a burst of parallel failures counts once.
+	failureMu      sync.Mutex
+	recentFailures map[string]time.Time
 	// defaultCooldown is applied to an account when an error carries no
 	// upstream-specified Retry-After.
 	defaultCooldown time.Duration
@@ -166,6 +188,7 @@ func New(conns ConnectorSource, accounts *store.AccountRepo, v *vault.Vault) *Di
 		vault:           v,
 		defaultCooldown: 60 * time.Second,
 		circuits:        make(map[string]providerCircuit),
+		recentFailures:  make(map[string]time.Time),
 	}
 }
 
@@ -323,6 +346,11 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 	attempts := make([]Attempt, 0, len(ordered))
 	unhealthyAttempts := make([]Attempt, 0, len(ordered))
 	var lastReason string
+	// nonCooldownReason remembers accounts skipped for actionable reasons
+	// (needs-reconnect, token refresh failure). Without it, one account on
+	// cooldown makes the final error read as a pure rate limit and masks the
+	// real problem on the remaining accounts.
+	var nonCooldownReason string
 	var earliestRetryAt time.Time
 	blockedScope := core.FailureScopeAccount
 
@@ -400,6 +428,7 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 			// they need the user to re-authenticate before serving traffic.
 			if acc.NeedsReconnect {
 				lastReason = fmt.Sprintf("account %s needs reconnection (refresh token revoked)", acc.ID)
+				nonCooldownReason = lastReason
 				continue
 			}
 			// Model-level cooldown: skip this account only for this model.
@@ -433,6 +462,7 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 			}
 			if prepared.err != nil {
 				lastReason = prepared.err.Error()
+				nonCooldownReason = fmt.Sprintf("account %s: %v", acc.ID, prepared.err)
 				continue
 			}
 
@@ -465,10 +495,16 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 			if retryAfter < 0 {
 				retryAfter = 0
 			}
+			msg := "dispatch: all matching candidates are temporarily unavailable"
+			// Surface non-cooldown skips so a dead account (revoked refresh
+			// token, vault error) is not misdiagnosed as a plain rate limit.
+			if nonCooldownReason != "" {
+				msg += "; also skipped: " + nonCooldownReason
+			}
 			return nil, &core.ProviderError{
 				Kind:       core.ErrRateLimit,
 				Scope:      blockedScope,
-				Message:    "dispatch: all matching candidates are temporarily unavailable",
+				Message:    msg,
 				RetryAfter: retryAfter,
 			}
 		}
@@ -489,7 +525,9 @@ func (d *Dispatcher) PlanWith(ctx context.Context, tenantID string, targets []Ta
 
 // NoteFailure applies cooldowns to an account (and optionally a model) based on
 // a provider error. Exponential backoff increases the cooldown on repeated
-// failures for rate-limit / quota errors.
+// failures for rate-limit / quota errors. Concurrent failures on the same
+// account within FailureDedupWindow escalate once, and locally computed
+// cooldowns carry jitter so cooled accounts recover at staggered times.
 //
 // Two categories of error are explicitly NOT cooled down:
 //   - Client cancellations (user pressed Esc, client closed connection): the
@@ -518,6 +556,16 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 		}
 		err.RetryAfter = cooldown
 		if d.routing != nil && err.Model != "" {
+			if !d.shouldEscalateFailure(accountID+"\x00"+err.Model, time.Now()) {
+				// A concurrent failure already locked this model; report the
+				// cooldown it set instead of extending the lock again.
+				if exps, rerr := d.routing.ActiveCooldownExpirations(ctx, []string{accountID}, err.Model); rerr == nil {
+					if until, ok := exps[accountID]; ok {
+						err.RetryAfter = max(time.Until(until), 0)
+					}
+				}
+				return
+			}
 			_ = d.routing.SetModelCooldown(ctx, accountID, err.Model, time.Now().Add(cooldown))
 		}
 		return
@@ -530,14 +578,10 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 		return
 	}
 
-	var cooldown time.Duration
+	// Classify first so errors that never cool down cannot consume the dedup
+	// window and suppress a real cooldown moments later.
 	switch err.Kind {
-	case core.ErrRateLimit:
-		cooldown = d.exponentialCooldown(ctx, accountID)
-	case core.ErrQuotaExhausted:
-		cooldown = 30 * time.Minute
-	case core.ErrAuth:
-		cooldown = 5 * time.Minute
+	case core.ErrRateLimit, core.ErrQuotaExhausted, core.ErrAuth:
 	case core.ErrUpstream, core.ErrTimeout:
 		// Self-inflicted timeout: our own request deadline fired while the
 		// upstream was still processing. The provider is healthy — skip
@@ -546,11 +590,44 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 			errors.Is(err.Cause, context.DeadlineExceeded) {
 			return
 		}
-		// Transient errors: apply a short cooldown so the account gets a
-		// breather without being locked out for too long.
-		cooldown = TransientCooldown
 	default:
 		return
+	}
+
+	if !d.shouldEscalateFailure(accountID, time.Now()) {
+		// A concurrent failure already cooled this account down; report the
+		// cooldown it set instead of advancing the backoff level again.
+		if acc, aerr := d.accounts.Get(ctx, accountID); aerr == nil && acc.CooldownUntil != nil {
+			if remaining := time.Until(*acc.CooldownUntil); remaining > err.RetryAfter {
+				err.RetryAfter = remaining
+			}
+		}
+		return
+	}
+
+	var cooldown time.Duration
+	jitter := true
+	switch err.Kind {
+	case core.ErrRateLimit:
+		cooldown = d.exponentialCooldown(ctx, accountID)
+	case core.ErrQuotaExhausted:
+		cooldown = 30 * time.Minute
+		if err.CreditsExhausted {
+			// A depleted paid balance is terminal until the user tops up.
+			// Park the account for a day instead of thrashing through
+			// half-hour cooldowns; jitter is pointless at this horizon.
+			cooldown = CreditsExhaustedCooldown
+			jitter = false
+		}
+	case core.ErrAuth:
+		cooldown = 5 * time.Minute
+	default:
+		// Transient upstream errors: apply a short cooldown so the account
+		// gets a breather without being locked out for too long.
+		cooldown = TransientCooldown
+	}
+	if jitter {
+		cooldown = withJitter(cooldown)
 	}
 
 	// An upstream reset time is a lower bound. Never replace it with the much
@@ -562,6 +639,13 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 	err.RetryAfter = cooldown
 
 	_ = d.accounts.SetCooldown(ctx, accountID, time.Now().Add(cooldown))
+
+	// A depleted balance is terminal until the user tops up: flag the account
+	// so the dashboard can surface it and a manual reset can clear it. The
+	// flag also clears automatically on the next successful request.
+	if err.Kind == core.ErrQuotaExhausted && err.CreditsExhausted {
+		_ = d.accounts.SetCreditsExhausted(ctx, accountID, true)
+	}
 
 	// Also set a model-level cooldown when a model is specified, so other
 	// models on the same account remain available.
@@ -575,6 +659,14 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 // cooldown. Called by the pipeline after a successful upstream response.
 func (d *Dispatcher) NoteSuccess(ctx context.Context, provider, accountID, model string) {
 	_ = d.accounts.ResetBackoffLevel(ctx, accountID)
+	// A success proves the account recovered, so a later failure is a fresh
+	// incident rather than part of the burst that set the dedup marker.
+	d.failureMu.Lock()
+	delete(d.recentFailures, accountID)
+	if model != "" {
+		delete(d.recentFailures, accountID+"\x00"+model)
+	}
+	d.failureMu.Unlock()
 	if d.routing != nil && model != "" {
 		_ = d.routing.ClearModelCooldown(ctx, accountID, model)
 	}
@@ -582,6 +674,44 @@ func (d *Dispatcher) NoteSuccess(ctx context.Context, provider, accountID, model
 		_ = d.health.MarkHealthy(ctx, accountID, model)
 	}
 	d.recordProviderSuccess(provider)
+}
+
+// shouldEscalateFailure reports whether this failure should escalate cooldown
+// state for key, recording it when so. Failures arriving within
+// FailureDedupWindow of a recorded one are collapsed: a burst of parallel
+// requests dying on the same credential is one incident, not N, so the backoff
+// level advances a single step and the cooldown horizon is set once.
+func (d *Dispatcher) shouldEscalateFailure(key string, now time.Time) bool {
+	d.failureMu.Lock()
+	defer d.failureMu.Unlock()
+	if last, ok := d.recentFailures[key]; ok && now.Sub(last) < FailureDedupWindow {
+		return false
+	}
+	if len(d.recentFailures) >= maxRecentFailureEntries {
+		for k, ts := range d.recentFailures {
+			if now.Sub(ts) >= FailureDedupWindow {
+				delete(d.recentFailures, k)
+			}
+		}
+	}
+	d.recentFailures[key] = now
+	return true
+}
+
+// withJitter extends a locally computed cooldown by a random amount up to
+// BackoffJitterFraction of its length. Accounts that fail together (e.g. a
+// shared quota window closing) then recover at staggered times instead of
+// receiving the retry burst simultaneously. Jitter is never applied to
+// upstream-specified Retry-After values, which remain exact lower bounds.
+func withJitter(cooldown time.Duration) time.Duration {
+	if cooldown <= 0 {
+		return cooldown
+	}
+	span := int64(float64(cooldown) * BackoffJitterFraction)
+	if span <= 0 {
+		return cooldown
+	}
+	return cooldown + time.Duration(rand.Int64N(span+1))
 }
 
 // exponentialCooldown computes the cooldown duration using exponential backoff.

--- a/backend/internal/dispatch/dispatch.go
+++ b/backend/internal/dispatch/dispatch.go
@@ -594,7 +594,11 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 		return
 	}
 
-	if !d.shouldEscalateFailure(accountID, time.Now()) {
+	// A depleted paid balance is terminal: the 24h park and credits flag are
+	// semantically stronger than whatever short cooldown a concurrent failure
+	// in the same burst may have set, so it must not be deduped away.
+	creditsExhausted := err.Kind == core.ErrQuotaExhausted && err.CreditsExhausted
+	if !d.shouldEscalateFailure(accountID, time.Now()) && !creditsExhausted {
 		// A concurrent failure already cooled this account down; report the
 		// cooldown it set instead of advancing the backoff level again.
 		if acc, aerr := d.accounts.Get(ctx, accountID); aerr == nil && acc.CooldownUntil != nil {
@@ -643,7 +647,7 @@ func (d *Dispatcher) NoteFailure(ctx context.Context, accountID string, err *cor
 	// A depleted balance is terminal until the user tops up: flag the account
 	// so the dashboard can surface it and a manual reset can clear it. The
 	// flag also clears automatically on the next successful request.
-	if err.Kind == core.ErrQuotaExhausted && err.CreditsExhausted {
+	if creditsExhausted {
 		_ = d.accounts.SetCreditsExhausted(ctx, accountID, true)
 	}
 

--- a/backend/internal/dispatch/dispatch_test.go
+++ b/backend/internal/dispatch/dispatch_test.go
@@ -367,6 +367,27 @@ func TestNoteFailureCreditsExhaustedParksAccount(t *testing.T) {
 	require.Nil(t, account.CooldownUntil)
 }
 
+func TestNoteFailureCreditsExhaustedBypassesDedup(t *testing.T) {
+	ctx := context.Background()
+	d, db := newDispatchTest(t, testAccount("acc-dry-burst", 10))
+
+	// A rate-limit failure consumes the dedup window first; the terminal
+	// credits failure arriving inside the window must still park and flag
+	// the account instead of being collapsed into the short cooldown.
+	d.NoteFailure(ctx, "acc-dry-burst", &core.ProviderError{Kind: core.ErrRateLimit})
+	d.NoteFailure(ctx, "acc-dry-burst", &core.ProviderError{
+		Kind:             core.ErrQuotaExhausted,
+		CreditsExhausted: true,
+	})
+
+	account, err := db.Accounts().Get(ctx, "acc-dry-burst")
+	require.NoError(t, err)
+	require.True(t, account.CreditsExhausted, "the terminal credits flag must not be deduped away")
+	require.NotNil(t, account.CooldownUntil)
+	require.WithinDuration(t, time.Now().Add(CreditsExhaustedCooldown), *account.CooldownUntil, time.Minute,
+		"the 24h park must replace the short rate-limit cooldown")
+}
+
 func TestNoteFailurePlainQuotaDoesNotFlagCredits(t *testing.T) {
 	ctx := context.Background()
 	d, db := newDispatchTest(t, testAccount("acc-quota", 10))

--- a/backend/internal/dispatch/dispatch_test.go
+++ b/backend/internal/dispatch/dispatch_test.go
@@ -281,6 +281,117 @@ func TestNoteFailureHonorsRateLimitRetryAfter(t *testing.T) {
 	require.WithinDuration(t, started.Add(4*time.Minute), *account.CooldownUntil, 2*time.Second)
 }
 
+func TestNoteFailureDedupsConcurrentFailures(t *testing.T) {
+	ctx := context.Background()
+	d, db := newDispatchTest(t, testAccount("acc-burst", 10))
+
+	// A burst of parallel requests failing on the same account must advance
+	// the backoff level once, not once per request.
+	for range 5 {
+		d.NoteFailure(ctx, "acc-burst", &core.ProviderError{Kind: core.ErrRateLimit})
+	}
+
+	account, err := db.Accounts().Get(ctx, "acc-burst")
+	require.NoError(t, err)
+	require.Equal(t, 1, account.BackoffLevel)
+	require.NotNil(t, account.CooldownUntil)
+}
+
+func TestNoteFailureDedupSuppressedStillReportsRetryAfter(t *testing.T) {
+	ctx := context.Background()
+	d, _ := newDispatchTest(t, testAccount("acc-hint", 10))
+
+	first := &core.ProviderError{Kind: core.ErrRateLimit, RetryAfter: 4 * time.Minute}
+	d.NoteFailure(ctx, "acc-hint", first)
+
+	// The suppressed failure reuses the cooldown set by the first one so the
+	// caller still surfaces an accurate retry hint.
+	second := &core.ProviderError{Kind: core.ErrRateLimit}
+	d.NoteFailure(ctx, "acc-hint", second)
+	require.Greater(t, second.RetryAfter, 3*time.Minute)
+}
+
+func TestNoteSuccessResetsFailureDedup(t *testing.T) {
+	ctx := context.Background()
+	d, db := newDispatchTest(t, testAccount("acc-recover", 10))
+
+	d.NoteFailure(ctx, "acc-recover", &core.ProviderError{Kind: core.ErrRateLimit})
+	d.NoteSuccess(ctx, "openai", "acc-recover", "gpt-4o")
+
+	// After a success the next failure is a fresh incident: it must apply a
+	// cooldown again instead of being swallowed by the dedup window.
+	d.NoteFailure(ctx, "acc-recover", &core.ProviderError{Kind: core.ErrRateLimit})
+
+	account, err := db.Accounts().Get(ctx, "acc-recover")
+	require.NoError(t, err)
+	require.Equal(t, 1, account.BackoffLevel)
+	require.NotNil(t, account.CooldownUntil)
+	require.True(t, account.CooldownUntil.After(time.Now()))
+}
+
+func TestNonCoolingErrorDoesNotConsumeDedupWindow(t *testing.T) {
+	ctx := context.Background()
+	d, db := newDispatchTest(t, testAccount("acc-mixed", 10))
+
+	// A client cancellation never cools down and must not suppress the real
+	// rate-limit failure that follows it.
+	d.NoteFailure(ctx, "acc-mixed", &core.ProviderError{Kind: core.ErrClientCanceled})
+	d.NoteFailure(ctx, "acc-mixed", &core.ProviderError{Kind: core.ErrRateLimit})
+
+	account, err := db.Accounts().Get(ctx, "acc-mixed")
+	require.NoError(t, err)
+	require.NotNil(t, account.CooldownUntil)
+}
+
+func TestNoteFailureCreditsExhaustedParksAccount(t *testing.T) {
+	ctx := context.Background()
+	d, db := newDispatchTest(t, testAccount("acc-dry", 10))
+
+	d.NoteFailure(ctx, "acc-dry", &core.ProviderError{
+		Kind:             core.ErrQuotaExhausted,
+		CreditsExhausted: true,
+	})
+
+	account, err := db.Accounts().Get(ctx, "acc-dry")
+	require.NoError(t, err)
+	require.True(t, account.CreditsExhausted, "a dry balance must flag the account")
+	require.NotNil(t, account.CooldownUntil)
+	require.WithinDuration(t, time.Now().Add(CreditsExhaustedCooldown), *account.CooldownUntil, time.Minute,
+		"a dry balance must park the account for the full credits cooldown")
+
+	// A later success (the user topped up) restores the account fully.
+	d.NoteSuccess(ctx, "openai", "acc-dry", "gpt-4o")
+	account, err = db.Accounts().Get(ctx, "acc-dry")
+	require.NoError(t, err)
+	require.False(t, account.CreditsExhausted)
+	require.Nil(t, account.CooldownUntil)
+}
+
+func TestNoteFailurePlainQuotaDoesNotFlagCredits(t *testing.T) {
+	ctx := context.Background()
+	d, db := newDispatchTest(t, testAccount("acc-quota", 10))
+
+	// A calendar-window quota (daily/monthly) is not a dry balance: cooldown
+	// applies but the terminal credits flag must stay clear.
+	d.NoteFailure(ctx, "acc-quota", &core.ProviderError{Kind: core.ErrQuotaExhausted})
+
+	account, err := db.Accounts().Get(ctx, "acc-quota")
+	require.NoError(t, err)
+	require.False(t, account.CreditsExhausted)
+	require.NotNil(t, account.CooldownUntil)
+}
+
+func TestWithJitterStaysWithinBounds(t *testing.T) {
+	base := 100 * time.Second
+	limit := base + time.Duration(float64(base)*BackoffJitterFraction)
+	for range 100 {
+		got := withJitter(base)
+		require.GreaterOrEqual(t, got, base)
+		require.LessOrEqual(t, got, limit)
+	}
+	require.Equal(t, time.Duration(0), withJitter(0))
+}
+
 func TestPlanWith_AllowedAccountPinsCredential(t *testing.T) {
 	ctx := context.Background()
 	d, _ := newDispatchTest(t,
@@ -350,7 +461,10 @@ func TestPlanWith_AllCandidatesCoolingReturnsTypedRetry(t *testing.T) {
 	require.Equal(t, core.ErrRateLimit, pe.Kind)
 	require.Equal(t, core.FailureScopeAccount, pe.EffectiveScope())
 	require.Greater(t, pe.RetryAfter, time.Duration(0))
-	require.LessOrEqual(t, pe.RetryAfter, 2*time.Second)
+	// The upstream Retry-After is a lower bound; the local cooldown may extend
+	// it by up to BackoffJitterFraction.
+	maxRetry := time.Duration(float64(2*time.Second) * (1 + BackoffJitterFraction))
+	require.LessOrEqual(t, pe.RetryAfter, maxRetry)
 }
 
 func TestProviderCircuitOpensAndSuccessClosesIt(t *testing.T) {

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -3136,6 +3136,12 @@ func providerAccountMetadata(spec connectors.ProviderSpec, in providerMetadataIn
 		}
 		// OpenAICompatible resolves {accountId} placeholders from Extra.
 		meta["accountId"] = accountID
+	case "qoder":
+		// API-key connections to Qoder use a Personal Access Token (pt-*),
+		// which the connector exchanges for a short-lived COSY job token. Mark
+		// the auth method and mint a stable machine id for the COSY envelope.
+		meta["qoder_auth_method"] = "pat"
+		meta["machine_id"] = uuid.NewString()
 	case "azure":
 		endpoint := strings.TrimRight(strings.TrimSpace(in.AzureEndpoint), "/")
 		deployment := strings.TrimSpace(in.AzureDeployment)

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -640,8 +640,9 @@ func (s *Server) adminListAccounts(w http.ResponseWriter, r *http.Request) {
 			"id": a.ID, "provider": a.Provider, "label": a.Label,
 			"auth_kind": a.AuthKind, "priority": a.Priority,
 			"disabled": a.Disabled, "proxy_pool_id": a.ProxyPoolID,
-			"needs_reconnect": a.NeedsReconnect,
-			"created_at":      a.CreatedAt,
+			"needs_reconnect":   a.NeedsReconnect,
+			"credits_exhausted": a.CreditsExhausted,
+			"created_at":        a.CreatedAt,
 		})
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"accounts": out})

--- a/backend/internal/gateway/handlers.go
+++ b/backend/internal/gateway/handlers.go
@@ -352,12 +352,33 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
+	// Heartbeats keep intermediate proxies from dropping the client connection
+	// as idle while the upstream model is silent (long thinking phases produce
+	// no SSE output). NDJSON has no comment syntax, so Ollama clients are
+	// exempt.
+	heartbeatInterval := s.cfg.Server.StreamHeartbeatInterval
+	if req.Metadata.SourceDialect == core.DialectOllama {
+		heartbeatInterval = 0
+	}
+
 	// Direct stream path: frame SSE events without decoding normal payloads. This
 	// preserves the low-overhead path while replacing late in-band provider
 	// errors before they can reach the client.
 	if result.DirectBody != nil {
 		defer result.DirectBody.Close()
-		n, cpErr := copySanitizedStream(w, result.DirectBody, req.Metadata.SourceDialect, flusher.Flush)
+		dst := io.Writer(w)
+		frameFlush := flusher.Flush
+		var hw *heartbeatWriter
+		if heartbeatInterval > 0 {
+			hw = newHeartbeatWriter(w, flusher.Flush, heartbeatInterval)
+			defer hw.stop()
+			dst = hw
+			frameFlush = nil // the heartbeat writer flushes after every frame
+		}
+		n, cpErr := copySanitizedStream(dst, result.DirectBody, req.Metadata.SourceDialect, frameFlush)
+		if hw != nil {
+			hw.stop()
+		}
 		if cpErr != nil && !isClientDisconnect(cpErr) {
 			s.consoleLog.Log("ERROR", fmt.Sprintf("Stream interrupted after %s", humanBytes(int(n))), cpErr.Error())
 			s.log.Warn("direct stream error", "bytes", n, "err", cpErr)
@@ -455,32 +476,64 @@ func (s *Server) streamChat(w http.ResponseWriter, r *http.Request, codec transf
 		flusher.Flush()
 	}
 
+	var heartbeatC <-chan time.Time
+	if heartbeatInterval > 0 {
+		heartbeatTicker := time.NewTicker(heartbeatInterval)
+		defer heartbeatTicker.Stop()
+		heartbeatC = heartbeatTicker.C
+	}
+	lastActivity := time.Now()
+
 	var streamErr error
-	for chunk := range result.Chunks {
-		if chunk.Type == core.ChunkError {
-			streamErr = chunk.Err
-			if streamErr == nil {
-				streamErr = &core.ProviderError{Kind: core.ErrUpstream, Message: "provider stream failed"}
+streamLoop:
+	for {
+		select {
+		case chunk, ok := <-result.Chunks:
+			if !ok {
+				break streamLoop
 			}
-			s.consoleLog.Log("ERROR", "Provider stream error", fmt.Sprintf("%v", streamErr))
-			s.log.Warn("stream error", "err", streamErr)
-			_, _ = bw.Write(streamErrorEvent(req.Metadata.SourceDialect, sanitizeUpstreamError(streamErr)))
-			// Emit terminal events so strict clients (Claude Code, Cline) see a
-			// well-formed stream end instead of a truncated connection. Without
-			// message_stop/[DONE], the client may treat the stream as incomplete
-			// and retry the request — causing duplicate responses on the user side.
-			for _, ev := range streamCodec.RenderStreamDone(state) {
-				_, _ = bw.Write(ev)
+			lastActivity = time.Now()
+			if chunk.Type == core.ChunkError {
+				streamErr = chunk.Err
+				if streamErr == nil {
+					streamErr = &core.ProviderError{Kind: core.ErrUpstream, Message: "provider stream failed"}
+				}
+				s.consoleLog.Log("ERROR", "Provider stream error", fmt.Sprintf("%v", streamErr))
+				s.log.Warn("stream error", "err", streamErr)
+				_, _ = bw.Write(streamErrorEvent(req.Metadata.SourceDialect, sanitizeUpstreamError(streamErr)))
+				// Emit terminal events so strict clients (Claude Code, Cline) see a
+				// well-formed stream end instead of a truncated connection. Without
+				// message_stop/[DONE], the client may treat the stream as incomplete
+				// and retry the request — causing duplicate responses on the user side.
+				for _, ev := range streamCodec.RenderStreamDone(state) {
+					_, _ = bw.Write(ev)
+				}
+				_ = bw.Flush()
+				flusher.Flush()
+				break streamLoop
 			}
-			_ = bw.Flush()
+			if chunk.Type == core.ChunkUsage && chunk.Usage != nil {
+				totalTokens = chunk.Usage.PromptTokens + chunk.Usage.CompletionTokens
+			}
+			chunkCount++
+			sanitizer.Process(chunk, renderChunk)
+		case <-heartbeatC:
+			// Only beat when the stream has actually been silent; steady chunk
+			// traffic is its own keep-alive.
+			if time.Since(lastActivity) < heartbeatInterval {
+				continue
+			}
+			if _, werr := bw.Write(sseHeartbeatFrame); werr != nil {
+				streamErr = &streamWriteError{err: werr}
+				break streamLoop
+			}
+			if werr := bw.Flush(); werr != nil {
+				streamErr = &streamWriteError{err: werr}
+				break streamLoop
+			}
 			flusher.Flush()
-			break
+			lastActivity = time.Now()
 		}
-		if chunk.Type == core.ChunkUsage && chunk.Usage != nil {
-			totalTokens = chunk.Usage.PromptTokens + chunk.Usage.CompletionTokens
-		}
-		chunkCount++
-		sanitizer.Process(chunk, renderChunk)
 	}
 
 	latency := int(time.Since(streamStart).Milliseconds())

--- a/backend/internal/gateway/heartbeat.go
+++ b/backend/internal/gateway/heartbeat.go
@@ -1,0 +1,106 @@
+package gateway
+
+import (
+	"io"
+	"sync"
+	"time"
+)
+
+// sseHeartbeatFrame is an SSE comment event. Spec-compliant SSE clients ignore
+// comment lines, so it is safe to interleave between real events; its only job
+// is to keep bytes flowing so proxies between KeiRouter and the client do not
+// drop the connection as idle while the upstream model is silent.
+var sseHeartbeatFrame = []byte(": keep-alive\n\n")
+
+// heartbeatWriter wraps a client stream writer and emits sseHeartbeatFrame
+// whenever no data has been written for the configured interval. It exists for
+// the direct (zero-copy) stream path, where the copy loop blocks on upstream
+// reads and cannot time-share heartbeats itself.
+//
+// All writes — frames from the copy loop and heartbeats from the background
+// goroutine — are serialized by a mutex, and the copy loop only ever writes
+// complete SSE frames per Write call, so a heartbeat can never split a frame.
+// Flushing is folded into Write so the underlying http.Flusher is also never
+// used concurrently.
+type heartbeatWriter struct {
+	mu       sync.Mutex
+	dst      io.Writer
+	flush    func()
+	interval time.Duration
+	last     time.Time
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// newHeartbeatWriter starts the heartbeat goroutine; callers must invoke stop
+// when the stream ends, or the goroutine leaks for the life of the process.
+func newHeartbeatWriter(dst io.Writer, flush func(), interval time.Duration) *heartbeatWriter {
+	hw := &heartbeatWriter{
+		dst:      dst,
+		flush:    flush,
+		interval: interval,
+		last:     time.Now(),
+		stopCh:   make(chan struct{}),
+		doneCh:   make(chan struct{}),
+	}
+	go hw.run()
+	return hw
+}
+
+// Write forwards one complete frame to the client and flushes it immediately,
+// matching the per-frame flush behavior of the unwrapped direct path.
+func (hw *heartbeatWriter) Write(p []byte) (int, error) {
+	hw.mu.Lock()
+	defer hw.mu.Unlock()
+	n, err := hw.dst.Write(p)
+	hw.last = time.Now()
+	if err == nil && hw.flush != nil {
+		hw.flush()
+	}
+	return n, err
+}
+
+func (hw *heartbeatWriter) run() {
+	defer close(hw.doneCh)
+	ticker := time.NewTicker(hw.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-hw.stopCh:
+			return
+		case <-ticker.C:
+			if !hw.beat() {
+				return
+			}
+		}
+	}
+}
+
+// beat sends a heartbeat if the stream has been silent for a full interval.
+// It reports false when the client is gone, which permanently stops the
+// heartbeat loop; the copy loop discovers the same failure on its next write.
+func (hw *heartbeatWriter) beat() bool {
+	hw.mu.Lock()
+	defer hw.mu.Unlock()
+	if time.Since(hw.last) < hw.interval {
+		return true
+	}
+	n, err := hw.dst.Write(sseHeartbeatFrame)
+	if err != nil || n != len(sseHeartbeatFrame) {
+		return false
+	}
+	hw.last = time.Now()
+	if hw.flush != nil {
+		hw.flush()
+	}
+	return true
+}
+
+// stop terminates the heartbeat loop and waits until it can no longer write to
+// the response. Waiting is required before the handler performs its final flush
+// or returns the ResponseWriter to net/http.
+func (hw *heartbeatWriter) stop() {
+	hw.stopOnce.Do(func() { close(hw.stopCh) })
+	<-hw.doneCh
+}

--- a/backend/internal/gateway/heartbeat_test.go
+++ b/backend/internal/gateway/heartbeat_test.go
@@ -1,0 +1,130 @@
+package gateway
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestHeartbeatWriterEmitsAfterIdle(t *testing.T) {
+	var dst lockedBuffer
+	flushed := make(chan struct{}, 4)
+	hw := newHeartbeatWriter(&dst, func() {
+		select {
+		case flushed <- struct{}{}:
+		default:
+		}
+	}, 10*time.Millisecond)
+	t.Cleanup(hw.stop)
+
+	select {
+	case <-flushed:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat was not flushed after idle interval")
+	}
+	hw.stop()
+
+	if got := dst.String(); got != string(sseHeartbeatFrame) {
+		t.Fatalf("heartbeat output = %q, want %q", got, sseHeartbeatFrame)
+	}
+}
+
+func TestHeartbeatWriterDataWritePostponesHeartbeat(t *testing.T) {
+	var dst lockedBuffer
+	interval := 80 * time.Millisecond
+	hw := newHeartbeatWriter(&dst, nil, interval)
+	t.Cleanup(hw.stop)
+
+	time.Sleep(interval / 2)
+	frame := []byte("data: hello\n\n")
+	if n, err := hw.Write(frame); err != nil || n != len(frame) {
+		t.Fatalf("Write = (%d, %v), want (%d, nil)", n, err, len(frame))
+	}
+
+	// First ticker firing occurs less than one interval after the data write.
+	time.Sleep(3 * interval / 4)
+	hw.stop()
+	if got := dst.String(); got != string(frame) {
+		t.Fatalf("output before renewed idle interval = %q, want %q", got, frame)
+	}
+}
+
+func TestHeartbeatWriterStopWaitsForWriter(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	dst := &blockingWriter{entered: entered, release: release}
+	hw := newHeartbeatWriter(dst, nil, 5*time.Millisecond)
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat write did not start")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		hw.stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+		t.Fatal("stop returned while heartbeat write was active")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not return after heartbeat write completed")
+	}
+}
+
+func TestHeartbeatWriterStopsAfterWriteFailure(t *testing.T) {
+	hw := newHeartbeatWriter(errorWriter{}, nil, 5*time.Millisecond)
+	select {
+	case <-hw.doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat loop did not stop after write failure")
+	}
+	// stop remains safe after run exits on its own and when called repeatedly.
+	hw.stop()
+	hw.stop()
+}
+
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}
+
+type blockingWriter struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.entered) })
+	<-w.release
+	return len(p), nil
+}
+
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}

--- a/backend/internal/gateway/oauth.go
+++ b/backend/internal/gateway/oauth.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -31,6 +32,7 @@ func (s *Server) mountOAuth(r chi.Router) {
 	r.Post("/oauth/{provider}/device-code", s.oauthDeviceCode)
 	r.Post("/oauth/{provider}/device-code-submit", s.oauthDeviceCodeSubmit)
 	r.Post("/oauth/{provider}/poll", s.oauthPoll)
+	r.Get("/oauth/{provider}/callback-status", s.oauthCallbackStatus)
 }
 
 // oauthListProviders reports which catalog providers support an OAuth flow.
@@ -171,6 +173,72 @@ func (s *Server) oauthExchange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{"id": id, "provider": provider, "email": tokens.Email})
+}
+
+// oauthResultTTL bounds how long a finished callback result is retained for
+// the dashboard's completion polling.
+const oauthResultTTL = 10 * time.Minute
+
+type oauthResultEntry struct {
+	Provider string
+	Status   string // success | error
+	Message  string
+	At       time.Time
+}
+
+// oauthResults records the outcome of browser-redirect callbacks keyed by the
+// flow state, so the dashboard can poll for completion. postMessage from the
+// popup alone is unreliable: auth pages that set Cross-Origin-Opener-Policy
+// (OpenAI's Codex login does) sever window.opener during the redirect, so the
+// opener never hears from the popup and the user was forced into manually
+// pasting the callback URL.
+var oauthResults = struct {
+	sync.Mutex
+	m map[string]oauthResultEntry
+}{m: map[string]oauthResultEntry{}}
+
+// recordOAuthResult stores the terminal outcome of a callback for polling.
+func recordOAuthResult(state, provider string, err error) {
+	oauthResults.Lock()
+	defer oauthResults.Unlock()
+	for k, v := range oauthResults.m {
+		if time.Since(v.At) > oauthResultTTL {
+			delete(oauthResults.m, k)
+		}
+	}
+	entry := oauthResultEntry{Provider: provider, Status: "success", At: time.Now()}
+	if err != nil {
+		entry.Status = "error"
+		entry.Message = err.Error()
+	}
+	oauthResults.m[state] = entry
+}
+
+// oauthCallbackStatus lets the dashboard poll whether a redirect-based flow
+// completed server-side (the loopback/gateway callback already exchanged the
+// code and persisted the account). Responses: pending | success | error |
+// expired.
+func (s *Server) oauthCallbackStatus(w http.ResponseWriter, r *http.Request) {
+	provider := chi.URLParam(r, "provider")
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		writeError(w, http.StatusBadRequest, "state is required")
+		return
+	}
+
+	oauthResults.Lock()
+	res, ok := oauthResults.m[state]
+	oauthResults.Unlock()
+	if ok && res.Provider == provider {
+		writeJSON(w, http.StatusOK, map[string]any{"status": res.Status, "message": res.Message})
+		return
+	}
+
+	if sess, ok := s.oauthSessions.Get(state); ok && sess.Provider == provider {
+		writeJSON(w, http.StatusOK, map[string]any{"status": "pending"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "expired"})
 }
 
 // oauthCallback handles the GET redirect from OAuth providers after the user

--- a/backend/internal/gateway/oauth_loopback.go
+++ b/backend/internal/gateway/oauth_loopback.go
@@ -134,6 +134,17 @@ func (s *Server) oauthFixedLoopbackCallback(provider string, w http.ResponseWrit
 }
 
 func (s *Server) completeOAuthCallback(r *http.Request, providerHint string) error {
+	err := s.finishOAuthCallback(r, providerHint)
+	// Record the outcome keyed by state so the dashboard's completion polling
+	// works even when the popup can't reach the opener (COOP severs
+	// window.opener on some providers' auth pages, e.g. OpenAI/Codex).
+	if state := r.URL.Query().Get("state"); state != "" {
+		recordOAuthResult(state, providerHint, err)
+	}
+	return err
+}
+
+func (s *Server) finishOAuthCallback(r *http.Request, providerHint string) error {
 	code := r.URL.Query().Get("code")
 	state := r.URL.Query().Get("state")
 	if errParam := r.URL.Query().Get("error"); errParam != "" {

--- a/backend/internal/oauth/providers.go
+++ b/backend/internal/oauth/providers.go
@@ -98,8 +98,12 @@ var configs = map[string]ProviderConfig{
 		AuthorizeURL:              "https://auth.openai.com/oauth/authorize",
 		TokenURL:                  "https://auth.openai.com/oauth/token",
 		Scopes:                    []string{"openid", "profile", "email", "offline_access"},
-		ExtraAuthParams:           map[string]string{"id_token_add_organizations": "true", "codex_cli_simplified_flow": "true", "originator": "codex_cli_rs"},
-		ExtraAuthParamOrder:       []string{"id_token_add_organizations", "codex_cli_simplified_flow", "originator"},
+		// prompt=login forces a fresh Auth0 session per flow. Without it, a
+		// second Codex OAuth on the same browser reuses the first session and
+		// Auth0 invalidates the earlier account's refresh-token family as a
+		// "session takeover", breaking multi-account setups.
+		ExtraAuthParams:           map[string]string{"id_token_add_organizations": "true", "codex_cli_simplified_flow": "true", "originator": "codex_cli_rs", "prompt": "login"},
+		ExtraAuthParamOrder:       []string{"id_token_add_organizations", "codex_cli_simplified_flow", "originator", "prompt"},
 		EncodeAuthSpacesAsPercent: true,
 		CallbackPath:              "/auth/callback",
 		FixedLoopbackPort:         1455,

--- a/backend/internal/qoder/constants.go
+++ b/backend/internal/qoder/constants.go
@@ -21,6 +21,18 @@ const (
 
 	// ModelListURL returns the live model catalog (COSY-signed GET).
 	ModelListURL = "https://api3.qoder.sh/algo/api/v2/model/list"
+
+	// JobTokenExchangeURL exchanges a Personal Access Token (pt-*) for a
+	// short-lived job token (jt-*). A raw PAT cannot be used as the COSY
+	// security_oauth_token; qodercli performs this exchange first and carries
+	// the resulting jt-* in the Cosy envelope for every signed request.
+	JobTokenExchangeURL = "https://openapi.qoder.sh/api/v1/jobToken/exchange"
+
+	// UserStatusURL returns the token owner's account profile (id, email,
+	// name) and plan/quota. It authenticates with a plain Bearer job token
+	// (no COSY). The COSY envelope's uid MUST be the owner's real user id
+	// from this endpoint — a synthetic uid is rejected with "Login expired".
+	UserStatusURL = "https://openapi.qoder.sh/api/v3/user/status"
 )
 
 // COSY header fingerprint constants. These are not arbitrary — the upstream

--- a/backend/internal/store/migrations/0029_credits_exhausted.sql
+++ b/backend/internal/store/migrations/0029_credits_exhausted.sql
@@ -1,0 +1,5 @@
+-- Add credits_exhausted flag so accounts whose paid balance is depleted are
+-- parked (long cooldown) and surfaced in the dashboard instead of thrashing
+-- through short quota cooldowns. Cleared on success, provider reconnect, or
+-- expiry of the parking cooldown.
+ALTER TABLE accounts ADD COLUMN credits_exhausted INTEGER NOT NULL DEFAULT 0;

--- a/backend/internal/store/models.go
+++ b/backend/internal/store/models.go
@@ -92,6 +92,10 @@ type Account struct {
 	CooldownUntil  *time.Time
 	ProxyPoolID    string // bound proxy pool id (empty = no proxy)
 	NeedsReconnect bool   // true when the OAuth refresh token was permanently rejected (re-auth required)
+	// CreditsExhausted is true when the provider reported a depleted paid
+	// balance. The dispatcher parks the account; the flag clears on a
+	// successful request, a provider reconnect, or a manual reset.
+	CreditsExhausted bool
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/backend/internal/store/repo_accounts.go
+++ b/backend/internal/store/repo_accounts.go
@@ -20,7 +20,7 @@ const accountColumns = `id, tenant_id, provider, label, auth_kind,
 	token_wrapped_dek, token_ciphertext,
 	refresh_wrapped_dek, refresh_ciphertext,
 	token_expires_at, metadata, priority, backoff_level, disabled, cooldown_until,
-	proxy_pool_id, needs_reconnect, created_at, updated_at`
+	proxy_pool_id, needs_reconnect, credits_exhausted, created_at, updated_at`
 
 // SetBackoffLevel updates the exponential backoff level for an account.
 func (r *AccountRepo) SetBackoffLevel(ctx context.Context, id string, level int) error {
@@ -30,9 +30,10 @@ func (r *AccountRepo) SetBackoffLevel(ctx context.Context, id string, level int)
 }
 
 // ResetBackoffLevel resets the exponential backoff level to 0 and clears
-// cooldown, called on a successful request.
+// cooldown and the credits-exhausted flag, called on a successful request
+// (a success proves the balance covers traffic again).
 func (r *AccountRepo) ResetBackoffLevel(ctx context.Context, id string) error {
-	q := r.db.rebind(`UPDATE accounts SET backoff_level = 0, cooldown_until = NULL, updated_at = ? WHERE id = ?`)
+	q := r.db.rebind(`UPDATE accounts SET backoff_level = 0, cooldown_until = NULL, credits_exhausted = 0, updated_at = ? WHERE id = ?`)
 	_, err := r.db.sql.ExecContext(ctx, q, formatTime(time.Now()), id)
 	return err
 }
@@ -40,7 +41,7 @@ func (r *AccountRepo) ResetBackoffLevel(ctx context.Context, id string) error {
 // Create inserts a new account.
 func (r *AccountRepo) Create(ctx context.Context, a Account) error {
 	q := r.db.rebind(`INSERT INTO accounts (` + accountColumns + `)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	_, err := r.db.sql.ExecContext(ctx, q,
 		a.ID, a.TenantID, a.Provider, a.Label, string(a.AuthKind),
 		nullString(a.SecretWrappedDEK), nullString(a.SecretCiphertext),
@@ -48,7 +49,7 @@ func (r *AccountRepo) Create(ctx context.Context, a Account) error {
 		nullString(a.RefreshWrappedDEK), nullString(a.RefreshCiphertext),
 		nullTime(a.TokenExpiresAt), a.Metadata, a.Priority, a.BackoffLevel,
 		boolToInt(a.Disabled), nullTime(a.CooldownUntil), a.ProxyPoolID,
-		boolToInt(a.NeedsReconnect),
+		boolToInt(a.NeedsReconnect), boolToInt(a.CreditsExhausted),
 		formatTime(a.CreatedAt), formatTime(a.UpdatedAt))
 	if err != nil {
 		return fmt.Errorf("store: create account: %w", err)
@@ -157,7 +158,7 @@ func (r *AccountRepo) Update(ctx context.Context, a Account) error {
 // cooldown has already expired. Called on startup so stale cooldowns from a
 // previous session don't block fresh requests.
 func (r *AccountRepo) ClearExpiredCooldowns(ctx context.Context) (int64, error) {
-	q := r.db.rebind(`UPDATE accounts SET cooldown_until = NULL, backoff_level = 0, updated_at = ? WHERE cooldown_until IS NOT NULL AND cooldown_until < ?`)
+	q := r.db.rebind(`UPDATE accounts SET cooldown_until = NULL, backoff_level = 0, credits_exhausted = 0, updated_at = ? WHERE cooldown_until IS NOT NULL AND cooldown_until < ?`)
 	res, err := r.db.sql.ExecContext(ctx, q, formatTime(time.Now()), formatTime(time.Now()))
 	if err != nil {
 		return 0, fmt.Errorf("store: clear expired cooldowns: %w", err)
@@ -173,8 +174,8 @@ func (r *AccountRepo) ClearExpiredCooldowns(ctx context.Context) (int64, error) 
 // is accessible again.
 func (r *AccountRepo) ClearProviderCooldowns(ctx context.Context, tenantID, provider string) error {
 	q := r.db.rebind(`UPDATE accounts SET cooldown_until = NULL, backoff_level = 0,
-		needs_reconnect = 0, updated_at = ?
-		WHERE tenant_id = ? AND provider = ? AND (cooldown_until IS NOT NULL OR needs_reconnect != 0)`)
+		needs_reconnect = 0, credits_exhausted = 0, updated_at = ?
+		WHERE tenant_id = ? AND provider = ? AND (cooldown_until IS NOT NULL OR needs_reconnect != 0 OR credits_exhausted != 0)`)
 	_, err := r.db.sql.ExecContext(ctx, q, formatTime(time.Now()), tenantID, provider)
 	if err != nil {
 		return fmt.Errorf("store: clear provider cooldowns: %w", err)
@@ -215,6 +216,16 @@ func (r *AccountRepo) SetNeedsReconnect(ctx context.Context, id string, flag boo
 	return err
 }
 
+// SetCreditsExhausted marks an account's paid balance as depleted (or clears
+// the flag). Set by the dispatcher when a provider reports the balance is
+// dry; cleared by a successful request, a provider reconnect, or expiry of
+// the parking cooldown.
+func (r *AccountRepo) SetCreditsExhausted(ctx context.Context, id string, flag bool) error {
+	q := r.db.rebind(`UPDATE accounts SET credits_exhausted = ?, updated_at = ? WHERE id = ?`)
+	_, err := r.db.sql.ExecContext(ctx, q, boolToInt(flag), formatTime(time.Now()), id)
+	return err
+}
+
 func (r *AccountRepo) queryList(ctx context.Context, q string, args ...any) ([]Account, error) {
 	rows, err := r.db.sql.QueryContext(ctx, q, args...)
 	if err != nil {
@@ -249,16 +260,17 @@ func scanAccountRow(scan func(dest ...any) error) (Account, error) {
 		backoffLevel   int
 		cooldown       sql.NullString
 		disabled       int
-		proxyPoolID    sql.NullString
-		needsReconnect int
-		createdRaw     string
-		updatedRaw     string
+		proxyPoolID      sql.NullString
+		needsReconnect   int
+		creditsExhausted int
+		createdRaw       string
+		updatedRaw       string
 	)
 	err := scan(
 		&a.ID, &a.TenantID, &a.Provider, &a.Label, &authKind,
 		&secretDEK, &secretCT, &tokenDEK, &tokenCT, &refreshDEK, &refreshCT,
 		&tokenExpires, &a.Metadata, &a.Priority, &backoffLevel, &disabled, &cooldown,
-		&proxyPoolID, &needsReconnect, &createdRaw, &updatedRaw,
+		&proxyPoolID, &needsReconnect, &creditsExhausted, &createdRaw, &updatedRaw,
 	)
 	if err != nil {
 		return Account{}, err
@@ -274,6 +286,7 @@ func scanAccountRow(scan func(dest ...any) error) (Account, error) {
 	a.Disabled = disabled != 0
 	a.ProxyPoolID = proxyPoolID.String
 	a.NeedsReconnect = needsReconnect != 0
+	a.CreditsExhausted = creditsExhausted != 0
 	a.CreatedAt = parseTime(createdRaw)
 	a.UpdatedAt = parseTime(updatedRaw)
 	if tokenExpires.Valid {

--- a/backend/internal/transform/openai_responses.go
+++ b/backend/internal/transform/openai_responses.go
@@ -17,7 +17,13 @@ import (
 // ({type,name,description,parameters}), and the streaming surface is a rich
 // event sequence (response.created → output_item.added → output_text.delta →
 // ... → response.completed) rather than uniform chat.completion.chunk deltas.
-type OpenAIResponsesCodec struct{}
+type OpenAIResponsesCodec struct {
+	// Codex tailors the rendered request to the ChatGPT Codex backend
+	// (reasoning summary, encrypted-content include, default instructions).
+	// It is set by the codex connector; the zero value renders the plain
+	// OpenAI Responses API shape.
+	Codex bool
+}
 
 func (OpenAIResponsesCodec) Dialect() core.Dialect { return core.DialectOpenAIResponses }
 
@@ -47,6 +53,11 @@ type respRequest struct {
 	Temperature *float64 `json:"temperature,omitempty"`
 	MaxTokens   *int     `json:"max_tokens,omitempty"`
 	TopP        *float64 `json:"top_p,omitempty"`
+	// Reasoning carries the Responses-native effort knob so codex CLI style
+	// clients keep their requested effort through the canonical model.
+	Reasoning *struct {
+		Effort string `json:"effort,omitempty"`
+	} `json:"reasoning,omitempty"`
 }
 
 // responsesAPIAllowlist enumerates the fields that the Responses API (/v1/responses)
@@ -118,6 +129,9 @@ func (OpenAIResponsesCodec) ParseRequest(body []byte) (*core.ChatRequest, error)
 	req.Temperature = raw.Temperature
 	req.MaxTokens = raw.MaxTokens
 	req.TopP = raw.TopP
+	if raw.Reasoning != nil && raw.Reasoning.Effort != "" {
+		req.Reasoning = &core.ReasoningConfig{Effort: raw.Reasoning.Effort}
+	}
 
 	for _, t := range raw.Tools {
 		name := t.Name
@@ -317,16 +331,43 @@ func rawToString(raw json.RawMessage) string {
 
 // ---- request rendering (outbound to Codex/Responses provider) ---------------
 
-func (OpenAIResponsesCodec) RenderRequest(req *core.ChatRequest) ([]byte, error) {
+func (c OpenAIResponsesCodec) RenderRequest(req *core.ChatRequest) ([]byte, error) {
 	out := map[string]any{
 		"model":  req.Model,
 		"stream": req.Stream,
 		"store":  false,
 	}
-	if req.System != "" {
+	switch {
+	case req.System != "":
 		out["instructions"] = req.System
-	} else {
+	case c.Codex:
+		// The Codex backend expects non-empty instructions; a neutral default
+		// keeps bare chat requests working (mirrors the codex CLI).
+		out["instructions"] = "You are a ChatGPT agent."
+	default:
 		out["instructions"] = ""
+	}
+	// Reasoning effort where the client (or the codex connector) requested it.
+	// "Model decides" values (auto/adaptive — e.g. Claude Code's adaptive
+	// thinking) have no Responses API wire value and cause 400
+	// invalid_value upstream, so they are omitted rather than forwarded.
+	// The codex connector normalizes efforts before rendering, so this guard
+	// only fires for non-codex Responses providers.
+	if req.Reasoning != nil && req.Reasoning.Effort != "" {
+		effort := strings.ToLower(req.Reasoning.Effort)
+		if effort == "auto" || effort == "adaptive" || effort == "default" {
+			effort = ""
+		}
+		if effort != "" {
+			reasoning := map[string]any{"effort": effort}
+			if c.Codex && effort != "none" {
+				// Codex streams reasoning summaries and needs the encrypted
+				// reasoning content echoed back on follow-up turns (store=false).
+				reasoning["summary"] = "auto"
+				out["include"] = []string{"reasoning.encrypted_content"}
+			}
+			out["reasoning"] = reasoning
+		}
 	}
 	// NOTE: temperature, max_tokens, top_p are intentionally NOT included.
 	// These are Chat Completions parameters that the Responses API does not

--- a/backend/internal/transform/openai_responses_stream.go
+++ b/backend/internal/transform/openai_responses_stream.go
@@ -152,6 +152,12 @@ func (OpenAIResponsesCodec) ParseStreamLine(line []byte, _ string) ([]core.Strea
 func classifyRespStreamError(msg string) *core.ProviderError {
 	m := strings.ToLower(msg)
 	switch {
+	// Rate limits mention token counts too ("Rate limit reached … too many
+	// tokens per min"); match the rate-limit vocabulary first so a TPM limit
+	// is never mistaken for context overflow below and left without cooldown.
+	case strings.Contains(m, "rate limit") || strings.Contains(m, "rate_limit") ||
+		strings.Contains(m, "tokens per min"):
+		return &core.ProviderError{Kind: core.ErrRateLimit, Message: msg}
 	// Context overflow: the request itself is too large. Only the client can
 	// fix it (compact/trim), so scope it to the request — no cooldown, no
 	// fallback, surface the error straight back.

--- a/backend/internal/transform/openai_responses_stream.go
+++ b/backend/internal/transform/openai_responses_stream.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	json "github.com/mydisha/keirouter/backend/internal/fastjson"
 
@@ -131,7 +132,7 @@ func (OpenAIResponsesCodec) ParseStreamLine(line []byte, _ string) ([]core.Strea
 		}
 		return []core.StreamChunk{{
 			Type: core.ChunkError,
-			Err:  &core.ProviderError{Kind: core.ErrUpstream, Message: msg},
+			Err:  classifyRespStreamError(msg),
 		}}, nil
 
 	default:
@@ -139,6 +140,36 @@ func (OpenAIResponsesCodec) ParseStreamLine(line []byte, _ string) ([]core.Strea
 		// output_text.done, reasoning_summary_*: nothing canonical to emit.
 		return nil, nil
 	}
+}
+
+// classifyRespStreamError maps an in-stream error event (HTTP 200 with an
+// error in the SSE body, so no status code) onto the right error kind/scope.
+// Codex reports request-level problems this way — e.g. "Your input exceeds
+// the context window of this model." — and the previous blanket ErrUpstream
+// classification (provider scope) put the account on cooldown and fed the
+// provider circuit breaker on every client retry, eventually locking out all
+// accounts with "all matching candidates are temporarily unavailable".
+func classifyRespStreamError(msg string) *core.ProviderError {
+	m := strings.ToLower(msg)
+	switch {
+	// Context overflow: the request itself is too large. Only the client can
+	// fix it (compact/trim), so scope it to the request — no cooldown, no
+	// fallback, surface the error straight back.
+	case strings.Contains(m, "exceeds the context window"),
+		strings.Contains(m, "context length"),
+		strings.Contains(m, "maximum context"),
+		strings.Contains(m, "input is too long"),
+		strings.Contains(m, "prompt is too long"),
+		strings.Contains(m, "too many tokens"):
+		return &core.ProviderError{Kind: core.ErrBadRequest, Scope: core.FailureScopeRequest, Message: msg}
+	// Unknown/inaccessible model reported in-stream: model-scoped so chains
+	// can fall back, mirroring the HTTP-status classification in connectors.
+	case strings.Contains(m, "model") &&
+		(strings.Contains(m, "not supported") || strings.Contains(m, "not available") ||
+			strings.Contains(m, "not found") || strings.Contains(m, "does not exist")):
+		return &core.ProviderError{Kind: core.ErrModelUnavailable, Scope: core.FailureScopeModel, Message: msg}
+	}
+	return &core.ProviderError{Kind: core.ErrUpstream, Message: msg}
 }
 
 // respStreamState tracks per-stream rendering bookkeeping for the Responses

--- a/backend/internal/transform/openai_responses_test.go
+++ b/backend/internal/transform/openai_responses_test.go
@@ -419,6 +419,11 @@ func TestClassifyRespStreamError(t *testing.T) {
 	require.Equal(t, core.ErrModelUnavailable, pe.Kind)
 	require.Equal(t, core.FailureScopeModel, pe.EffectiveScope())
 
+	// A TPM rate limit mentions token counts too; it must classify as a rate
+	// limit (account cooldown) and never as request-scoped context overflow.
+	pe = classifyRespStreamError("Rate limit reached for gpt-5-codex: too many tokens per min. Limit 30000, Requested 31000.")
+	require.Equal(t, core.ErrRateLimit, pe.Kind)
+
 	// Anything else stays a provider-scoped upstream error.
 	pe = classifyRespStreamError("server_is_overloaded")
 	require.Equal(t, core.ErrUpstream, pe.Kind)

--- a/backend/internal/transform/openai_responses_test.go
+++ b/backend/internal/transform/openai_responses_test.go
@@ -404,3 +404,23 @@ func toStrings(b [][]byte) []string {
 	}
 	return out
 }
+
+// TestClassifyRespStreamError verifies that in-stream error events (HTTP 200
+// with an error in the SSE body) are scoped correctly: request problems must
+// not cool down accounts or trip the provider circuit breaker.
+func TestClassifyRespStreamError(t *testing.T) {
+	// The reported failure: Codex context overflow arrives in-stream.
+	pe := classifyRespStreamError("Your input exceeds the context window of this model. Please adjust your input and try again.")
+	require.Equal(t, core.ErrBadRequest, pe.Kind)
+	require.Equal(t, core.FailureScopeRequest, pe.EffectiveScope())
+	require.False(t, pe.Fallbackable())
+
+	pe = classifyRespStreamError("The 'gpt-5-6' model is not supported when using Codex with a ChatGPT account.")
+	require.Equal(t, core.ErrModelUnavailable, pe.Kind)
+	require.Equal(t, core.FailureScopeModel, pe.EffectiveScope())
+
+	// Anything else stays a provider-scoped upstream error.
+	pe = classifyRespStreamError("server_is_overloaded")
+	require.Equal(t, core.ErrUpstream, pe.Kind)
+	require.Equal(t, core.FailureScopeProvider, pe.EffectiveScope())
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,8 +9,10 @@
 server:
   host: 127.0.0.1
   port: 20180
-  # Abort a stream that produces no bytes for this long.
-  stream_stall_timeout: 30s
+  # Abort an upstream stream that produces no bytes for this long.
+  stream_stall_timeout: 60s
+  # Keep SSE client connections alive through proxy idle periods. Zero disables.
+  stream_heartbeat_interval: 15s
   # Bound non-streaming upstream calls.
   request_timeout: 5m
   # Allowed dashboard origins. Use specific origins in production.

--- a/frontend/src/components/QoderConnectModal.tsx
+++ b/frontend/src/components/QoderConnectModal.tsx
@@ -1,20 +1,24 @@
 import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { ExternalLink, RefreshCw, CheckCircle2, X, AlertTriangle } from "lucide-react";
+import { ExternalLink, RefreshCw, CheckCircle2, X, AlertTriangle, KeyRound, ChevronLeft } from "lucide-react";
 import { api, type DeviceCode } from "../lib/api";
-import { Button, ErrorBanner } from "./ui";
+import { Button, ErrorBanner, Field, Input } from "./ui";
 import { useToast } from "./Toast";
 
-// QoderConnectModal implements the Qoder PKCE device-token flow:
-//   1. Backend generates PKCE pair + nonce + machine_id.
-//   2. We open https://qoder.com/device/selectAccounts?challenge=... in the browser.
-//   3. We poll openapi.qoder.sh until the user authorizes and we get a token.
+// QoderConnectModal offers two ways to connect a Qoder account:
+//   1. OAuth PKCE device-token flow (sign in with your Qoder account).
+//   2. Personal Access Token (PAT, pt-*) — pasted from qoder.com/account/
+//      integrations. The backend exchanges the PAT for a short-lived COSY job
+//      token on each request, so no browser round-trip is needed.
 //
-// The flow mirrors Kiro's device-code UX but is simpler — no method picker,
-// no user code to type. The user just picks their Qoder account in the popup.
+// The OAuth flow mirrors Kiro's device-code UX; the method picker mirrors
+// Kiro's multi-method connect modal.
+type QoderMethod = "oauth" | "pat";
+
 export function QoderConnectModal({ onClose }: { onClose: () => void }) {
   const qc = useQueryClient();
   const toast = useToast();
+  const [method, setMethod] = useState<QoderMethod | null>(null);
   const [dc, setDc] = useState<DeviceCode | null>(null);
   const [status, setStatus] = useState<"idle" | "starting" | "waiting" | "done" | "error">("idle");
   const [error, setError] = useState("");
@@ -127,32 +131,159 @@ export function QoderConnectModal({ onClose }: { onClose: () => void }) {
 
         {/* Body */}
         <div className="px-6 py-5">
-          {status === "idle" && <IdleState onStart={start} />}
+          {method === null && <MethodSelect onSelect={setMethod} />}
 
-          {status === "starting" && <StartingState />}
+          {method === "oauth" && (
+            <>
+              {status === "idle" && <IdleState onStart={start} onBack={() => setMethod(null)} />}
 
-          {status === "waiting" && dc && (
-            <WaitingState
-              dc={dc}
-              elapsed={elapsed}
-              formatElapsed={formatElapsed}
-            />
+              {status === "starting" && <StartingState />}
+
+              {status === "waiting" && dc && (
+                <WaitingState
+                  dc={dc}
+                  elapsed={elapsed}
+                  formatElapsed={formatElapsed}
+                />
+              )}
+
+              {status === "done" && <DoneState />}
+
+              {status === "error" && (
+                <ErrorState error={error} onRetry={start} onClose={onClose} />
+              )}
+            </>
           )}
 
-          {status === "done" && <DoneState />}
-
-          {status === "error" && (
-            <ErrorState error={error} onRetry={start} onClose={onClose} />
-          )}
+          {method === "pat" && <PATFlow onClose={onClose} onBack={() => setMethod(null)} />}
         </div>
       </div>
     </div>
   );
 }
 
-function IdleState({ onStart }: { onStart: () => void }) {
+function MethodSelect({ onSelect }: { onSelect: (m: QoderMethod) => void }) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-[var(--text-muted)]">Choose how to connect your Qoder account:</p>
+
+      <button
+        onClick={() => onSelect("oauth")}
+        className="flex w-full items-start gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg-subtle)] p-4 text-left transition-colors hover:border-accent-400 hover:bg-ink-100 dark:hover:bg-ink-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/60"
+      >
+        <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent-100 text-accent-700 dark:bg-accent-800/40 dark:text-accent-200">
+          <ExternalLink className="h-4 w-4" />
+        </span>
+        <span>
+          <span className="block text-sm font-medium text-[var(--text)]">Sign in with Qoder</span>
+          <span className="block text-xs text-[var(--text-muted)]">Authorize in your browser — no key to copy.</span>
+        </span>
+      </button>
+
+      <button
+        onClick={() => onSelect("pat")}
+        className="flex w-full items-start gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg-subtle)] p-4 text-left transition-colors hover:border-accent-400 hover:bg-ink-100 dark:hover:bg-ink-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/60"
+      >
+        <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent-100 text-accent-700 dark:bg-accent-800/40 dark:text-accent-200">
+          <KeyRound className="h-4 w-4" />
+        </span>
+        <span>
+          <span className="block text-sm font-medium text-[var(--text)]">Personal Access Token</span>
+          <span className="block text-xs text-[var(--text-muted)]">Paste a pt-… token from your Qoder integrations page.</span>
+        </span>
+      </button>
+    </div>
+  );
+}
+
+function BackLink({ onBack }: { onBack: () => void }) {
+  return (
+    <button
+      onClick={onBack}
+      className="inline-flex items-center gap-1 text-xs font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text)] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/60 rounded"
+    >
+      <ChevronLeft className="h-3.5 w-3.5" />
+      Back
+    </button>
+  );
+}
+
+function PATFlow({ onClose, onBack }: { onClose: () => void; onBack: () => void }) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const [token, setToken] = useState("");
+  const [label, setLabel] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [done, setDone] = useState(false);
+
+  const submit = async () => {
+    const pat = token.trim();
+    if (!pat) {
+      setError("Please enter a Personal Access Token");
+      return;
+    }
+    setBusy(true);
+    setError("");
+    try {
+      await api.createAccount({ provider: "qoder", label: label.trim(), api_key: pat });
+      setDone(true);
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      toast.success("Qoder connected", "Personal Access Token added successfully.");
+      setTimeout(onClose, 1200);
+    } catch (e) {
+      setError((e as Error).message);
+      toast.error("Qoder token validation failed", (e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (done) return <DoneState />;
+
+  return (
+    <div className="space-y-4">
+      <BackLink onBack={onBack} />
+      <p className="text-sm text-[var(--text-muted)]">
+        Paste a Personal Access Token from your{" "}
+        <a
+          href="https://qoder.com/account/integrations"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-0.5 font-medium text-accent-600 hover:underline dark:text-accent-300"
+        >
+          Qoder integrations page
+          <ExternalLink className="h-3 w-3" />
+        </a>
+        . It is validated and encrypted before storage.
+      </p>
+      <Field label="Personal Access Token">
+        <Input
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="pt-…"
+          className="font-mono"
+        />
+      </Field>
+      <Field label="Label (optional)">
+        <Input
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="Qoder"
+        />
+      </Field>
+      {error && <ErrorBanner message={error} />}
+      <Button onClick={submit} disabled={busy} className="w-full">
+        {busy ? "Validating…" : "Connect Qoder"}
+      </Button>
+    </div>
+  );
+}
+
+function IdleState({ onStart, onBack }: { onStart: () => void; onBack: () => void }) {
   return (
     <div className="space-y-5">
+      <BackLink onBack={onBack} />
       <p className="text-sm text-[var(--text-muted)]">
         Connect your Qoder account to route requests through Qoder's API.
         No API key needed — you'll sign in with your Qoder account.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -169,6 +169,11 @@ export interface OAuthPollResult {
   provider?: string;
 }
 
+export interface OAuthCallbackStatus {
+  status: "pending" | "success" | "error" | "expired" | string;
+  message?: string;
+}
+
 export interface Plan {
   id: string;
   name: string;
@@ -1426,6 +1431,11 @@ export const api = {
     }),
   oauthExchange: (provider: string, input: { code: string; state: string; label?: string }) =>
     request<{ id: string; provider: string; email: string }>("POST", `/oauth/${provider}/exchange`, input),
+  // Polls whether a redirect-based flow completed server-side. Needed for
+  // providers whose auth pages sever window.opener (COOP), where the popup's
+  // postMessage never reaches the dashboard.
+  oauthCallbackStatus: (provider: string, state: string) =>
+    request<OAuthCallbackStatus>("GET", `/oauth/${provider}/callback-status?state=${encodeURIComponent(state)}`),
   oauthDeviceCode: (provider: string) =>
     request<DeviceCode>("POST", `/oauth/${provider}/device-code`, {}),
   oauthDeviceCodeSubmit: (

--- a/frontend/src/pages/ProviderDetail.tsx
+++ b/frontend/src/pages/ProviderDetail.tsx
@@ -454,7 +454,10 @@ export function ProviderDetailPage() {
   // for Azure (each key needs its own endpoint + deployment, so there is no
   // shared config to bulk against) and for no-auth providers (nothing to bulk).
   const providerSupportsApiKey = provider.auth_modes.includes("api_key") || provider.auth_kind === "api_key";
-  const supportsBulkUpload = supportsManualConnect && providerSupportsApiKey && provider.id !== "azure";
+  // Qoder connects through a custom modal (so supportsManualConnect is false),
+  // but its API-key mode accepts Personal Access Tokens that bulk-import cleanly
+  // through the shared endpoint — surface the button for it too.
+  const supportsBulkUpload = (supportsManualConnect || isQoder) && providerSupportsApiKey && provider.id !== "azure";
   const enabledAccounts = myAccounts.filter((account) => !account.disabled).length;
   const activeModelCount = Math.max(0, modelList.length - disabledModelIds.size);
   const hasPrimaryConnect = hasCustomModal || !!oauthProvider || supportsManualConnect;
@@ -609,7 +612,7 @@ export function ProviderDetailPage() {
                 {supportsBulkUpload && (
                   <Button variant="ghost" onClick={() => setBulkOpen(true)}>
                     <Layers className="h-4 w-4" />
-                    Import keys
+                    {isQoder ? "Import tokens" : "Import keys"}
                   </Button>
                 )}
               </div>
@@ -1189,12 +1192,12 @@ function AccountRow({
 
   const boundPool = pools.find((p) => p.id === a.proxy_pool_id);
   const [detailsOpen, setDetailsOpen] = useState(false);
-  const supportsKiroQuota = a.provider === "kiro";
-  const hasExpandableDetails = supportsKiroQuota || a.provider === "codex";
+  const supportsQuota = a.provider === "kiro" || a.provider === "qoder";
+  const hasExpandableDetails = supportsQuota || a.provider === "codex";
   const accountQuota = useQuery({
     queryKey: ["account-quota", a.id],
     queryFn: () => api.accountQuota(a.id),
-    enabled: supportsKiroQuota && detailsOpen && !a.disabled,
+    enabled: supportsQuota && detailsOpen && !a.disabled,
     staleTime: 60_000,
     retry: 1,
   });
@@ -1344,8 +1347,8 @@ function AccountRow({
 
       {detailsOpen && (
         <div className="ml-6 mt-2">
-          {supportsKiroQuota && (
-            <KiroQuotaPanel
+          {supportsQuota && (
+            <AccountQuotaPanel
               loading={accountQuota.isLoading || accountQuota.isFetching}
               error={accountQuota.error instanceof Error ? accountQuota.error.message : ""}
               planName={accountQuota.data?.plan_name}
@@ -1362,7 +1365,7 @@ function AccountRow({
   );
 }
 
-function KiroQuotaPanel({
+function AccountQuotaPanel({
   loading,
   error,
   planName,
@@ -1387,7 +1390,7 @@ function KiroQuotaPanel({
             <Package className="h-4 w-4" />
           </div>
           <div className="min-w-0">
-            <p className="truncate text-sm font-semibold text-[var(--text)]">{planName || "Kiro package"}</p>
+            <p className="truncate text-sm font-semibold text-[var(--text)]">{planName || "Package"}</p>
             <p className="mt-0.5 text-xs text-[var(--text-muted)]">Live allowance from this account</p>
           </div>
         </div>
@@ -1396,7 +1399,7 @@ function KiroQuotaPanel({
           onClick={onRefresh}
           disabled={loading || disabled}
           className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-[var(--text-muted)] transition-[transform,background-color,color] duration-150 hover:bg-[var(--bg-elevated)] hover:text-[var(--text)] active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40 disabled:active:scale-100"
-          aria-label="Refresh Kiro usage"
+          aria-label="Refresh usage"
           title="Refresh usage"
         >
           <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
@@ -1406,7 +1409,7 @@ function KiroQuotaPanel({
       {disabled ? (
         <p className="mt-3 text-xs text-[var(--text-muted)]">Enable this account to refresh its package usage.</p>
       ) : loading && quotas.length === 0 ? (
-        <div className="mt-4 space-y-3" aria-label="Loading Kiro usage">
+        <div className="mt-4 space-y-3" aria-label="Loading usage">
           {[0, 1].map((item) => (
             <div key={item} className="space-y-2">
               <div className="skeleton h-3 w-2/5 rounded" />
@@ -1426,7 +1429,7 @@ function KiroQuotaPanel({
           ))}
         </div>
       ) : (
-        <p className="mt-3 text-xs text-[var(--text-muted)]">{message || "Kiro did not report a usage allowance for this account."}</p>
+        <p className="mt-3 text-xs text-[var(--text-muted)]">{message || "No usage allowance reported for this account."}</p>
       )}
       {message && quotas.length > 0 && <p className="mt-3 text-xs text-[var(--text-muted)]">{message}</p>}
     </div>
@@ -1491,6 +1494,7 @@ function BulkAddKeysModal({ provider, onClose }: { provider: Provider; onClose: 
   const fileRef = useRef<HTMLInputElement>(null);
 
   const isCloudflare = provider.id === "cloudflare-ai";
+  const isQoder = provider.id === "qoder";
   const hasRegions = (provider.regions?.length ?? 0) > 0;
   // User-created custom provider instances already define a base URL, so keys
   // inherit it — no shared base URL input is needed here.
@@ -1501,8 +1505,10 @@ function BulkAddKeysModal({ provider, onClose }: { provider: Provider; onClose: 
   // Generic providers expose an optional shared base URL; region/Cloudflare
   // providers use their own dedicated control, and inherited-base-URL custom
   // instances need no input at all.
-  const showBaseURL = !hasRegions && !isCloudflare && !inheritsBaseURL;
-  const keyPlaceholder = provider.id === "xai" ? "xai-..." : "sk-...";
+  // Qoder PAT connections use Qoder's fixed endpoint, so hide the shared
+  // base-URL input for a clean paste-only flow.
+  const showBaseURL = !hasRegions && !isCloudflare && !inheritsBaseURL && !isQoder;
+  const keyPlaceholder = isQoder ? "pt-..." : provider.id === "xai" ? "xai-..." : "sk-...";
 
   const parsed = useMemo(() => parseKeys(text), [text]);
   const validCount = parsed.entries.length;
@@ -1561,8 +1567,8 @@ function BulkAddKeysModal({ provider, onClose }: { provider: Provider; onClose: 
     <Modal
       open
       onClose={onClose}
-      title={`Bulk add API keys — ${provider.display_name}`}
-      subtitle="Paste one key per line, or load a .txt/.csv file."
+      title={`${isQoder ? "Bulk add Personal Access Tokens" : "Bulk add API keys"} — ${provider.display_name}`}
+      subtitle={isQoder ? "Paste one pt-… token per line, or load a .txt/.csv file." : "Paste one key per line, or load a .txt/.csv file."}
       maxWidth="max-w-2xl"
     >
       {results ? (
@@ -1647,7 +1653,7 @@ function BulkAddKeysModal({ provider, onClose }: { provider: Provider; onClose: 
 
           <div className="space-y-1.5">
             <div className="flex items-center justify-between">
-              <label className="text-sm font-medium">API keys</label>
+              <label className="text-sm font-medium">{isQoder ? "Personal Access Tokens" : "API keys"}</label>
               <button
                 type="button"
                 onClick={() => fileRef.current?.click()}
@@ -1667,7 +1673,8 @@ function BulkAddKeysModal({ provider, onClose }: { provider: Provider; onClose: 
               className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2 font-mono text-xs placeholder:text-[var(--text-muted)] focus:border-accent-400 focus:outline-none"
             />
             <p className="text-[11px] leading-relaxed text-[var(--text-muted)]">
-              One key per line. Optional inline label: <code className="font-mono">label,key</code>. Blank lines and{" "}
+              One {isQoder ? "token" : "key"} per line. Optional inline label:{" "}
+              <code className="font-mono">label,{isQoder ? "token" : "key"}</code>. Blank lines and{" "}
               <code className="font-mono">#</code> comments are ignored.
             </p>
           </div>

--- a/frontend/src/pages/ProviderDetail.tsx
+++ b/frontend/src/pages/ProviderDetail.tsx
@@ -2132,6 +2132,50 @@ function AuthCodeFlow({ provider, onClose }: { provider: OAuthProvider; onClose:
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [waiting, provider.provider]);
 
+  // Poll the gateway for server-side completion in parallel with the
+  // postMessage listener. postMessage alone is not enough: providers that set
+  // Cross-Origin-Opener-Policy on their auth pages (OpenAI/Codex) sever
+  // window.opener during the redirect, so the popup can never notify us and
+  // the user would be forced into pasting the callback URL manually.
+  useEffect(() => {
+    if (!waiting || !stateRef.current) return;
+    let stopped = false;
+    let timer = 0;
+    let expiredPolls = 0;
+    const tick = async () => {
+      try {
+        const res = await api.oauthCallbackStatus(provider.provider, stateRef.current);
+        if (stopped) return;
+        if (res.status === "success") {
+          finishSuccess();
+          return;
+        }
+        if (res.status === "error") {
+          setError(res.message || "Connection failed.");
+          setWaiting(false);
+          return;
+        }
+        // The session lives ~10 minutes; a few consecutive "expired" polls
+        // mean it is genuinely gone and the user should restart the flow.
+        if (res.status === "expired" && ++expiredPolls >= 3) {
+          setError("Sign-in session expired. Please try again.");
+          setWaiting(false);
+          return;
+        }
+        if (res.status === "pending") expiredPolls = 0;
+      } catch {
+        // Transient poll failures are ignored; the next tick retries.
+      }
+      if (!stopped) timer = window.setTimeout(tick, 2000);
+    };
+    timer = window.setTimeout(tick, 2000);
+    return () => {
+      stopped = true;
+      window.clearTimeout(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [waiting, provider.provider]);
+
   const start = async () => {
     setError("");
     try {


### PR DESCRIPTION
## Summary

Stabilizes account handling across dispatch, connectors, and streaming, adds Qoder Personal Access Token (PAT) support, and hardens the branch against concurrency findings from code review.

### Dispatch stability
- 5s failure-dedup window: a burst of parallel failures on one account escalates backoff once, not N times
- Jitter (up to +25%) on locally computed cooldowns to avoid synchronized retry storms
- Terminal `credits_exhausted` state (new DB column, migration 0029) with a 24h park, distinct from resettable quota windows; the flag clears on success/reconnect/expiry
- Credits-exhausted failures bypass the dedup gate so the terminal park is never suppressed by a concurrent rate-limit cooldown

### Error classification
- `classify429` detects depleted paid balances (plus 402/403/400 body heuristics)
- Plain-400 "model not supported" bodies reclassified as model-unavailable for chain fallback
- In-stream Responses errors are scoped per-request/per-model instead of blanket provider-scope; rate-limit vocabulary is matched before context-overflow patterns so TPM limits keep their account cooldown

### Codex hardening
- New `codex.go` normalizes model ids (dash-typo tolerance anchored to the version segment, effort suffixes, gpt-5.6 aliases) and reasoning efforts per model family
- CLI identity headers (`chatgpt-account-id`, originator); `prompt=login` on the OAuth flow to protect multi-account setups

### Qoder PAT support
- PAT (pt-*) connections exchange for short-lived job tokens; the exchange is single-flighted in a process-wide session cache shared by dispatch connectors and the quota source, so each PAT holds at most one live job token under concurrent load
- Real-uid COSY signing, quota reporting from `user/status` with corrected trial/team-plan messaging
- Frontend: auth-method picker, PAT flow with error handling, bulk token import

### SSE keep-alive
- Configurable `stream_heartbeat_interval` (default 15s) emits SSE comments on silent streams on both direct and decoded chunk paths; OAuth callback completion pollable server-side for COOP-severed popups

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] Full test suites pass on dispatch, connectors, gateway, transform, config, store (including `-race` on dispatch/connectors)
- [x] Frontend `tsc -b` clean
- [x] New tests: failure dedup window, jitter bounds, credits parking + dedup bypass, heartbeat lifecycle, PAT parsing, codex model normalization (incl. date-suffixed snapshot ids), in-stream rate-limit classification
