### PR TITLE
fix(transform): strip echoed reasoning_content for non-reasoning providers

### DIFF
--- a/backend/internal/transform/openai.go
+++ b/backend/internal/transform/openai.go
@@ -454,7 +454,7 @@ func renderOAIRequestForProvider(req *core.ChatRequest, providerID string, scope
 	if providerID == "codebuddy" {
 		applyCodebuddyRequestFixes(out, req)
 	}
-	if providerID == "kimchi" {
+	if stripReasoningFor(providerID) {
 		stripReasoningContent(out)
 	}
 	return json.Marshal(out)
@@ -705,6 +705,18 @@ func deepSeekToolCallIDs(msg oaiMessage) []string {
 // reasoning_content on the next turn. Real chain-of-thought blocks exceed this
 // length and are stripped to bound multi-turn input token growth.
 const reasoningPlaceholderMaxLen = 8
+
+// stripReasoningFor reports whether the target provider rejects echoed
+// reasoning_content from prior assistant turns. Non-reasoning providers such
+// as groq answer 400 with "property 'reasoning_content' is unsupported" when
+// history carries it, so their requests are stripped before dispatch.
+func stripReasoningFor(providerID string) bool {
+	switch providerID {
+	case "kimchi", "groq":
+		return true
+	}
+	return false
+}
 
 // stripReasoningContent removes echoed reasoning_content from assistant messages
 // in the outgoing request. Clients replay the full reasoning block from prior

--- a/backend/internal/transform/openai_strip_reasoning_test.go
+++ b/backend/internal/transform/openai_strip_reasoning_test.go
@@ -1,0 +1,61 @@
+package transform
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mydisha/keirouter/backend/internal/core"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenAI_RenderRequest_StripsReasoningForGroq verifies that non-reasoning
+// providers which reject echoed reasoning_content (groq) receive assistant
+// history with real chain-of-thought blocks stripped.
+func TestOpenAI_RenderRequest_StripsReasoningForGroq(t *testing.T) {
+	req := &core.ChatRequest{
+		Model: "qwen/qwen3.6-27b",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "hi"}}},
+			{Role: core.RoleAssistant, Content: []core.ContentPart{
+				{Type: core.PartThinking, Text: "a genuine multi-sentence deliberation block"},
+				{Type: core.PartText, Text: "hello"},
+			}},
+			{Role: core.RoleUser, Content: []core.ContentPart{{Type: core.PartText, Text: "continue"}}},
+		},
+	}
+	body, err := OpenAICodec{}.RenderRequestForProvider(req, "groq")
+	require.NoError(t, err)
+
+	var got oaiRequest
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Equal(t, "assistant", got.Messages[1].Role)
+	require.Empty(t, got.Messages[1].ReasoningContent)
+}
+
+// TestOpenAI_RenderRequest_KeepsShortPlaceholderForGroq verifies the minimal
+// validation placeholder survives stripping so upstreams that require the
+// field's presence keep working.
+func TestOpenAI_RenderRequest_KeepsShortPlaceholderForGroq(t *testing.T) {
+	req := &core.ChatRequest{
+		Model: "qwen/qwen3.6-27b",
+		Messages: []core.Message{
+			{Role: core.RoleAssistant, Content: []core.ContentPart{
+				{Type: core.PartThinking, Text: " "},
+				{Type: core.PartText, Text: "hello"},
+			}},
+		},
+	}
+	body, err := OpenAICodec{}.RenderRequestForProvider(req, "groq")
+	require.NoError(t, err)
+
+	var got oaiRequest
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Equal(t, reasoningPlaceholder, got.Messages[0].ReasoningContent)
+}
+
+func TestStripReasoningFor(t *testing.T) {
+	require.True(t, stripReasoningFor("kimchi"))
+	require.True(t, stripReasoningFor("groq"))
+	require.False(t, stripReasoningFor("deepseek"))
+	require.False(t, stripReasoningFor("openai"))
+}


### PR DESCRIPTION
## Problem

When a fallback chain routes follow-up turns to a provider that does not support `reasoning_content` (e.g. groq), the request fails with:

```
400: 'messages.N': for 'role:assistant' ... property 'reasoning_content' is unsupported
```

This happens because history replayed from earlier turns — answered by a reasoning-capable provider in the same chain — carries `reasoning_content` on assistant messages.

## Fix

Extend the existing kimchi-only `stripReasoningContent` behavior via a `stripReasoningFor` allowlist that includes groq. Real chain-of-thought (>8 chars, per `reasoningPlaceholderMaxLen`) is stripped; the minimal validation placeholder injected by `buildOAIRequest` is preserved, so reasoning-mode upstreams are unaffected.

## Testing

- New unit tests: strips long reasoning for groq, keeps short placeholders, allowlist behavior (`openai_strip_reasoning_test.go`)
- `go test ./internal/transform/ -run 'ReasoningFor|StripsReasoningForGroq|KeepsShortPlaceholder'` passes
- Verified in production: groq is now attempted first on a 3-step fallback chain without 400s falling through