### PR TITLE
feat: add 9router SQLite import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Reference material (not part of KeiRouter source)
 _research/
 docs/
+9router-import
+out_inspect.txt
 
 # Go
 backend/bin/

--- a/backend/internal/auth/auth.go
+++ b/backend/internal/auth/auth.go
@@ -103,12 +103,24 @@ func (s *Service) loadOrCreateSigningKey(ctx context.Context) ([]byte, error) {
 }
 
 // VerifyPassword reports whether the given password matches the stored hash.
+// A successful match against an imported bcrypt hash ($2a$/$2b$) is lazily
+// upgraded to the native argon2id verifier so subsequent logins never touch
+// the bcrypt path again.
 func (s *Service) VerifyPassword(ctx context.Context, password string) (bool, error) {
 	hash, err := s.settings.Get(ctx, keyPasswordHash)
 	if err != nil {
 		return false, err
 	}
-	return crypto.VerifyPassword(password, hash)
+	ok, err := crypto.VerifyPassword(password, hash)
+	if err != nil || !ok {
+		return ok, err
+	}
+	if crypto.IsLegacyBcrypt(hash) {
+		if newHash, herr := crypto.HashPassword(password); herr == nil {
+			_ = s.settings.Set(ctx, keyPasswordHash, newHash)
+		}
+	}
+	return true, nil
 }
 
 // SetPassword changes the dashboard password.

--- a/backend/internal/crypto/password.go
+++ b/backend/internal/crypto/password.go
@@ -1,5 +1,7 @@
 package crypto
 
+import "strings"
+
 // HashPassword produces an argon2id verifier for a dashboard password, using
 // the same parameters as API key hashing. Passwords are never stored in
 // plaintext; only this hash is persisted.
@@ -7,8 +9,14 @@ func HashPassword(plaintext string) (string, error) {
 	return HashAPIKey(plaintext)
 }
 
-// VerifyPassword reports whether plaintext matches the stored argon2id hash via
-// a constant-time comparison.
+// VerifyPassword reports whether plaintext matches the stored hash. It detects
+// the hash format: argon2id PHC strings are verified via argon2; bcrypt hashes
+// ($2a$/$2b$) are verified via bcrypt.CompareHashAndPassword for backward
+// compatibility with 9router/foreign imports. The caller can re-hash a
+// bcrypt match by calling HashPassword + persisting the new argon2id hash.
 func VerifyPassword(plaintext, encodedHash string) (bool, error) {
+	if strings.HasPrefix(encodedHash, "$2a$") || strings.HasPrefix(encodedHash, "$2b$") {
+		return verifyBcrypt(plaintext, encodedHash)
+	}
 	return VerifyAPIKey(plaintext, encodedHash)
 }

--- a/backend/internal/crypto/password_bcrypt.go
+++ b/backend/internal/crypto/password_bcrypt.go
@@ -1,0 +1,27 @@
+package crypto
+
+import (
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// verifyBcrypt checks a plaintext against a bcrypt hash ($2a$/$2b$).
+// Used as a fallback in VerifyPassword for imported 9router credentials.
+func verifyBcrypt(plaintext, encodedHash string) (bool, error) {
+	err := bcrypt.CompareHashAndPassword([]byte(encodedHash), []byte(plaintext))
+	if err != nil {
+		if err == bcrypt.ErrMismatchedHashAndPassword {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// IsLegacyBcrypt reports whether an encoded password hash is a bcrypt hash
+// ($2a$/$2b$) rather than a native argon2id verifier. Callers use it to lazily
+// upgrade an imported bcrypt password to argon2id after a successful login.
+func IsLegacyBcrypt(encodedHash string) bool {
+	return strings.HasPrefix(encodedHash, "$2a$") || strings.HasPrefix(encodedHash, "$2b$")
+}

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -110,6 +110,7 @@ func (s *Server) mountAdmin(r chi.Router) {
 	r.Get("/settings/database", s.adminExportDatabase)
 	r.Post("/settings/database", s.adminImportDatabase)
 	r.Post("/settings/database/import-foreign", s.adminImportForeignConfig)
+	r.Post("/settings/database/import-9router-sqlite", s.adminImport9routerSQLite)
 	r.Get("/settings/sqlite", s.adminSQLiteStatus)
 	r.Get("/settings/sqlite/backup", s.adminSQLiteBackup)
 	r.Post("/settings/sqlite/restore", s.adminSQLiteRestore)

--- a/backend/internal/gateway/admin.go
+++ b/backend/internal/gateway/admin.go
@@ -111,6 +111,7 @@ func (s *Server) mountAdmin(r chi.Router) {
 	r.Post("/settings/database", s.adminImportDatabase)
 	r.Post("/settings/database/import-foreign", s.adminImportForeignConfig)
 	r.Post("/settings/database/import-9router-sqlite", s.adminImport9routerSQLite)
+	r.Post("/settings/database/analyze-9router-sqlite", s.adminAnalyze9routerSQLite)
 	r.Get("/settings/sqlite", s.adminSQLiteStatus)
 	r.Get("/settings/sqlite/backup", s.adminSQLiteBackup)
 	r.Post("/settings/sqlite/restore", s.adminSQLiteRestore)

--- a/backend/internal/gateway/admin_foreign_import.go
+++ b/backend/internal/gateway/admin_foreign_import.go
@@ -386,7 +386,10 @@ func (s *Server) importN9routerConnections(ctx context.Context, doc map[string]j
 
 		now := time.Now()
 		acc := store.Account{
-			ID:        uuid.NewString(),
+			// Deterministic id: re-imports upsert instead of duplicating, and
+			// usage_records.account_id (carrying the raw 9router connectionId)
+			// resolves to this row.
+			ID:        n9IDPrefix + c.ID,
 			TenantID:  adminTenant,
 			Provider:  provider,
 			Label:     label,
@@ -489,7 +492,7 @@ func (s *Server) importN9routerAPIKeys(ctx context.Context, doc map[string]json.
 			continue
 		}
 		rec := store.APIKey{
-			ID:         uuid.NewString(),
+			ID:         n9IDPrefix + k.ID,
 			TenantID:   adminTenant,
 			Name:       name,
 			KeyHash:    hash,
@@ -551,7 +554,7 @@ func (s *Server) importN9routerCombos(ctx context.Context, doc map[string]json.R
 		strategy := mapN9routerStrategy(c.Kind, c.Strategy)
 		now := time.Now()
 		chain := store.Chain{
-			ID:        uuid.NewString(),
+			ID:        n9IDPrefix + c.ID,
 			TenantID:  adminTenant,
 			Name:      name,
 			Strategy:  strategy,
@@ -617,6 +620,7 @@ func (s *Server) importN9routerProxyPools(ctx context.Context, doc map[string]js
 		return
 	}
 	var pools []struct {
+		ID       string `json:"id"`
 		Name     string `json:"name"`
 		ProxyURL string `json:"proxyUrl"`
 		NoProxy  string `json:"noProxy"`
@@ -633,9 +637,12 @@ func (s *Server) importN9routerProxyPools(ctx context.Context, doc map[string]js
 			res.Skipped++
 			continue
 		}
+		if p.ID == "" {
+			p.ID = uuid.NewString()
+		}
 		now := time.Now()
 		pool := store.ProxyPool{
-			ID:         uuid.NewString(),
+			ID:         n9IDPrefix + p.ID,
 			Name:       p.Name,
 			Type:       defaultStr(p.Type, "http"),
 			ProxyURL:   p.ProxyURL,

--- a/backend/internal/gateway/admin_foreign_import.go
+++ b/backend/internal/gateway/admin_foreign_import.go
@@ -44,6 +44,7 @@ type foreignImportResult struct {
 	Chains          int      `json:"chains"`
 	Aliases         int      `json:"aliases"`
 	ProxyPools      int      `json:"proxy_pools"`
+	UsageRecords    int      `json:"usage_records,omitempty"`
 	Errors          []string `json:"errors,omitempty"`
 }
 

--- a/backend/internal/gateway/admin_foreign_import_sqlite.go
+++ b/backend/internal/gateway/admin_foreign_import_sqlite.go
@@ -32,6 +32,7 @@ func (s *Server) adminImport9routerSQLite(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "9router SQLite import requires database.driver=sqlite")
 		return
 	}
+	started := time.Now()
 
 	r.Body = http.MaxBytesReader(w, r.Body, sqliteBackupMaxBytes)
 	if err := r.ParseMultipartForm(sqliteBackupMaxBytes); err != nil {
@@ -95,11 +96,21 @@ func (s *Server) adminImport9routerSQLite(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "read 9router database: "+err.Error())
 		return
 	}
+	s.log.Info("9router import: database read", "elapsed_ms", time.Since(started).Milliseconds())
 
 	res := &foreignImportResult{Source: "9router"}
 	s.importN9router(ctx, doc, res)
+	s.log.Info("9router import: config tables", "elapsed_ms", time.Since(started).Milliseconds(),
+		"accounts", res.Accounts, "custom_providers", res.CustomProviders,
+		"api_keys", res.APIKeys, "chains", res.Chains, "proxy_pools", res.ProxyPools)
+
 	s.import9routerUsageHistory(ctx, doc, res)
+	s.log.Info("9router import: usage records", "elapsed_ms", time.Since(started).Milliseconds(),
+		"usage_records", res.UsageRecords)
+
 	s.import9routerSettings(ctx, doc, res)
+	s.log.Info("9router import: complete", "elapsed_ms", time.Since(started).Milliseconds(),
+		"errors", len(res.Errors))
 
 	res.Imported = res.Accounts + res.CustomProviders + res.APIKeys + res.Chains + res.Aliases + res.ProxyPools
 	writeJSON(w, http.StatusOK, res)
@@ -392,7 +403,7 @@ func (s *Server) import9routerUsageHistory(ctx context.Context, doc map[string]j
 		}
 		imported = end
 	}
-	res.Errors = append(res.Errors, fmt.Sprintf("usageHistory: imported %d rows", imported))
+	res.UsageRecords = imported
 }
 
 // usageKeyLookup builds a map from api_key lookup_hash → api_key id for the

--- a/backend/internal/gateway/admin_foreign_import_sqlite.go
+++ b/backend/internal/gateway/admin_foreign_import_sqlite.go
@@ -285,11 +285,22 @@ func (s *Server) import9routerUsageHistory(ctx context.Context, doc map[string]j
 		records = append(records, rec)
 	}
 
-	if err := s.usage.RecordBatch(ctx, records); err != nil {
-		res.Errors = append(res.Errors, "usageHistory: "+err.Error())
-		return
+	// Insert in chunks so each transaction stays short: one 60k-row
+	// transaction holds the SQLite write lock for the whole import and starves
+	// background writers (health checks, resource samples) with SQLITE_BUSY.
+	// RecordBatch already splits statements to respect bind limits; chunking
+	// here additionally bounds transaction duration.
+	const chunkSize = 1000
+	imported := 0
+	for start := 0; start < len(records); start += chunkSize {
+		end := min(start+chunkSize, len(records))
+		if err := s.usage.RecordBatch(ctx, records[start:end]); err != nil {
+			res.Errors = append(res.Errors, fmt.Sprintf("usageHistory: %d/%d rows: %v", start, len(records), err))
+			break
+		}
+		imported = end
 	}
-	res.Errors = append(res.Errors, fmt.Sprintf("usageHistory: imported %d rows", len(records)))
+	res.Errors = append(res.Errors, fmt.Sprintf("usageHistory: imported %d rows", imported))
 }
 
 // usageKeyLookup builds a map from api_key lookup_hash → api_key id for the

--- a/backend/internal/gateway/admin_foreign_import_sqlite.go
+++ b/backend/internal/gateway/admin_foreign_import_sqlite.go
@@ -1,0 +1,542 @@
+package gateway
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/mydisha/keirouter/backend/internal/caveman"
+	"github.com/mydisha/keirouter/backend/internal/crypto"
+	"github.com/mydisha/keirouter/backend/internal/ponytail"
+	"github.com/mydisha/keirouter/backend/internal/store"
+)
+
+// adminImport9routerSQLite imports a 9router SQLite database (data.sqlite)
+// directly, converting its tables into KeiRouter's native model. It reuses the
+// JSON importer's per-table converters (importN9router*) by reading the SQLite
+// rows into the same map[string]json.RawMessage document shape.
+//
+// Unlike the JSON path, this also migrates usageHistory (usage_records) and the
+// settings blob (token saver / routing / dashboard password), which the JSON
+// export does not carry.
+func (s *Server) adminImport9routerSQLite(w http.ResponseWriter, r *http.Request) {
+	if s.dbDialect() != store.DialectSQLite {
+		writeError(w, http.StatusBadRequest, "9router SQLite import requires database.driver=sqlite")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, sqliteBackupMaxBytes)
+	if err := r.ParseMultipartForm(sqliteBackupMaxBytes); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid upload: "+err.Error())
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "file is required")
+		return
+	}
+	defer file.Close()
+
+	if header.Size <= 0 {
+		writeError(w, http.StatusBadRequest, "uploaded file is empty")
+		return
+	}
+
+	tmp, err := os.CreateTemp(s.dataDirOrTemp(), "keirouter-9router-import-*.sqlite")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "create temp file failed: "+err.Error())
+		return
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.ReadFrom(file); err != nil {
+		_ = tmp.Close()
+		writeError(w, http.StatusInternalServerError, "save upload failed: "+err.Error())
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		writeError(w, http.StatusInternalServerError, "close upload failed: "+err.Error())
+		return
+	}
+
+	if err := validateSQLiteFile(r.Context(), tmpPath); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid SQLite database: "+err.Error())
+		return
+	}
+
+	// Import is additive (best-effort skip on conflict), so no full-database
+	// replacement is needed. Still checkpoint WAL so the safety copy is clean.
+	if err := s.checkpointSQLite(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "sqlite checkpoint failed: "+err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
+	defer cancel()
+
+	doc, err := read9routerSQLiteDoc(ctx, tmpPath)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "read 9router database: "+err.Error())
+		return
+	}
+
+	res := &foreignImportResult{Source: "9router"}
+	s.importN9router(ctx, doc, res)
+	s.import9routerUsageHistory(ctx, doc, res)
+	s.import9routerSettings(ctx, doc, res)
+
+	res.Imported = res.Accounts + res.CustomProviders + res.APIKeys + res.Chains + res.Aliases + res.ProxyPools
+	writeJSON(w, http.StatusOK, res)
+}
+
+// read9routerSQLiteDoc opens the 9router SQLite file read-only and returns a
+// document keyed by table name, where each value is a JSON array of row objects
+// (column name -> value). This mirrors the JSON export shape consumed by the
+// importN9router* converters.
+func read9routerSQLiteDoc(ctx context.Context, path string) (map[string]json.RawMessage, error) {
+	db, err := sql.Open("sqlite", "file:"+path+"?mode=ro")
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	// Tables the JSON importer understands, plus usageHistory/settings handled
+	// separately. requestDetails/usageDaily/_meta/sqlite_sequence are ignored.
+	tables := []string{
+		"providerNodes", "providerConnections", "apiKeys", "combos",
+		"proxyPools", "modelAliases", "customModels", "usageHistory", "settings",
+	}
+
+	doc := make(map[string]json.RawMessage, len(tables))
+	for _, t := range tables {
+		raw, err := readTableAsJSON(ctx, db, t)
+		if err != nil {
+			return nil, fmt.Errorf("table %s: %w", t, err)
+		}
+		if raw == nil {
+			continue // table absent
+		}
+		doc[t] = raw
+	}
+	return doc, nil
+}
+
+// readTableAsJSON returns a JSON array of row objects for the given table, or
+// nil when the table does not exist.
+func readTableAsJSON(ctx context.Context, db *sql.DB, table string) (json.RawMessage, error) {
+	var exists int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&exists); err != nil {
+		return nil, err
+	}
+	if exists == 0 {
+		return nil, nil
+	}
+
+	rows, err := db.QueryContext(ctx, "SELECT * FROM "+table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]map[string]any, 0)
+	scan := make([]any, len(cols))
+	scanPtrs := make([]any, len(cols))
+	for i := range scan {
+		scanPtrs[i] = &scan[i]
+	}
+	for rows.Next() {
+		if err := rows.Scan(scanPtrs...); err != nil {
+			return nil, err
+		}
+		obj := make(map[string]any, len(cols))
+		for i, c := range cols {
+			obj[c] = scan[i]
+		}
+		out = append(out, obj)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(out)
+}
+
+// ── usageHistory → usage_records ──────────────────────────────────────────
+
+// n9routerUsageRow is one 9router usageHistory row.
+type n9routerUsageRow struct {
+	ID               int64   `json:"id"`
+	Timestamp        string  `json:"timestamp"`
+	Provider         string  `json:"provider"`
+	Model            string  `json:"model"`
+	ConnectionID     string  `json:"connectionId"`
+	APIKey           string  `json:"apiKey"`
+	Endpoint         string  `json:"endpoint"`
+	PromptTokens     int     `json:"promptTokens"`
+	CompletionTokens int     `json:"completionTokens"`
+	Cost             float64 `json:"cost"`
+	Status           string  `json:"status"`
+	Tokens           string  `json:"tokens"`
+	Meta             string  `json:"meta"`
+}
+
+// import9routerUsageHistory migrates 9router usageHistory rows into
+// usage_records. Cost is converted USD → nanos (authoritative) and micros
+// (compatibility). Provider ids are transformed to KeiRouter's custom-provider
+// naming. Rows are inserted in batches via RecordBatch.
+func (s *Server) import9routerUsageHistory(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	raw, ok := doc["usageHistory"]
+	if !ok {
+		return
+	}
+	var rows []n9routerUsageRow
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		res.Errors = append(res.Errors, "usageHistory: "+err.Error())
+		return
+	}
+
+	// Pre-resolve apiKey plaintext → api_key_id via lookup hash.
+	keyIDByLookup := s.usageKeyLookup(ctx)
+
+	records := make([]store.UsageRecord, 0, len(rows))
+	for _, r := range rows {
+		rec := store.UsageRecord{
+			ID:        strconv.FormatInt(r.ID, 10),
+			TenantID:  adminTenant,
+			Provider:  xform9routerProvider(r.Provider),
+			Model:     r.Model,
+			AccountID: r.ConnectionID,
+			Status:    map9routerUsageStatus(r.Status),
+		}
+		if ts := parseRFC3339(r.Timestamp); ts != nil {
+			rec.CreatedAt = *ts
+		} else {
+			rec.CreatedAt = time.Now()
+		}
+		rec.PromptTokens = r.PromptTokens
+		rec.CompletionTokens = r.CompletionTokens
+
+		// Cost: USD float → nanos (round half up), micros = nanos/1000.
+		nanos := int64(r.Cost*1e9 + 0.5)
+		rec.CostNanos = nanos
+		rec.CostMicros = (nanos + 500) / 1000
+		rec.PricingStatus = "legacy"
+		rec.PricingSource = "legacy"
+		rec.UsageSource = "provider"
+
+		// tokens JSON carries cached/reasoning/cache-write breakdown.
+		if r.Tokens != "" {
+			var tk struct {
+				CachedTokens     int `json:"cached_tokens"`
+				CacheReadTokens  int `json:"cache_read_input_tokens"`
+				CacheWriteTokens int `json:"cache_creation_input_tokens"`
+				ReasoningTokens  int `json:"reasoning_tokens"`
+			}
+			if err := json.Unmarshal([]byte(r.Tokens), &tk); err == nil {
+				rec.CachedTokens = tk.CachedTokens
+				if rec.CachedTokens == 0 {
+					rec.CachedTokens = tk.CacheReadTokens
+				}
+				rec.CacheWriteTokens = tk.CacheWriteTokens
+				rec.ReasoningTokens = tk.ReasoningTokens
+			}
+		}
+
+		// meta JSON carries client/request_id/latency.
+		if r.Meta != "" && r.Meta != "{}" {
+			var m struct {
+				Client    string `json:"client"`
+				RequestID string `json:"request_id"`
+				LatencyMS int    `json:"latency_ms"`
+				TTFTMS    int    `json:"ttft_ms"`
+			}
+			if err := json.Unmarshal([]byte(r.Meta), &m); err == nil {
+				rec.Client = m.Client
+				rec.RequestID = m.RequestID
+				rec.LatencyMS = m.LatencyMS
+				rec.EndToEndLatencyMS = m.LatencyMS
+				rec.TTFTMS = m.TTFTMS
+			}
+		}
+
+		// Resolve apiKey plaintext → api_key_id.
+		if r.APIKey != "" {
+			if id, ok := keyIDByLookup[crypto.LookupHash(r.APIKey)]; ok {
+				rec.APIKeyID = id
+			}
+		}
+
+		records = append(records, rec)
+	}
+
+	if err := s.usage.RecordBatch(ctx, records); err != nil {
+		res.Errors = append(res.Errors, "usageHistory: "+err.Error())
+		return
+	}
+	res.Errors = append(res.Errors, fmt.Sprintf("usageHistory: imported %d rows", len(records)))
+}
+
+// usageKeyLookup builds a map from api_key lookup_hash → api_key id for the
+// current tenant, so usageHistory rows can be linked to imported keys.
+func (s *Server) usageKeyLookup(ctx context.Context) map[string]string {
+	out := map[string]string{}
+	if s.identity == nil {
+		return out
+	}
+	keys, err := s.identity.List(ctx, adminTenant)
+	if err != nil {
+		return out
+	}
+	for _, k := range keys {
+		if k.LookupHash != "" {
+			out[k.LookupHash] = k.ID
+		}
+	}
+	return out
+}
+
+// xform9routerProvider maps 9router provider ids to KeiRouter custom-provider
+// naming. Unknown providers pass through unchanged.
+func xform9routerProvider(p string) string {
+	switch {
+	case strings.HasPrefix(p, "openai-compatible-chat-"):
+		return "custom-openai-" + strings.TrimPrefix(p, "openai-compatible-chat-")
+	case strings.HasPrefix(p, "openai-compatible-responses-"):
+		return "custom-openai-" + strings.TrimPrefix(p, "openai-compatible-responses-")
+	case strings.HasPrefix(p, "anthropic-compatible-"):
+		return "custom-anthropic-" + strings.TrimPrefix(p, "anthropic-compatible-")
+	default:
+		return p
+	}
+}
+
+// map9routerUsageStatus normalizes 9router status strings to KeiRouter's
+// usage_records.status vocabulary.
+func map9routerUsageStatus(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "ok", "success":
+		return "success"
+	case "cache", "cache_hit", "cached":
+		return "cache_hit"
+	case "blocked", "guardrail":
+		return "blocked"
+	case "failed", "error":
+		return "failed"
+	case "cancelled", "canceled":
+		return "cancelled"
+	default:
+		return "success"
+	}
+}
+
+// ── settings (token saver / routing / password) ───────────────────────────
+
+// import9routerSettings migrates the 9router settings blob into KeiRouter's
+// endpoint_settings (token saver + routing strategy), per-provider routing
+// overrides, and the dashboard password.
+//
+// Settings are additive: existing keys are overwritten only if the imported
+// value is non-zero, so manual tweaks are preserved when re-importing.
+func (s *Server) import9routerSettings(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+	raw, ok := doc["settings"]
+	if !ok {
+		return
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(raw, &rows); err != nil || len(rows) == 0 {
+		return
+	}
+	dataRaw, ok := rows[0]["data"]
+	if !ok {
+		return
+	}
+	var data map[string]any
+	switch v := dataRaw.(type) {
+	case string:
+		if err := json.Unmarshal([]byte(v), &data); err != nil {
+			return
+		}
+	case map[string]any:
+		data = v
+	default:
+		return
+	}
+	if s.settings == nil {
+		return
+	}
+
+	// ── Patch 5: token saver → endpoint_settings ──────────────────────
+	s.import9routerTokenSaver(ctx, data, res)
+
+	// ── Patch 6: routing strategy → endpoint_settings + provider_routing_*
+	s.import9routerRouting(ctx, data, res)
+
+	// ── Patch 7: dashboard password bcrypt → argon2id ─────────────────
+	s.import9routerPassword(ctx, data, res)
+}
+
+// import9routerTokenSaver maps 9router's rtk/caveman/ponytail/headroom
+// settings into KeiRouter's endpoint_settings JSON blob.
+func (s *Server) import9routerTokenSaver(ctx context.Context, data map[string]any, res *foreignImportResult) {
+	current := s.loadEndpointSettings(ctx)
+	changed := false
+
+	// RTK: 9router uses rtkEnabled bool; map "on" → rtk_filter_level "minimal".
+	if v, ok := data["rtkEnabled"].(bool); ok {
+		current.RTKEnabled = v
+		if v {
+			current.RTKFilterLevel = "minimal"
+		}
+		changed = true
+	}
+
+	// Caveman: cavemanEnabled + cavemanLevel (lite/full/ultra).
+	if v, ok := data["cavemanEnabled"].(bool); ok {
+		current.CavemanEnabled = v
+		changed = true
+	}
+	if v, ok := data["cavemanLevel"].(string); ok && caveman.ValidLevel(caveman.Level(v)) {
+		current.CavemanLevel = v
+		changed = true
+	}
+
+	// Ponytail: ponytailEnabled + ponytailLevel (lite/full/ultra).
+	if v, ok := data["ponytailEnabled"].(bool); ok {
+		current.PonytailEnabled = v
+		changed = true
+	}
+	if v, ok := data["ponytailLevel"].(string); ok && ponytail.ValidLevel(ponytail.Level(v)) {
+		current.PonytailLevel = v
+		changed = true
+	}
+
+	// Headroom: headroomEnabled + headroomUrl + headroomCodeAware.
+	if v, ok := data["headroomEnabled"].(bool); ok {
+		current.HeadroomEnabled = v
+		changed = true
+	}
+	if v, ok := data["headroomUrl"].(string); ok && v != "" {
+		current.HeadroomURL = v
+		changed = true
+	}
+	if v, ok := data["headroomCodeAware"].(bool); ok {
+		current.HeadroomCompressUserMessages = v
+		changed = true
+	}
+
+	if !changed {
+		return
+	}
+
+	rawJSON, _ := json.Marshal(current)
+	if err := s.settings.Set(ctx, endpointSettingsKey, string(rawJSON)); err != nil {
+		res.Errors = append(res.Errors, "token saver settings: "+err.Error())
+		return
+	}
+}
+
+// import9routerRouting maps 9router's fallbackStrategy/comboStrategy/sticky
+// limits into KeiRouter's endpoint_settings and per-provider routing overrides.
+func (s *Server) import9routerRouting(ctx context.Context, data map[string]any, res *foreignImportResult) {
+	current := s.loadEndpointSettings(ctx)
+
+	// Global routing strategy.
+	if v, ok := data["fallbackStrategy"].(string); ok {
+		if normalized, ok := normalizeAccountRoutingStrategy(v); ok {
+			current.RoutingStrategy = normalized
+		}
+	}
+	// Global combo strategy.
+	if v, ok := data["comboStrategy"].(string); ok {
+		if normalized, ok := normalizeComboRoutingStrategy(v); ok {
+			current.ComboStrategy = normalized
+		}
+	}
+	// Global sticky limits.
+	if v, ok := data["stickyRoundRobinLimit"].(float64); ok && v > 0 {
+		current.StickyLimit = int(v)
+	}
+	if v, ok := data["comboStickyRoundRobinLimit"].(float64); ok && v > 0 {
+		current.ComboStickyLimit = int(v)
+	}
+
+	rawJSON, _ := json.Marshal(current)
+	if err := s.settings.Set(ctx, endpointSettingsKey, string(rawJSON)); err != nil {
+		res.Errors = append(res.Errors, "routing settings: "+err.Error())
+		return
+	}
+
+	// Per-provider routing overrides.
+	if ps, ok := data["providerStrategies"].(map[string]any); ok {
+		s.import9routerProviderRouting(ctx, ps, res)
+	}
+}
+
+// import9routerProviderRouting writes per-provider routing overrides to the
+// settings store under the "provider_routing_{provider}" key. 9router provider
+// ids (openai-compatible-chat-X / anthropic-compatible-X) are transformed to
+// KeiRouter's custom-provider naming so the keys resolve at read time.
+func (s *Server) import9routerProviderRouting(ctx context.Context, ps map[string]any, res *foreignImportResult) {
+	for provider, v := range ps {
+		m, ok := v.(map[string]any)
+		if !ok || provider == "" {
+			continue
+		}
+		provider = xform9routerProvider(provider)
+		prs := ProviderRoutingSettings{
+			RoutingStrategy: "inherit",
+			StickyLimit:     3,
+		}
+		if fs, ok := m["fallbackStrategy"].(string); ok {
+			if normalized, ok := normalizeProviderRoutingStrategy(fs); ok {
+				prs.RoutingStrategy = normalized
+			}
+		}
+		if sr, ok := m["stickyRoundRobinLimit"].(float64); ok && sr > 0 {
+			prs.StickyLimit = int(sr)
+		}
+		rawJSON, _ := json.Marshal(prs)
+		_ = s.settings.Set(ctx, providerRoutingPrefix+provider, string(rawJSON))
+	}
+}
+
+// import9routerPassword imports the 9router dashboard password (bcrypt) into
+// KeiRouter's auth.password_hash. If Keirouter already has a non-default
+// password, the imported one is skipped to avoid overwriting.
+func (s *Server) import9routerPassword(ctx context.Context, data map[string]any, res *foreignImportResult) {
+	pw, ok := data["password"].(string)
+	if !ok || pw == "" {
+		return
+	}
+
+	// Only import if the current password is still the seeded default.
+	if s.auth != nil && !s.auth.UsingDefaultPassword(ctx) {
+		res.Errors = append(res.Errors, "password: skipped (dashboard already has a custom password)")
+		return
+	}
+
+	// The bcrypt hash is stored directly; VerifyPassword detects $2b$/etc.
+	// and re-hashes to argon2id on successful verification. Here we store it
+	// as-is and let the login flow handle migration.
+	if err := s.settings.Set(ctx, "auth.password_hash", pw); err != nil {
+		res.Errors = append(res.Errors, "password: "+err.Error())
+		return
+	}
+	res.Errors = append(res.Errors, "password: imported (bcrypt, will re-hash to argon2id on first login)")
+}

--- a/backend/internal/gateway/admin_foreign_import_sqlite.go
+++ b/backend/internal/gateway/admin_foreign_import_sqlite.go
@@ -58,6 +58,12 @@ func (s *Server) adminImport9routerSQLite(w http.ResponseWriter, r *http.Request
 	}
 	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
+	defer func() {
+		// A WAL-mode upload leaves -wal/-shm siblings when opened; remove them
+		// with the temp file so the data dir stays clean.
+		_ = os.Remove(tmpPath + "-wal")
+		_ = os.Remove(tmpPath + "-shm")
+	}()
 
 	if _, err := tmp.ReadFrom(file); err != nil {
 		_ = tmp.Close()
@@ -128,7 +134,43 @@ func read9routerSQLiteDoc(ctx context.Context, path string) (map[string]json.Raw
 		}
 		doc[t] = raw
 	}
+	// proxyPools keeps name/proxyUrl/type/strictProxy inside the nested `data`
+	// JSON column; the JSON export flattens them and the importer reads the
+	// flat shape. Merge `data` fields to the top level to match.
+	flattenNestedData(doc, "proxyPools")
 	return doc, nil
+}
+
+// flattenNestedData merges the parsed `data` JSON column of every row in the
+// given table into the row's top level (without clobbering existing keys).
+func flattenNestedData(doc map[string]json.RawMessage, table string) {
+	raw, ok := doc[table]
+	if !ok {
+		return
+	}
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return
+	}
+	for _, row := range rows {
+		dataRaw, ok := row["data"]
+		if !ok {
+			continue
+		}
+		var data map[string]json.RawMessage
+		if err := json.Unmarshal(dataRaw, &data); err != nil {
+			continue
+		}
+		delete(row, "data")
+		for k, v := range data {
+			if _, exists := row[k]; !exists {
+				row[k] = v
+			}
+		}
+	}
+	if b, err := json.Marshal(rows); err == nil {
+		doc[table] = b
+	}
 }
 
 // readTableAsJSON returns a JSON array of row objects for the given table, or
@@ -214,19 +256,36 @@ func looksLikeJSON(s string) bool {
 
 // n9routerUsageRow is one 9router usageHistory row.
 type n9routerUsageRow struct {
-	ID               int64   `json:"id"`
-	Timestamp        string  `json:"timestamp"`
-	Provider         string  `json:"provider"`
-	Model            string  `json:"model"`
-	ConnectionID     string  `json:"connectionId"`
-	APIKey           string  `json:"apiKey"`
-	Endpoint         string  `json:"endpoint"`
-	PromptTokens     int     `json:"promptTokens"`
-	CompletionTokens int     `json:"completionTokens"`
-	Cost             float64 `json:"cost"`
-	Status           string  `json:"status"`
-	Tokens           string  `json:"tokens"`
-	Meta             string  `json:"meta"`
+	ID               int64           `json:"id"`
+	Timestamp        string          `json:"timestamp"`
+	Provider         string          `json:"provider"`
+	Model            string          `json:"model"`
+	ConnectionID     string          `json:"connectionId"`
+	APIKey           string          `json:"apiKey"`
+	Endpoint         string          `json:"endpoint"`
+	PromptTokens     int             `json:"promptTokens"`
+	CompletionTokens int             `json:"completionTokens"`
+	Cost             float64         `json:"cost"`
+	Status           string          `json:"status"`
+	Tokens           json.RawMessage `json:"tokens"`
+	Meta             json.RawMessage `json:"meta"`
+}
+
+// decode9routerJSONCol decodes a column that may arrive either as a JSON
+// string containing JSON (the JSON export path) or as an already-parsed JSON
+// object (the SQLite reader path).
+func decode9routerJSONCol(raw json.RawMessage, target any) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if strings.TrimSpace(s) == "" {
+			return nil
+		}
+		return json.Unmarshal([]byte(s), target)
+	}
+	return json.Unmarshal(raw, target)
 }
 
 // import9routerUsageHistory migrates 9router usageHistory rows into
@@ -274,14 +333,14 @@ func (s *Server) import9routerUsageHistory(ctx context.Context, doc map[string]j
 		rec.UsageSource = "provider"
 
 		// tokens JSON carries cached/reasoning/cache-write breakdown.
-		if r.Tokens != "" {
+		if len(r.Tokens) > 0 {
 			var tk struct {
 				CachedTokens     int `json:"cached_tokens"`
 				CacheReadTokens  int `json:"cache_read_input_tokens"`
 				CacheWriteTokens int `json:"cache_creation_input_tokens"`
 				ReasoningTokens  int `json:"reasoning_tokens"`
 			}
-			if err := json.Unmarshal([]byte(r.Tokens), &tk); err == nil {
+			if err := decode9routerJSONCol(r.Tokens, &tk); err == nil {
 				rec.CachedTokens = tk.CachedTokens
 				if rec.CachedTokens == 0 {
 					rec.CachedTokens = tk.CacheReadTokens
@@ -292,14 +351,14 @@ func (s *Server) import9routerUsageHistory(ctx context.Context, doc map[string]j
 		}
 
 		// meta JSON carries client/request_id/latency.
-		if r.Meta != "" && r.Meta != "{}" {
+		if len(r.Meta) > 0 && string(r.Meta) != "{}" && string(r.Meta) != `"{}"` {
 			var m struct {
 				Client    string `json:"client"`
 				RequestID string `json:"request_id"`
 				LatencyMS int    `json:"latency_ms"`
 				TTFTMS    int    `json:"ttft_ms"`
 			}
-			if err := json.Unmarshal([]byte(r.Meta), &m); err == nil {
+			if err := decode9routerJSONCol(r.Meta, &m); err == nil {
 				rec.Client = m.Client
 				rec.RequestID = m.RequestID
 				rec.LatencyMS = m.LatencyMS

--- a/backend/internal/gateway/admin_foreign_import_sqlite.go
+++ b/backend/internal/gateway/admin_foreign_import_sqlite.go
@@ -154,6 +154,18 @@ func readTableAsJSON(ctx context.Context, db *sql.DB, table string) (json.RawMes
 		return nil, err
 	}
 
+	// 9router stores booleans as SQLite INTEGER (0/1) and nested config as
+	// JSON strings (e.g. providerNodes.data, combos.models). The JSON importer
+	// structs expect real bools/arrays, so normalize while building each row:
+	// INTEGER 0/1 → JSON bool, JSON-looking strings → embedded JSON values.
+	intCols := make([]bool, len(cols))
+	for i, c := range cols {
+		switch c {
+		case "isActive", "disabled", "enabled", "strictProxy":
+			intCols[i] = true
+		}
+	}
+
 	out := make([]map[string]any, 0)
 	scan := make([]any, len(cols))
 	scanPtrs := make([]any, len(cols))
@@ -166,7 +178,21 @@ func readTableAsJSON(ctx context.Context, db *sql.DB, table string) (json.RawMes
 		}
 		obj := make(map[string]any, len(cols))
 		for i, c := range cols {
-			obj[c] = scan[i]
+			v := scan[i]
+			if intCols[i] {
+				if n, ok := v.(int64); ok {
+					obj[c] = n != 0
+					continue
+				}
+			}
+			if s, ok := v.(string); ok && looksLikeJSON(s) {
+				var parsed any
+				if err := json.Unmarshal([]byte(s), &parsed); err == nil {
+					obj[c] = parsed
+					continue
+				}
+			}
+			obj[c] = v
 		}
 		out = append(out, obj)
 	}
@@ -175,6 +201,13 @@ func readTableAsJSON(ctx context.Context, db *sql.DB, table string) (json.RawMes
 	}
 
 	return json.Marshal(out)
+}
+
+// looksLikeJSON reports whether s starts like a JSON object or array (9router
+// JSON-string columns such as data/models/tokens/meta always do).
+func looksLikeJSON(s string) bool {
+	s = strings.TrimSpace(s)
+	return len(s) > 1 && (s[0] == '{' || s[0] == '[')
 }
 
 // ── usageHistory → usage_records ──────────────────────────────────────────

--- a/backend/internal/gateway/admin_foreign_import_sqlite.go
+++ b/backend/internal/gateway/admin_foreign_import_sqlite.go
@@ -27,12 +27,140 @@ import (
 // Unlike the JSON path, this also migrates usageHistory (usage_records) and the
 // settings blob (token saver / routing / dashboard password), which the JSON
 // export does not carry.
+//
+// n9IDPrefix marks rows imported from 9router so re-imports can replace them
+// without touching KeiRouter-native rows.
+const n9IDPrefix = "n9:"
+
+// n9routerImportOptions controls which sections are imported and how existing
+// data interacts with the incoming rows.
+type n9routerImportOptions struct {
+	// Sections.
+	Usage      bool `json:"usage"`
+	Providers  bool `json:"providers"`
+	APIKeys    bool `json:"api_keys"`
+	ProxyPools bool `json:"proxy_pools"`
+	Chains     bool `json:"chains"`
+	Settings   bool `json:"settings"`
+	Password   bool `json:"password"`
+	// Mode: "merge" (skip existing), "overwrite" (delete previous n9: rows
+	// for selected sections first), "wipe" (delete ALL rows in selected
+	// sections, including KeiRouter-native data).
+	Mode string `json:"mode"`
+}
+
+// defaultN9routerImportOptions returns all sections enabled in merge mode.
+func defaultN9routerImportOptions() n9routerImportOptions {
+	return n9routerImportOptions{
+		Usage: true, Providers: true, APIKeys: true, ProxyPools: true,
+		Chains: true, Settings: true, Password: true,
+		Mode: "merge",
+	}
+}
+
+// adminAnalyze9routerSQLite reads the uploaded 9router database and returns
+// per-table row counts so the UI can render an informed confirmation before
+// the actual import. Nothing is written.
+func (s *Server) adminAnalyze9routerSQLite(w http.ResponseWriter, r *http.Request) {
+	counts, err := s.analyze9routerUpload(w, r)
+	if err != nil {
+		return // response already written
+	}
+	writeJSON(w, http.StatusOK, counts)
+}
+
+// analyze9routerUpload performs the shared upload+validate+count steps for
+// both the analyze and import endpoints.
+func (s *Server) analyze9routerUpload(w http.ResponseWriter, r *http.Request) (map[string]int64, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, sqliteBackupMaxBytes)
+	if err := r.ParseMultipartForm(sqliteBackupMaxBytes); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid upload: "+err.Error())
+		return nil, err
+	}
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "file is required")
+		return nil, err
+	}
+	defer file.Close()
+	if header.Size <= 0 {
+		writeError(w, http.StatusBadRequest, "uploaded file is empty")
+		return nil, fmt.Errorf("empty file")
+	}
+	tmp, err := os.CreateTemp(s.dataDirOrTemp(), "keirouter-9router-import-*.sqlite")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "create temp file failed: "+err.Error())
+		return nil, err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	defer func() {
+		// A WAL-mode upload leaves -wal/-shm siblings when opened; remove them
+		// with the temp file so the data dir stays clean.
+		_ = os.Remove(tmpPath + "-wal")
+		_ = os.Remove(tmpPath + "-shm")
+	}()
+	if _, err := tmp.ReadFrom(file); err != nil {
+		_ = tmp.Close()
+		writeError(w, http.StatusInternalServerError, "save upload failed: "+err.Error())
+		return nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		writeError(w, http.StatusInternalServerError, "close upload failed: "+err.Error())
+		return nil, err
+	}
+	if err := validateSQLiteFile(r.Context(), tmpPath); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid SQLite database: "+err.Error())
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Minute)
+	defer cancel()
+	db, err := sql.Open("sqlite", "file:"+tmpPath+"?mode=ro")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "open 9router database: "+err.Error())
+		return nil, err
+	}
+	defer db.Close()
+	counts := map[string]int64{}
+	for _, t := range []string{"providerNodes", "providerConnections", "apiKeys", "combos", "proxyPools", "usageHistory"} {
+		var exists int
+		if err := db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?", t).Scan(&exists); err != nil {
+			writeError(w, http.StatusBadRequest, "read 9router database: "+err.Error())
+			return nil, err
+		}
+		if exists == 0 {
+			continue
+		}
+		var n int64
+		if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+t).Scan(&n); err == nil {
+			counts[t] = n
+		}
+	}
+	return counts, nil
+}
+
 func (s *Server) adminImport9routerSQLite(w http.ResponseWriter, r *http.Request) {
 	if s.dbDialect() != store.DialectSQLite {
 		writeError(w, http.StatusBadRequest, "9router SQLite import requires database.driver=sqlite")
 		return
 	}
 	started := time.Now()
+
+	// Options arrive as a JSON form field alongside the file.
+	opts := defaultN9routerImportOptions()
+	if raw := r.FormValue("options"); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &opts); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid options: "+err.Error())
+			return
+		}
+	}
+	switch opts.Mode {
+	case "merge", "overwrite", "wipe":
+	default:
+		writeError(w, http.StatusBadRequest, "mode must be merge, overwrite, or wipe")
+		return
+	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, sqliteBackupMaxBytes)
 	if err := r.ParseMultipartForm(sqliteBackupMaxBytes); err != nil {
@@ -98,22 +226,93 @@ func (s *Server) adminImport9routerSQLite(w http.ResponseWriter, r *http.Request
 	}
 	s.log.Info("9router import: database read", "elapsed_ms", time.Since(started).Milliseconds())
 
+	// Wipe mode destroys ALL rows in the selected sections (including
+	// KeiRouter-native data). Take a safety backup first so the operator can
+	// recover; overwrite mode only removes previous n9: rows, which the
+	// re-import recreates, so no backup is needed there.
+	if opts.Mode == "wipe" {
+		if err := s.n9routerSafetyBackup(); err != nil {
+			writeError(w, http.StatusInternalServerError, "safety backup failed: "+err.Error())
+			return
+		}
+	}
 	res := &foreignImportResult{Source: "9router"}
-	s.importN9router(ctx, doc, res)
-	s.log.Info("9router import: config tables", "elapsed_ms", time.Since(started).Milliseconds(),
-		"accounts", res.Accounts, "custom_providers", res.CustomProviders,
-		"api_keys", res.APIKeys, "chains", res.Chains, "proxy_pools", res.ProxyPools)
+	if opts.Mode != "merge" {
+		s.delete9routerRows(ctx, opts, res)
+	}
 
-	s.import9routerUsageHistory(ctx, doc, res)
-	s.log.Info("9router import: usage records", "elapsed_ms", time.Since(started).Milliseconds(),
-		"usage_records", res.UsageRecords)
-
-	s.import9routerSettings(ctx, doc, res)
+	if opts.Providers {
+		s.importN9router(ctx, doc, res) // nodes + connections + keys + combos + pools + aliases + custom models
+	}
+	if opts.Usage {
+		s.import9routerUsageHistory(ctx, doc, res)
+	}
+	if opts.Settings {
+		s.import9routerSettings(ctx, doc, res, opts.Password)
+	}
 	s.log.Info("9router import: complete", "elapsed_ms", time.Since(started).Milliseconds(),
-		"errors", len(res.Errors))
+		"mode", opts.Mode, "accounts", res.Accounts, "custom_providers", res.CustomProviders,
+		"api_keys", res.APIKeys, "chains", res.Chains, "proxy_pools", res.ProxyPools,
+		"usage_records", res.UsageRecords, "errors", len(res.Errors))
 
 	res.Imported = res.Accounts + res.CustomProviders + res.APIKeys + res.Chains + res.Aliases + res.ProxyPools
 	writeJSON(w, http.StatusOK, res)
+}
+
+// n9routerSafetyBackup copies the live SQLite database to a timestamped
+// safety file before destructive (wipe-mode) imports.
+func (s *Server) n9routerSafetyBackup() error {
+	path, ok := s.sqliteDBPath()
+	if !ok {
+		return fmt.Errorf("sqlite database path unavailable")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := s.checkpointSQLite(ctx); err != nil {
+		return err
+	}
+	safetyPath := path + ".before-9router-import-" + time.Now().UTC().Format("20060102-150405")
+	return copyFile(path, safetyPath)
+}
+
+// delete9routerRows removes previously imported 9router rows before a
+// re-import. Overwrite mode deletes only rows carrying the n9: id prefix;
+// wipe mode deletes every row in the selected sections.
+func (s *Server) delete9routerRows(ctx context.Context, opts n9routerImportOptions, res *foreignImportResult) {
+	onlyN9 := opts.Mode == "overwrite"
+	del := func(table, idCol string) {
+		q := "DELETE FROM " + table
+		if onlyN9 {
+			q += " WHERE " + idCol + " LIKE '" + n9IDPrefix + "%'"
+		}
+		if _, err := s.db.SQL().ExecContext(ctx, q); err != nil {
+			res.Errors = append(res.Errors, fmt.Sprintf("delete %s: %v", table, err))
+		}
+	}
+	if opts.Usage {
+		del("usage_records", "id")
+	}
+	if opts.Providers {
+		del("accounts", "id")
+	}
+	if opts.APIKeys {
+		del("api_keys", "id")
+	}
+	if opts.ProxyPools {
+		del("proxy_pools", "id")
+	}
+	if opts.Chains {
+		del("chains", "id")
+	}
+	if opts.Settings {
+		// Settings are keyed, not prefixed; reset the imported keys so the
+		// incoming blob lands cleanly.
+		for _, k := range []string{endpointSettingsKey, "auth.password_hash"} {
+			_ = s.settings.Delete(ctx, k)
+		}
+		_, _ = s.db.SQL().ExecContext(ctx,
+			"DELETE FROM settings WHERE key LIKE '"+providerRoutingPrefix+"%'")
+	}
 }
 
 // read9routerSQLiteDoc opens the 9router SQLite file read-only and returns a
@@ -320,11 +519,13 @@ func (s *Server) import9routerUsageHistory(ctx context.Context, doc map[string]j
 	records := make([]store.UsageRecord, 0, len(rows))
 	for _, r := range rows {
 		rec := store.UsageRecord{
-			ID:        strconv.FormatInt(r.ID, 10),
-			TenantID:  adminTenant,
-			Provider:  xform9routerProvider(r.Provider),
-			Model:     r.Model,
-			AccountID: r.ConnectionID,
+			ID:       strconv.FormatInt(r.ID, 10),
+			TenantID: adminTenant,
+			Provider: xform9routerProvider(r.Provider),
+			Model:    r.Model,
+			// Deterministic account id: matches the n9:-prefixed account row
+			// created by the connections importer.
+			AccountID: n9IDPrefix + r.ConnectionID,
 			Status:    map9routerUsageStatus(r.Status),
 		}
 		if ts := parseRFC3339(r.Timestamp); ts != nil {
@@ -463,11 +664,11 @@ func map9routerUsageStatus(s string) string {
 
 // import9routerSettings migrates the 9router settings blob into KeiRouter's
 // endpoint_settings (token saver + routing strategy), per-provider routing
-// overrides, and the dashboard password.
+// overrides, and optionally the dashboard password.
 //
 // Settings are additive: existing keys are overwritten only if the imported
 // value is non-zero, so manual tweaks are preserved when re-importing.
-func (s *Server) import9routerSettings(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult) {
+func (s *Server) import9routerSettings(ctx context.Context, doc map[string]json.RawMessage, res *foreignImportResult, includePassword bool) {
 	raw, ok := doc["settings"]
 	if !ok {
 		return
@@ -502,7 +703,9 @@ func (s *Server) import9routerSettings(ctx context.Context, doc map[string]json.
 	s.import9routerRouting(ctx, data, res)
 
 	// ── Patch 7: dashboard password bcrypt → argon2id ─────────────────
-	s.import9routerPassword(ctx, data, res)
+	if includePassword {
+		s.import9routerPassword(ctx, data, res)
+	}
 }
 
 // import9routerTokenSaver maps 9router's rtk/caveman/ponytail/headroom

--- a/backend/internal/gateway/sqlite_backup.go
+++ b/backend/internal/gateway/sqlite_backup.go
@@ -139,12 +139,24 @@ func (s *Server) adminSQLiteRestore(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := os.Rename(tmpPath, path); err != nil {
-		writeError(w, http.StatusInternalServerError, "replace database failed: "+err.Error())
-		return
+		// Windows keeps an open handle to keirouter.db while the server runs,
+		// so os.Rename fails with "Access is denied". Release the handle by
+		// closing the DB pool, clean WAL/SHM, remove the old file, then retry.
+		// The response signals restart_required, so closing here is safe.
+		_ = s.db.Close()
+		_ = os.Remove(path + "-wal")
+		_ = os.Remove(path + "-shm")
+		if _, statErr := os.Stat(path); statErr == nil {
+			_ = os.Remove(path)
+		}
+		if err2 := os.Rename(tmpPath, path); err2 != nil {
+			writeError(w, http.StatusInternalServerError, "replace database failed: "+err2.Error()+" (original: "+err.Error()+")")
+			return
+		}
+	} else {
+		_ = os.Remove(path + "-wal")
+		_ = os.Remove(path + "-shm")
 	}
-
-	_ = os.Remove(path + "-wal")
-	_ = os.Remove(path + "-shm")
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":               true,

--- a/backend/internal/store/repo_misc.go
+++ b/backend/internal/store/repo_misc.go
@@ -80,6 +80,15 @@ func (r *SettingsRepo) Set(ctx context.Context, key, value string) error {
 	return nil
 }
 
+// Delete removes a setting key. Absent keys are not an error.
+func (r *SettingsRepo) Delete(ctx context.Context, key string) error {
+	q := r.db.rebind(`DELETE FROM settings WHERE key = ?`)
+	if _, err := r.db.sql.ExecContext(ctx, q, key); err != nil {
+		return fmt.Errorf("store: delete setting: %w", err)
+	}
+	return nil
+}
+
 // AuditRepo appends and reads audit entries.
 type AuditRepo struct{ db *DB }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2920,17 +2920,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
       "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1433,6 +1433,12 @@ export const api = {
     body.append("file", file);
     return requestForm<SQLiteRestoreResult>("POST", "/settings/sqlite/restore", body);
   },
+  // Import 9router SQLite database directly (usageHistory, apiKeys, providers, proxyPools, settings).
+  import9routerSQLite: (file: File) => {
+    const body = new FormData();
+    body.append("file", file);
+    return requestForm<ForeignImportResult>("POST", "/settings/database/import-9router-sqlite", body);
+  },
 
   // Proxy test.
   testProxy: (proxyUrl: string) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1086,9 +1086,10 @@ async function requestBlob(method: string, path: string): Promise<Blob> {
 }
 
 async function requestForm<T>(method: string, path: string, body: FormData): Promise<T> {
-  // Uploads (e.g. SQLite restore) can legitimately take longer than a JSON
-  // call, so allow a more generous deadline than the default.
-  const res = await fetchWithTimeout(`/api${path}`, { method, body }, 60_000);
+  // Uploads can legitimately take longer than a JSON call: a 9router SQLite
+  // import uploads tens of MB and converts 60k+ usage rows. Use the largest
+  // supported timeout and let callers with smaller payloads finish early.
+  const res = await fetchWithTimeout(`/api${path}`, { method, body }, 300_000);
   if (!res.ok) {
     let message = res.statusText;
     try {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1001,8 +1001,22 @@ export interface ForeignImportResult {
   chains: number;
   aliases: number;
   proxy_pools: number;
+  usage_records?: number;
   errors?: string[];
 }
+export interface N9routerImportOptions {
+  usage: boolean;
+  providers: boolean;
+  api_keys: boolean;
+  proxy_pools: boolean;
+  chains: boolean;
+  settings: boolean;
+  password: boolean;
+  mode: "merge" | "overwrite" | "wipe";
+}
+export type N9routerAnalyzeResult = Partial<
+  Record<"providerNodes" | "providerConnections" | "apiKeys" | "combos" | "proxyPools" | "usageHistory", number>
+>;
 
 class APIError extends Error {
   status: number;
@@ -1435,10 +1449,17 @@ export const api = {
     return requestForm<SQLiteRestoreResult>("POST", "/settings/sqlite/restore", body);
   },
   // Import 9router SQLite database directly (usageHistory, apiKeys, providers, proxyPools, settings).
-  import9routerSQLite: (file: File) => {
+  import9routerSQLite: (file: File, options?: Partial<N9routerImportOptions>) => {
     const body = new FormData();
     body.append("file", file);
+    if (options) body.append("options", JSON.stringify(options));
     return requestForm<ForeignImportResult>("POST", "/settings/database/import-9router-sqlite", body);
+  },
+  // Analyze a 9router SQLite upload: per-table row counts, nothing written.
+  analyze9routerSQLite: (file: File) => {
+    const body = new FormData();
+    body.append("file", file);
+    return requestForm<N9routerAnalyzeResult>("POST", "/settings/database/analyze-9router-sqlite", body);
   },
 
   // Proxy test.

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,7 +6,7 @@ import {
   Gauge, Eye, EyeOff, KeyRound, Download, Upload, ShieldCheck, Info,
   Palette, Shield,
 } from "lucide-react";
-import { api, type EndpointSettings, type BrandingSettings, type HeadroomTestResult, type ForeignImportResult } from "../lib/api";
+import { api, type EndpointSettings, type BrandingSettings, type HeadroomTestResult, type ForeignImportResult, type N9routerImportOptions, type N9routerAnalyzeResult } from "../lib/api";
 import { ChangelogMarkdown } from "../components/ChangelogMarkdown";
 import { PALETTES, getPaletteScales } from "../lib/palettes";
 import { applyShadeScale, generateShades } from "../lib/color-utils";
@@ -1227,6 +1227,20 @@ function ForeignImportSettings() {
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<ForeignImportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [analyze, setAnalyze] = useState<N9routerAnalyzeResult | null>(null);
+  const [pendingSqliteFile, setPendingSqliteFile] = useState<File | null>(null);
+  const [sqliteOptions, setSqliteOptions] = useState<N9routerImportOptions>({
+    usage: true,
+    providers: true,
+    api_keys: true,
+    proxy_pools: true,
+    chains: true,
+    settings: true,
+    password: true,
+    mode: "merge",
+  });
+  const setSection = (key: keyof N9routerImportOptions, v: boolean) =>
+    setSqliteOptions((o) => ({ ...o, [key]: v }));
 
   const runImport = async (source: "9router" | "omniroute", file: File) => {
     setLoading(true);
@@ -1275,8 +1289,27 @@ function ForeignImportSettings() {
     setLoading(true);
     setError(null);
     setResult(null);
+    setAnalyze(null);
     try {
-      const res = await api.import9routerSQLite(file);
+      const counts = await api.analyze9routerSQLite(file);
+      setAnalyze(counts);
+      setPendingSqliteFile(file);
+    } catch (err) {
+      setError((err as Error).message || "Analyze failed.");
+      toast.error("Analyze failed", (err as Error).message);
+    } finally {
+      setLoading(false);
+      if (importSqliteRef.current) importSqliteRef.current.value = "";
+    }
+  };
+
+  const runSqliteImport = async () => {
+    if (!pendingSqliteFile) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await api.import9routerSQLite(pendingSqliteFile, sqliteOptions);
       setResult(res);
       const parts: string[] = [];
       if (res.accounts) parts.push(`${res.accounts} account${res.accounts === 1 ? "" : "s"}`);
@@ -1285,17 +1318,19 @@ function ForeignImportSettings() {
       if (res.chains) parts.push(`${res.chains} chain${res.chains === 1 ? "" : "s"}`);
       if (res.aliases) parts.push(`${res.aliases} alias${res.aliases === 1 ? "" : "es"}`);
       if (res.proxy_pools) parts.push(`${res.proxy_pools} pool${res.proxy_pools === 1 ? "" : "s"}`);
+      if (res.usage_records) parts.push(`${res.usage_records} usage record${res.usage_records === 1 ? "" : "s"}`);
       const summary = parts.length ? parts.join(", ") : "nothing";
       toast.success(
         "9router SQLite import complete",
         `${res.imported} record${res.imported === 1 ? "" : "s"} imported (${summary}).${res.skipped ? ` ${res.skipped} skipped.` : ""}`,
       );
-    } catch (e) {
-      setError((e as Error).message || "Import failed.");
-      toast.error("Import failed", (e as Error).message);
+      setPendingSqliteFile(null);
+      setAnalyze(null);
+    } catch (err) {
+      setError((err as Error).message || "Import failed.");
+      toast.error("Import failed", (err as Error).message);
     } finally {
       setLoading(false);
-      if (importSqliteRef.current) importSqliteRef.current.value = "";
     }
   };
 
@@ -1375,22 +1410,119 @@ function ForeignImportSettings() {
               <p className="text-[11px] text-[var(--text-muted)]">Full import incl. usage history &amp; settings</p>
             </div>
           </div>
-          <p className="text-xs leading-relaxed text-[var(--text-muted)]">
-            Upload 9router's <code>data.sqlite</code> directly. Imports everything the JSON backup does, plus usage
-            history (60k+ rows), token saver settings (RTK/Caveman/Ponytail), routing strategy, and the dashboard
-            password. Requires SQLite driver.
-          </p>
-          <Button variant="ghost" onClick={() => importSqliteRef.current?.click()} disabled={loading} className="w-full">
-            <Upload className="h-4 w-4" />
-            Select 9router data.sqlite
-          </Button>
-          <input
-            ref={importSqliteRef}
-            type="file"
-            accept=".sqlite,.db,application/vnd.sqlite3,application/x-sqlite3"
-            className="hidden"
-            onChange={handleSqliteFile}
-          />
+
+          {!analyze && !pendingSqliteFile && (
+            <>
+              <p className="text-xs leading-relaxed text-[var(--text-muted)]">
+                Upload 9router's <code>data.sqlite</code> directly. Imports everything the JSON backup does, plus usage
+                history, token saver settings, routing strategy, and the dashboard password. Analyzes the file first
+                so you can choose exactly which sections to import.
+              </p>
+              <Button variant="ghost" onClick={() => importSqliteRef.current?.click()} disabled={loading} className="w-full">
+                <Upload className="h-4 w-4" />
+                Select 9router data.sqlite
+              </Button>
+              <input
+                ref={importSqliteRef}
+                type="file"
+                accept=".sqlite,.db,application/vnd.sqlite3,application/x-sqlite3"
+                className="hidden"
+                onChange={handleSqliteFile}
+              />
+            </>
+          )}
+
+          {analyze && (
+            <div className="space-y-4">
+              {/* Per-table row counts from the uploaded file */}
+              <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-subtle)] px-4 py-3">
+                <p className="mb-2 text-xs font-semibold uppercase text-[var(--text-muted)]">Detected in file</p>
+                <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-[var(--text)]">
+                  {analyze.providerConnections != null && <span>{analyze.providerConnections} providers/accounts</span>}
+                  {analyze.providerNodes != null && <span>{analyze.providerNodes} custom nodes</span>}
+                  {analyze.apiKeys != null && <span>{analyze.apiKeys} API keys</span>}
+                  {analyze.combos != null && <span>{analyze.combos} chains</span>}
+                  {analyze.proxyPools != null && <span>{analyze.proxyPools} proxy pools</span>}
+                  {analyze.usageHistory != null && <span>{analyze.usageHistory.toLocaleString()} usage records</span>}
+                </div>
+              </div>
+
+              {/* Section checkboxes */}
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase text-[var(--text-muted)]">Sections to import</p>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="checkbox" checked={sqliteOptions.usage} onChange={(e) => setSection("usage", e.target.checked)} className="mt-0.5" />
+                  <span>Usage records <span className="text-[var(--text-muted)]">— token usage, costs, model stats</span></span>
+                </label>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="checkbox" checked={sqliteOptions.providers} onChange={(e) => setSection("providers", e.target.checked)} className="mt-0.5" />
+                  <span>Providers &amp; accounts <span className="text-[var(--text-muted)]">— connections, custom nodes, credentials re-encrypted</span></span>
+                </label>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="checkbox" checked={sqliteOptions.api_keys} onChange={(e) => setSection("api_keys", e.target.checked)} className="mt-0.5" />
+                  <span>API keys <span className="text-[var(--text-muted)]">— re-hashed; same key strings keep working</span></span>
+                </label>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="checkbox" checked={sqliteOptions.proxy_pools} onChange={(e) => setSection("proxy_pools", e.target.checked)} className="mt-0.5" />
+                  <span>Proxy pools <span className="text-[var(--text-muted)]">— Cloudflare / HTTP proxy configs</span></span>
+                </label>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="checkbox" checked={sqliteOptions.chains} onChange={(e) => setSection("chains", e.target.checked)} className="mt-0.5" />
+                  <span>Routing chains <span className="text-[var(--text-muted)]">— combos → chains (fallback/RR strategies)</span></span>
+                </label>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="checkbox" checked={sqliteOptions.settings} onChange={(e) => setSection("settings", e.target.checked)} className="mt-0.5" />
+                  <span>Settings <span className="text-[var(--text-muted)]">— token saver (RTK/Caveman/Ponytail), routing strategy</span></span>
+                </label>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="checkbox" checked={sqliteOptions.password} onChange={(e) => setSection("password", e.target.checked)} className="mt-0.5" />
+                  <span>Dashboard password <span className="text-[var(--text-muted)]">— import 9router's bcrypt hash (triggers re-login)</span></span>
+                </label>
+              </div>
+
+              {/* Mode radio */}
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase text-[var(--text-muted)]">Import mode</p>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="radio" name="n9mode" value="merge" checked={sqliteOptions.mode === "merge"} onChange={() => setSqliteOptions((o) => ({ ...o, mode: "merge" }))} className="mt-0.5" />
+                  <span>Merge <span className="text-[var(--text-muted)]">— add new rows, skip existing (safe, repeatable)</span></span>
+                </label>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="radio" name="n9mode" value="overwrite" checked={sqliteOptions.mode === "overwrite"} onChange={() => setSqliteOptions((o) => ({ ...o, mode: "overwrite" }))} className="mt-0.5" />
+                  <span>Overwrite <span className="text-[var(--text-muted)]">— remove previous 9router imports, then re-import (clean sync)</span></span>
+                </label>
+                <label className="flex items-start gap-2 text-xs text-[var(--text)]">
+                  <input type="radio" name="n9mode" value="wipe" checked={sqliteOptions.mode === "wipe"} onChange={() => setSqliteOptions((o) => ({ ...o, mode: "wipe" }))} className="mt-0.5" />
+                  <span>Wipe &amp; replace <span className="text-[var(--text-muted)] font-medium text-red-500">— DESTROYS all selected data including KeiRouter-native rows</span></span>
+                </label>
+                {sqliteOptions.mode === "wipe" && (
+                  <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[11px] text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+                    ⚠️ Wipe mode deletes ALL rows in the selected sections, not just previously imported ones. A safety
+                    backup is created automatically before any deletion.
+                  </p>
+                )}
+              </div>
+
+              {/* Action buttons */}
+              <div className="flex gap-2">
+                <Button
+                  variant="primary"
+                  onClick={runSqliteImport}
+                  disabled={loading || !Object.values(sqliteOptions).some((v) => typeof v === "boolean" && v)}
+                  className="w-full"
+                >
+                  {loading ? "Importing…" : "Run import"}
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => { setAnalyze(null); setPendingSqliteFile(null); }}
+                  disabled={loading}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1223,6 +1223,7 @@ function ForeignImportSettings() {
   const toast = useToast();
   const import9rRef = useRef<HTMLInputElement>(null);
   const importOmniRef = useRef<HTMLInputElement>(null);
+  const importSqliteRef = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<ForeignImportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1266,6 +1267,36 @@ function ForeignImportSettings() {
     const file = e.target.files?.[0];
     if (file) void runImport("omniroute", file);
     if (importOmniRef.current) importOmniRef.current.value = "";
+  };
+
+  const handleSqliteFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await api.import9routerSQLite(file);
+      setResult(res);
+      const parts: string[] = [];
+      if (res.accounts) parts.push(`${res.accounts} account${res.accounts === 1 ? "" : "s"}`);
+      if (res.custom_providers) parts.push(`${res.custom_providers} provider${res.custom_providers === 1 ? "" : "s"}`);
+      if (res.api_keys) parts.push(`${res.api_keys} key${res.api_keys === 1 ? "" : "s"}`);
+      if (res.chains) parts.push(`${res.chains} chain${res.chains === 1 ? "" : "s"}`);
+      if (res.aliases) parts.push(`${res.aliases} alias${res.aliases === 1 ? "" : "es"}`);
+      if (res.proxy_pools) parts.push(`${res.proxy_pools} pool${res.proxy_pools === 1 ? "" : "s"}`);
+      const summary = parts.length ? parts.join(", ") : "nothing";
+      toast.success(
+        "9router SQLite import complete",
+        `${res.imported} record${res.imported === 1 ? "" : "s"} imported (${summary}).${res.skipped ? ` ${res.skipped} skipped.` : ""}`,
+      );
+    } catch (e) {
+      setError((e as Error).message || "Import failed.");
+      toast.error("Import failed", (e as Error).message);
+    } finally {
+      setLoading(false);
+      if (importSqliteRef.current) importSqliteRef.current.value = "";
+    }
   };
 
   return (
@@ -1330,6 +1361,35 @@ function ForeignImportSettings() {
             accept="application/json,.json"
             className="hidden"
             onChange={handleOmniFile}
+          />
+        </div>
+
+        {/* 9router SQLite direct import */}
+        <div className="flex flex-col gap-3 rounded-xl border border-[var(--border)] bg-[var(--bg)] p-4 sm:col-span-2">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex h-7 w-7 items-center justify-center rounded-md bg-accent-100 text-xs font-bold text-accent-700 dark:bg-accent-900/40 dark:text-accent-200">
+              DB
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-[var(--text)]">9router SQLite database</p>
+              <p className="text-[11px] text-[var(--text-muted)]">Full import incl. usage history &amp; settings</p>
+            </div>
+          </div>
+          <p className="text-xs leading-relaxed text-[var(--text-muted)]">
+            Upload 9router's <code>data.sqlite</code> directly. Imports everything the JSON backup does, plus usage
+            history (60k+ rows), token saver settings (RTK/Caveman/Ponytail), routing strategy, and the dashboard
+            password. Requires SQLite driver.
+          </p>
+          <Button variant="ghost" onClick={() => importSqliteRef.current?.click()} disabled={loading} className="w-full">
+            <Upload className="h-4 w-4" />
+            Select 9router data.sqlite
+          </Button>
+          <input
+            ref={importSqliteRef}
+            type="file"
+            accept=".sqlite,.db,application/vnd.sqlite3,application/x-sqlite3"
+            className="hidden"
+            onChange={handleSqliteFile}
           />
         </div>
       </div>


### PR DESCRIPTION
## What

Adds a direct 9router SQLite (`data.sqlite`) import path to the dashboard, plus
support for 9router's bcrypt dashboard passwords. New admin endpoints
`POST /settings/database/import-9router-sqlite` and
`POST /settings/database/analyze-9router-sqlite`, a section/mode-aware import
UI in Settings, and lazy bcrypt→argon2id password migration on login.

## Why

The existing JSON foreign-import covers config only — it can't carry usage
history (60k+ rows), the token-saver settings blob, routing strategy, or the
dashboard password. Operators migrating from 9router lost their usage data and
got locked out because 9router hashes passwords with bcrypt, which KeiRouter's
argon2id verifier rejects. Importing the SQLite file directly closes both gaps.

## How

- **SQLite reader** (`admin_foreign_import_sqlite.go`): uploads are saved to a
  temp file, validated, then read into the same `map[string]json.RawMessage`
  document shape the JSON importer already consumes, so all per-table
  converters (`importN9router*`) are reused. Type normalization handles 9router's
  INTEGER-as-bool columns and JSON-in-string columns; nested `data` blobs
  (e.g. `proxyPools`) are flattened to match the JSON export shape.
- **Usage history**: `usageHistory` → `usage_records` in 1000-row chunks — one
  60k-row transaction would hold the SQLite write lock and starve background
  writers with `SQLITE_BUSY`. Cost converts USD float → nanos (authoritative)
  and micros (compat); pricing marked `legacy`.
- **Deterministic ids** (`n9:` prefix) for accounts/keys/chains/pools let
  re-imports upsert and let `usage_records.account_id` resolve to imported rows.
- **Analyze-then-import**: the UI first uploads for a read-only row-count probe,
  then shows per-section checkboxes and a mode radio — `merge` (skip existing),
  `overwrite` (delete previous `n9:` rows), `wipe` (delete all rows in selected
  sections, safety DB backup taken first).
- **Password**: bcrypt (`$2a$`/`$2b$`) hashes import as-is; `VerifyPassword`
  detects the format, verifies via bcrypt, and lazily re-hashes to argon2id on
  a successful match, so the bcrypt path is touched at most once. Imported
  password only applies while the dashboard still uses the seeded default.
- **Windows fix** (side effect): SQLite restore now closes the DB pool and
  cleans `-wal`/`-shm` before retrying `os.Rename`, which otherwise fails with
  "Access is denied" while the server holds the file open.

Trade-offs: import requires `database.driver=sqlite`; usage rows are inserted
best-effort (chunk errors are reported, import stops at the failing chunk);
the 5-minute server timeout assumes LAN-speed uploads for multi-MB files.

## Checklist

- [x] `make test` passes
- [x] `make vet` passes
- [x] `npm run lint` and `npm run typecheck` pass (if frontend changed)
- [ ] Documentation updated (needed)
- [ ] Config example updated (if applicable)


## Screens

<img width="1896" height="1081" alt="image" src="https://github.com/user-attachments/assets/ac5efb57-07f5-4651-ba33-b4f56662ae45" />
